### PR TITLE
add Korean localization

### DIFF
--- a/locales/ko.ftl
+++ b/locales/ko.ftl
@@ -1,0 +1,215 @@
+language-name = 한국어
+is_rtl = false
+
+settings = 설정
+theme_editor = 테마 편집기
+appearance = 모양
+language = 언어
+library = 라이브러리
+playlists = 재생목록
+album = 앨범
+artist = 아티스트
+home = 홈
+search = 검색
+favorites = 즐겨찾기
+logs = 로그
+activity = 활동
+general = 일반
+music_directory = 음악 폴더
+service = 서비스: { $name }
+connected = ● 연결됨
+disconnected = ● 연결 끊김
+reconnect = 다시 연결
+remove = 제거
+add = 추가
+add_server = 서버 추가
+server_details = 서버 세부 정보
+server_name = 서버 이름
+server_url = 서버 URL
+choose_service = 서비스 선택
+cancel = 취소
+login = 로그인
+logging_in = 로그인 중...
+login_to_service = { $service }에 로그인
+username = 사용자 이름
+password = 비밀번호
+player_settings = 플레이어 설정
+discord_presence = Discord 상태 표시
+reduce_animations = 애니메이션 줄이기
+show_source_toggle = 소스 전환 표시
+volume = 음량
+local = 로컬
+server = 서버
+
+# UI Actions & Buttons
+add_to_favorites = 즐겨찾기에 추가
+remove_from_favorites = 즐겨찾기에서 제거
+add_to_playlist = 재생목록에 추가
+remove_from_playlist = 재생목록에서 제거
+delete = 삭제
+delete_song = 곡 삭제
+delete_album = 앨범 삭제
+add_all_to_playlist = 모두 재생목록에 추가
+remove_from_cache = 캐시에서 제거
+create = 만들기
+save = 저장
+enabled = 켜짐
+disabled = 꺼짐
+
+# Navigation & Headers
+tracks = 트랙
+albums = 앨범
+artists = 아티스트
+all_albums = 모든 앨범
+your_library = 내 라이브러리
+listening_logs = 감상 기록
+browse_genres = 장르 둘러보기
+top_artists = 인기 아티스트
+new_releases = 새 앨범
+
+# Navigation Buttons
+back_to_albums = 앨범으로 돌아가기
+back_to_artists = 아티스트로 돌아가기
+back_to_playlists = 재생목록으로 돌아가기
+back_to_browse = 둘러보기로 돌아가기
+back = 뒤로
+back_to_previous = 이전으로
+up_next = 다음 곡
+lyrics = 가사
+
+# Player/Media
+loading_lyrics = 가사 불러오는 중...
+lyrics_not_found = 가사를 찾을 수 없습니다
+no_previous_songs = 이전 곡이 없습니다
+playlist_track_count = { $count }곡
+music_playlist_count = 음악 • { $count }곡
+showcase_song_count = { $count }곡
+
+# Modal Titles
+add_playlist = 재생목록 추가
+create_new_playlist = 새 재생목록 만들기
+playlist_name_placeholder = 재생목록 이름
+playlist_name_input = 재생목록 이름
+add_media_server = 미디어 서버 추가
+media_server = 미디어 서버
+jellyfin = Jellyfin
+subsonic = Subsonic
+custom_manual = 사용자 지정(수동 API)
+server_name_optional = 서버 이름(선택 사항)
+server_url_placeholder = http://localhost:8096
+change = 변경
+heart_track_to_add = 재생 중인 곡에 하트를 눌러 여기에 추가하세요.
+heart_track_to_add_server = 재생 중인 곡에 하트를 눌러 여기에 추가하고 서버와 동기화하세요.
+
+# Search & Placeholders
+search_placeholder = 아티스트, 앨범 또는 트랙 검색...
+no_results_found = "{ $query }"에 대한 결과가 없습니다
+listenbrainz_token_placeholder = ListenBrainz 토큰 입력
+
+# Empty States
+album_not_found = 앨범을 찾을 수 없습니다
+playlist_not_found = 재생목록을 찾을 수 없습니다
+no_playlists_found = 재생목록을 찾을 수 없습니다
+no_playlists_yet = 아직 재생목록이 없습니다. 라이브러리에서 곡을 추가하세요!
+add_music_to_get_started = 시작하려면 음악을 추가하세요
+
+# Data Labels
+title = 제목
+time = 시간
+genre = 장르
+plays = 재생 횟수
+track_count = { $count }곡
+track_count_singular = 1곡
+songs = 곡
+min = 분
+
+# Error Messages
+invalid_server_url = 잘못된 서버 URL입니다
+username_and_password_required = 사용자 이름과 비밀번호가 필요합니다
+login_failed = 로그인 실패: { $error }
+error_server_not_configured = 서버가 설정되지 않았거나 인증 정보가 없습니다
+error_fetch_songs = 앨범 '{ $album_id }'의 곡을 가져오지 못했습니다: { $error }
+unsupported_provider = { $service }가 설정되어 있지만 이 페이지는 아직 해당 제공자를 지원하지 않습니다
+unsupported_provider_desc = { $service } 전용 탐색 기능은 새 서버 추상화와 함께 추가될 예정입니다
+
+# Additional Keys
+no_genres_found = 라이브러리에서 장르를 찾을 수 없습니다.
+jump_back_in = 이어서 듣기
+by_artist = 아티스트
+by_artist_full = { $artist }
+start_listening = 듣기 시작
+listen_now = 지금 듣기
+no_albums_found = 라이브러리에서 앨범을 찾을 수 없습니다.
+no_favorites = 아직 즐겨찾기가 없습니다.
+no_tracks_found = 트랙을 찾을 수 없습니다.
+unknown_artist = 알 수 없는 아티스트
+unknown_album = 알 수 없는 앨범
+unknown_title = 알 수 없는 제목
+unknown_genre = 알 수 없음
+most_played_local_tracks = 가장 많이 들은 로컬 트랙입니다.
+no_tracks_in_library = 라이브러리에서 트랙을 찾을 수 없습니다.
+no_songs_here = 여기에 곡이 없습니다.
+syncing_with_server = 서버와 동기화 중...
+most_played_tracks = 가장 많이 들은 트랙입니다.
+no_more_songs = 대기열에 더 이상 곡이 없습니다
+server_playlist = 서버 재생목록
+shuffle_on = 셔플: 켜짐
+shuffle_off = 셔플: 꺼짐
+repeat_off = 반복: 꺼짐
+repeat_queue = 반복: 대기열
+repeat_track = 반복: 트랙
+rescan_library = 라이브러리 다시 스캔
+refresh_music_library = 음악 라이브러리 새로고침
+listenbrainz = ListenBrainz
+album_art_gradient = 앨범 아트 그라데이션
+default_theme = 기본
+gruvbox_material = Gruvbox Material
+gruvbox_classic = Gruvbox Classic
+gruvbox_dark_soft = Gruvbox Dark Soft
+dracula = Dracula
+nord = Nord
+catppuccin_mocha = Catppuccin Mocha
+ef_night = Ef Night
+ayu_dark = Ayu Dark
+ayu_mirage = Ayu Mirage
+vague = Vague
+one_dark_pro = One Dark Pro
+osmium = Osmium
+kanagawa_dragon = Kanagawa Dragon
+everforest = Everforest
+rosepine = Rosé Pine
+default_light = 기본 라이트
+catppuccin_latte = Catppuccin Latte
+rosepine_dawn = Rosé Pine Dawn
+everforest_light = Everforest Light
+ayu_light = Ayu Light
+one_light = One Light
+gruvbox_light_soft = Gruvbox Light Soft
+
+# Theme Editor
+new_theme = 새 테마
+theme_name = 테마 이름
+my_custom_theme = 내 사용자 지정 테마
+theme_group_dynamic = 동적
+theme_group_dark = 다크
+theme_group_light = 라이트
+theme_group_custom = 사용자 지정
+colors = 색상
+preview = 미리보기
+save_theme = 테마 저장
+track_title = 트랙 제목
+
+# Color Labels
+bg = 배경
+raised = 돌출된 표면
+surface = 표면
+text = 텍스트
+text-muted = 흐린 텍스트
+accent = 강조
+accent-soft = 부드러운 강조
+accent-alt = 대체 강조
+accent-deep = 진한 강조
+highlight = 하이라이트
+highlight-dark = 어두운 하이라이트
+progress = 진행률
+danger = 위험


### PR DESCRIPTION
## Summary
- Add Korean (`ko`) localization
- Translate existing Fluent locale keys from `en.ftl`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Korean language support with complete translations for navigation, playback controls, search functionality, authentication, theme customization, and system notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->