### PR TITLE
Implement virtual scrolling for server library

### DIFF
--- a/pages/src/server/library.rs
+++ b/pages/src/server/library.rs
@@ -11,6 +11,7 @@ use reader::Library;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
+const ITEM_HEIGHT: f64 = 60.0;
 #[component]
 pub fn JellyfinLibrary(
     mut library: Signal<Library>,
@@ -23,7 +24,7 @@ pub fn JellyfinLibrary(
     let mut has_fetched = use_signal(|| false);
     let mut fetch_generation = use_signal(|| 0usize);
     let mut sort_order = use_signal(|| config.peek().sort_order.clone());
-
+    let mut scroll_stat = use_signal(|| 0.0);
     use_effect(move || {
         let curr = sort_order.read().clone();
         if config.peek().sort_order != curr {
@@ -130,12 +131,41 @@ pub fn JellyfinLibrary(
     });
 
     let is_empty = displayed_tracks().is_empty();
-
     let queue_source = std::sync::Arc::new(queue_tracks());
+    let mut container_height = use_signal(|| 800.0);
+    let scroll_top = *scroll_stat.read();
+    let row_height = ITEM_HEIGHT;
+    let window_size = (*container_height.read() / row_height).ceil() as usize;
+    let buffer_size = 10;
+    let total_tracks = displayed_tracks().len();
+
+    let start_index = {
+        let calc = (scroll_top - (buffer_size as f64) * row_height) / row_height;
+        calc.floor().max(0.0) as usize
+    };
+
+    let end_index = {
+        let last_index = start_index + 2 * buffer_size + window_size;
+        let last_index_inclusive = last_index.saturating_sub(1);
+        if total_tracks == 0 { 0 } else { last_index_inclusive.min(total_tracks - 1) }
+    };
+
+    let items_to_render = if total_tracks == 0 { 0 } else { (end_index + 1).saturating_sub(start_index) };
+    
+    let top_pad = (start_index as f64) * row_height;
+    
+    let bottom_pad = {
+        let total_height = (total_tracks as f64) * row_height;
+        let rendered_height = (items_to_render as f64) * row_height;
+        (total_height - rendered_height - top_pad).max(0.0)
+    };
+
     let tracks_nodes =
         displayed_tracks()
             .into_iter()
             .enumerate()
+            .skip(start_index)
+            .take(items_to_render)
             .map(|(idx, (track, cover_url))| {
                 let track_menu = track.clone();
                 let track_add = track.clone();
@@ -145,10 +175,12 @@ pub fn JellyfinLibrary(
                 let track_key = format!("{}-{}", track.path.display(), idx);
                 let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
                 let is_selected = selected_tracks.read().contains(&track_path);
-
                 rsx! {
-                    TrackRow {
+                    div {
                         key: "{track_key}",
+                        class: "mb-1",
+                        style: "height: {ITEM_HEIGHT}px;",
+                    TrackRow {
                         track: track.clone(),
                         cover_url: cover_url.clone(),
                         is_menu_open,
@@ -188,6 +220,7 @@ pub fn JellyfinLibrary(
                             ctrl.play_track(idx);
                         },
                     }
+                }
                 }
             });
 
@@ -418,7 +451,20 @@ pub fn JellyfinLibrary(
             }
 
             div {
-                class: "space-y-1 pb-20",
+                class: "pb-20 h-[calc(100vh-300px)] overflow-y-auto",
+                onmounted: move |event| {
+                    spawn(async move {
+                        if let Ok(window) = event.get_client_rect().await {
+                            container_height.set(window.height());
+                        }
+                    });
+                },
+                onscroll: move |event| {
+                    let scroll_y = event.scroll_top();
+                    let height = event.client_height() as f64;
+                    scroll_stat.set(scroll_y);
+                    container_height.set(height);
+                },
                 if is_empty {
                     if *is_loading.read() {
                         div { class: "flex items-center justify-center py-12",
@@ -428,7 +474,9 @@ pub fn JellyfinLibrary(
                         p { class: "text-slate-500 italic", "No tracks found." }
                     }
                 } else {
+                    div { style: "height: {top_pad}px; flex-shrink: 0;" }
                     {tracks_nodes}
+                    div { style: "height: {bottom_pad}px; flex-shrink: 0;" }
                     if *is_loading.read() {
                         div { class: "flex items-center justify-center py-4",
                             i { class: "fa-solid fa-spinner fa-spin text-xl text-white/20" }

--- a/pages/src/server/library.rs
+++ b/pages/src/server/library.rs
@@ -11,7 +11,7 @@ use reader::Library;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-const ITEM_HEIGHT: f64 = 60.0;
+const ITEM_HEIGHT: f64 = 64.0; // 60px content + 4px margin (mb-1)
 #[component]
 pub fn JellyfinLibrary(
     mut library: Signal<Library>,


### PR DESCRIPTION
Hello, this PR implements a virtual scrolling to the server library page that only renders the tracks visible on the screen
When scrolling a library with a lot of files, it gets laggy and almost unusable
Before:

https://github.com/user-attachments/assets/8d728553-e158-413e-9647-8ffa3d3c7302

After:

https://github.com/user-attachments/assets/f9036b2a-d580-4c47-802e-6c2af5ae967a

It can still get more optimized, but it was my first time using dioxus, i had to look up some javascript tutorials for this
Great project btw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved track list rendering with scroll-based virtualization for noticeably smoother, more responsive scrolling through large music libraries.
  * Track rows now render at consistent heights and the list uses dynamic spacer padding to preserve scroll position, reducing lag and rendering jank.
  * The track container is now scrollable and updates layout on mount/scroll for a more fluid browsing experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->