### PR TITLE
Track number sorting to AlbumDetails (fixes issue #82)

### DIFF
--- a/components/src/album_details.rs
+++ b/components/src/album_details.rs
@@ -35,12 +35,17 @@ pub fn AlbumDetails(
         None => return rsx! { div { "{rust_i18n::t!(\"album_not_found\")}" } },
     };
 
-    let tracks: Vec<_> = lib
+    let mut tracks: Vec<_> = lib
         .tracks
         .iter()
         .filter(|t| t.album == album.title)
         .cloned()
         .collect();
+    tracks.sort_by(|a, b| {
+        a.track_number
+            .cmp(&b.track_number)
+            .then_with(|| a.title.cmp(&b.title))
+    });
 
     let album_cover = utils::format_artwork_url(album.cover_path.as_ref());
 


### PR DESCRIPTION
Tracks on albums lists out in the order in the library.json file this makes them sort by track number to ensure the tracks lists according to their track number

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Album tracks now display in a deterministic order, sorted by track number with title as a secondary sort criterion, ensuring consistent and predictable track listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->