### PR TITLE
Sort by multiple keys

### DIFF
--- a/hooks/src/use_library_items.rs
+++ b/hooks/src/use_library_items.rs
@@ -54,9 +54,15 @@ pub fn use_library_items(library: Signal<Library>) -> LibraryItems {
             .collect();
 
         match *sort_order.read() {
-            SortOrder::Title => tracks.sort_by_cached_key(|(a, _)| a.title.to_lowercase()),
-            SortOrder::Artist => tracks.sort_by_cached_key(|(a, _)| a.artist.to_lowercase()),
-            SortOrder::Album => tracks.sort_by_cached_key(|(a, _)| a.album.to_lowercase()),
+            SortOrder::Title => tracks.sort_by_cached_key(|(a, _)| {
+                (a.title.to_lowercase(), a.artist.to_lowercase(), a.album.to_lowercase(), a.disc_number, a.track_number)
+            }),
+            SortOrder::Artist => tracks.sort_by_cached_key(|(a, _)| {
+                (a.artist.to_lowercase(), a.album.to_lowercase(), a.disc_number, a.track_number, a.title.to_lowercase())
+            }),
+            SortOrder::Album => tracks.sort_by_cached_key(|(a, _)| {
+                (a.album.to_lowercase(), a.disc_number, a.track_number, a.title.to_lowercase())
+            }),
         }
 
         tracks

--- a/pages/src/jellyfin/library.rs
+++ b/pages/src/jellyfin/library.rs
@@ -240,13 +240,13 @@ pub fn JellyfinLibrary(
         let mut tracks = library.read().jellyfin_tracks.clone();
         match *sort_order.read() {
             config::SortOrder::Title => {
-                tracks.sort_by(|a, b| a.title.to_lowercase().cmp(&b.title.to_lowercase()))
+                tracks.sort_by_cached_key(|a| (a.title.to_lowercase(), a.artist.to_lowercase(), a.album.to_lowercase(), a.disc_number, a.track_number))
             }
             config::SortOrder::Artist => {
-                tracks.sort_by(|a, b| a.artist.to_lowercase().cmp(&b.artist.to_lowercase()))
+                tracks.sort_by_cached_key(|a| (a.artist.to_lowercase(), a.album.to_lowercase(), a.disc_number, a.track_number, a.title.to_lowercase()))
             }
             config::SortOrder::Album => {
-                tracks.sort_by(|a, b| a.album.to_lowercase().cmp(&b.album.to_lowercase()))
+                tracks.sort_by_cached_key(|a| (a.album.to_lowercase(), a.disc_number, a.track_number, a.title.to_lowercase()))
             }
         }
         let conf = config.read();


### PR DESCRIPTION
If you're sorting by album name alone, the next most appropriate sorting criterion is track order.
Similarly, we've added sub-sort options for other items as well.