### PR TITLE
Russian locale fixes

### DIFF
--- a/locales/ru.ftl
+++ b/locales/ru.ftl
@@ -129,8 +129,8 @@ username_and_password_required = Укажите имя пользователя 
 login_failed = Ошибка входа: { $error }
 error_server_not_configured = Сервер не настроен или учётные данные отсутствуют
 error_fetch_songs = Ошибка подгрузки треков альбома '{ $album_id }': { $error }
-unsupported_provider = { $service } настроен, но эта страница ещё не доступна для этого провайдера
-unsupported_provider_desc = Провайдер-специфичные возможности браузера будут добавлены с новой абстракцией сервера
+unsupported_provider = { $service } настроен, но эта страница ещё недоступна для этого провайдера
+unsupported_provider_desc = Специфичные для { $service } провайдера возможности браузера будут добавлены вместе с новой абстракцией сервера
 
 # Additional Keys
 no_genres_found = Жанры не найдены в вашей библиотеке.
@@ -210,6 +210,6 @@ accent-soft = Мягкий акцент
 accent-alt = Альтернативный акцент
 accent-deep = Глубокий акцент
 highlight = Выделение
-highlight-dark = Темное выделение
+highlight-dark = Тёмное выделение
 progress = Прогресс
 danger = Опасно

--- a/locales/ru.ftl
+++ b/locales/ru.ftl
@@ -130,7 +130,7 @@ login_failed = Ошибка входа: { $error }
 error_server_not_configured = Сервер не настроен или учётные данные отсутствуют
 error_fetch_songs = Ошибка подгрузки треков альбома '{ $album_id }': { $error }
 unsupported_provider = { $service } настроен, но эта страница ещё недоступна для этого провайдера
-unsupported_provider_desc = Специфичные для { $service } провайдера возможности браузера будут добавлены вместе с новой абстракцией сервера
+unsupported_provider_desc = Специфичные для провайдера { $service } возможности просмотра будут добавлены вместе с новой абстракцией сервера
 
 # Additional Keys
 no_genres_found = Жанры не найдены в вашей библиотеке.


### PR DESCRIPTION
Change three lines in the Russian localization:
1. Fix grammar (unnecessary space) in `unsupported_provider` ("не" + adjectives in sentences without a contrastive conjunction or other types of contrast between two adjectives is spelled without a space)
2. Change `unsupported_provider_desc` to sound less like an English calque or like it has been machine-translated + add `$service` for consistency with other languages
3. Fix an inconsistent usage of ⟨ё⟩ in `highlight-dark` (⟨ё⟩ is allowed to be spelled as ⟨е⟩ in the standard Russian orthography, but it has to be consistent across all usages, and since in all the other places it is spelled as ⟨ё⟩, change it in this one line to be consistent with the others)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved Russian language messaging for unsupported service notifications
  * Corrected Russian text formatting in UI labels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->