### PR TITLE
Implement virtual scrolling in Local library

### DIFF
--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -10,6 +10,8 @@ use reader::Library;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
+const ITEM_HEIGHT: f64 = 64.0; // 60px content + 4px margin (mb-1)
+
 #[component]
 pub fn LocalLibrary(
     library: Signal<Library>,
@@ -20,6 +22,8 @@ pub fn LocalLibrary(
 ) -> Element {
     let items = use_library_items(library);
     let mut sort_order = items.sort_order;
+    let mut scroll_stat = use_signal(|| 0.0);
+    let mut container_height = use_signal(|| 800.0);
 
     use_effect(move || {
         let curr = sort_order.read().clone();
@@ -47,26 +51,65 @@ pub fn LocalLibrary(
     });
 
     let is_empty = displayed_tracks().is_empty();
-
     let queue_source = std::sync::Arc::new(queue_tracks());
-    let tracks_nodes =
-        displayed_tracks()
-            .into_iter()
-            .enumerate()
-            .map(|(idx, (track, cover_url))| {
-                let track_menu = track.clone();
-                let track_add = track.clone();
-                let track_delete = track.clone();
-                let track_path = track.path.clone();
-                let track_select = track.path.clone();
-                let queue_arc = std::sync::Arc::clone(&queue_source);
-                let track_key = format!("{}-{}", track.path.display(), idx);
-                let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
-                let is_selected = selected_tracks.read().contains(&track_path);
 
-                rsx! {
+    let scroll_top = *scroll_stat.read();
+    let row_height = ITEM_HEIGHT;
+    let window_size = (*container_height.read() / row_height).ceil() as usize;
+    let buffer_size = 10;
+    let total_tracks = displayed_tracks().len();
+
+    let start_index = {
+        let calc = (scroll_top - (buffer_size as f64) * row_height) / row_height;
+        calc.floor().max(0.0) as usize
+    };
+
+    let end_index = {
+        let last_index = start_index + 2 * buffer_size + window_size;
+        let last_index_inclusive = last_index.saturating_sub(1);
+        if total_tracks == 0 {
+            0
+        } else {
+            last_index_inclusive.min(total_tracks - 1)
+        }
+    };
+
+    let items_to_render = if total_tracks == 0 {
+        0
+    } else {
+        (end_index + 1).saturating_sub(start_index)
+    };
+
+    let top_pad = (start_index as f64) * row_height;
+
+    let bottom_pad = {
+        let total_height = (total_tracks as f64) * row_height;
+        let rendered_height = (items_to_render as f64) * row_height;
+        (total_height - rendered_height - top_pad).max(0.0)
+    };
+
+    let tracks_nodes = displayed_tracks()
+        .into_iter()
+        .enumerate()
+        .skip(start_index)
+        .take(items_to_render)
+        .map(|(idx, (track, cover_url))| {
+            let track_menu = track.clone();
+            let track_add = track.clone();
+            let track_delete = track.clone();
+            let track_path = track.path.clone();
+            let track_select = track.path.clone();
+            let queue_arc = std::sync::Arc::clone(&queue_source);
+            let track_key = format!("{}-{}", track.path.display(), idx);
+            let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
+            let is_selected = selected_tracks.read().contains(&track_path);
+
+            rsx! {
+                div {
+                    key: "{track_key}",
+                    class: "mb-1",
+                    style: "height: {ITEM_HEIGHT}px;",
                     TrackRow {
-                        key: "{track_key}",
                         track: track.clone(),
                         cover_url: cover_url.clone(),
                         is_menu_open,
@@ -111,7 +154,8 @@ pub fn LocalLibrary(
                         },
                     }
                 }
-            });
+            }
+        });
 
     rsx! {
         div {
@@ -257,11 +301,26 @@ pub fn LocalLibrary(
             }
 
             div {
-                class: "space-y-1 pb-20",
+                class: "flex-1 overflow-y-auto pb-20",
+                onmounted: move |event| {
+                    spawn(async move {
+                        if let Ok(window) = event.get_client_rect().await {
+                            container_height.set(window.height());
+                        }
+                    });
+                },
+                onscroll: move |event| {
+                    let scroll_y = event.scroll_top();
+                    let height = event.client_height() as f64;
+                    scroll_stat.set(scroll_y);
+                    container_height.set(height);
+                },
                 if is_empty {
                     p { class: "text-slate-500 italic", "{rust_i18n::t!(\"no_tracks_found\")}" }
                 } else {
+                    div { style: "height: {top_pad}px; flex-shrink: 0;" }
                     {tracks_nodes}
+                    div { style: "height: {bottom_pad}px; flex-shrink: 0;" }
                 }
             }
         }

--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -158,8 +158,8 @@ div {
         });
 
     rsx! {
-        div {
-            class: "p-8 relative min-h-full",
+             div {
+                 class: "p-8 relative min-h-full flex flex-col",
 
             if *show_playlist_modal.read() {
                 PlaylistModal {

--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -60,8 +60,9 @@ pub fn LocalLibrary(
     let total_tracks = displayed_tracks().len();
 
     let start_index = {
+        let max_start = total_tracks.saturating_sub(1);
         let calc = (scroll_top - (buffer_size as f64) * row_height) / row_height;
-        calc.floor().max(0.0) as usize
+        (calc.floor().max(0.0) as usize).min(max_start)
     };
 
     let end_index = {

--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -10,7 +10,7 @@ use reader::Library;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-const ITEM_HEIGHT: f64 = 64.0; // 60px content + 4px margin (mb-1)
+const ITEM_HEIGHT: f64 = 60.0; // 60px content
 
 #[component]
 pub fn LocalLibrary(
@@ -105,10 +105,9 @@ pub fn LocalLibrary(
             let is_selected = selected_tracks.read().contains(&track_path);
 
             rsx! {
-                div {
-                    key: "{track_key}",
-                    class: "mb-1",
-                    style: "height: {ITEM_HEIGHT}px;",
+div {
+    key: "{track_key}",
+    style: "height: {ITEM_HEIGHT}px;",
                     TrackRow {
                         track: track.clone(),
                         cover_url: cover_url.clone(),

--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -10,7 +10,7 @@ use reader::Library;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-const ITEM_HEIGHT: f64 = 60.0; // 60px content
+const ITEM_HEIGHT: f64 = 60.0; // 60px: p-2 padding (16px*2=32) + content height (~28px)
 
 #[component]
 pub fn LocalLibrary(
@@ -23,7 +23,7 @@ pub fn LocalLibrary(
     let items = use_library_items(library);
     let mut sort_order = items.sort_order;
     let mut scroll_stat = use_signal(|| 0.0);
-    let mut container_height = use_signal(|| 800.0);
+    let mut container_height = use_signal(|| f64::NAN); // Set on mount
 
     use_effect(move || {
         let curr = sort_order.read().clone();
@@ -55,7 +55,12 @@ pub fn LocalLibrary(
 
     let scroll_top = *scroll_stat.read();
     let row_height = ITEM_HEIGHT;
-    let window_size = (*container_height.read() / row_height).ceil() as usize;
+    let container_h = *container_height.read();
+    let window_size = if container_h.is_nan() {
+        0
+    } else {
+        (container_h / row_height).ceil() as usize
+    };
     let buffer_size = 10;
     let total_tracks = displayed_tracks().len();
 
@@ -101,7 +106,7 @@ pub fn LocalLibrary(
             let track_path = track.path.clone();
             let track_select = track.path.clone();
             let queue_arc = std::sync::Arc::clone(&queue_source);
-            let track_key = format!("{}-{}", track.path.display(), idx);
+            let track_key = track.path.display().to_string();
             let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
             let is_selected = selected_tracks.read().contains(&track_path);
 


### PR DESCRIPTION

Summary of changes:
- Added virtual scrolling implementation to pages/src/local/library.rs
- Only renders tracks currently in viewport plus buffer, dramatically reducing memory usage
- Maintains scroll position with top/bottom padding divs
- Updated container to use proper overflow handling

Hopefully this fixes #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual scrolling in the library: only visible track rows are rendered and the list tracks viewport position for smooth continuous scrolling.
  * Track rows use a fixed height to support predictable windowed rendering.

* **Performance Improvements**
  * Reduced memory and rendering overhead through windowed rendering and spacer-managed scroll area, improving navigation performance for large libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->