### PR TITLE
Add Simplified Chinese translation

### DIFF
--- a/locales/zh-CN.ftl
+++ b/locales/zh-CN.ftl
@@ -1,0 +1,215 @@
+language-name = 简体中文
+is_rtl = false
+
+settings = 设置
+theme_editor = 主题编辑器
+appearance = 外观
+language = 语言
+library = 媒体库
+playlists = 播放列表
+album = 专辑
+artist = 艺术家
+home = 首页
+search = 搜索
+favorites = 收藏
+logs = 日志
+activity = 活动
+general = 通用
+music_directory = 音乐目录
+service = 服务：{ $name }
+connected = ● 已连接
+disconnected = ● 未连接
+reconnect = 重新连接
+remove = 移除
+add = 添加
+add_server = 添加服务器
+server_details = 服务器详情
+server_name = 服务器名称
+server_url = 服务器地址
+choose_service = 选择服务
+cancel = 取消
+login = 登录
+logging_in = 正在登录...
+login_to_service = 登录到 { $service }
+username = 用户名
+password = 密码
+player_settings = 播放器设置
+discord_presence = Discord 状态
+reduce_animations = 减少动画
+show_source_toggle = 显示来源切换
+volume = 音量
+local = 本地
+server = 服务器
+
+# UI Actions & Buttons
+add_to_favorites = 添加到收藏
+remove_from_favorites = 从收藏中移除
+add_to_playlist = 添加到播放列表
+remove_from_playlist = 从播放列表中移除
+delete = 删除
+delete_song = 删除歌曲
+delete_album = 删除专辑
+add_all_to_playlist = 全部添加到播放列表
+remove_from_cache = 从缓存中移除
+create = 创建
+save = 保存
+enabled = 已启用
+disabled = 已禁用
+
+# Navigation & Headers
+tracks = 曲目
+albums = 专辑
+artists = 艺术家
+all_albums = 所有专辑
+your_library = 你的媒体库
+listening_logs = 听歌记录
+browse_genres = 浏览流派
+top_artists = 热门艺术家
+new_releases = 新添加
+
+# Navigation Buttons
+back_to_albums = 返回专辑
+back_to_artists = 返回艺术家
+back_to_playlists = 返回播放列表
+back_to_browse = 返回浏览
+back = 返回
+back_to_previous = 返回
+up_next = 接下来播放
+lyrics = 歌词
+
+# Player/Media
+loading_lyrics = 正在加载歌词...
+lyrics_not_found = 未找到歌词
+no_previous_songs = 没有上一首歌曲
+playlist_track_count = { $count } 首曲目
+music_playlist_count = 音乐 • { $count } 首曲目
+showcase_song_count = { $count } 首歌曲
+
+# Modal Titles
+add_playlist = 添加播放列表
+create_new_playlist = 创建新播放列表
+playlist_name_placeholder = 播放列表名称
+playlist_name_input = 播放列表名称
+add_media_server = 添加媒体服务器
+media_server = 媒体服务器
+jellyfin = Jellyfin
+subsonic = Subsonic
+custom_manual = 自定义（手动 API）
+server_name_optional = 服务器名称（可选）
+server_url_placeholder = http://localhost:8096
+change = 更改
+heart_track_to_add = 播放时点收藏即可添加到这里。
+heart_track_to_add_server = 播放时点收藏即可添加到这里，并同步到你的服务器。
+
+# Search & Placeholders
+search_placeholder = 搜索艺术家、专辑或曲目...
+no_results_found = 没有找到“{ $query }”的结果
+listenbrainz_token_placeholder = 输入你的 ListenBrainz 令牌
+
+# Empty States
+album_not_found = 未找到专辑
+playlist_not_found = 未找到播放列表
+no_playlists_found = 未找到播放列表
+no_playlists_yet = 还没有播放列表。请从媒体库添加歌曲！
+add_music_to_get_started = 添加音乐以开始使用
+
+# Data Labels
+title = 标题
+time = 时间
+genre = 流派
+plays = 播放次数
+track_count = { $count } 首曲目
+track_count_singular = 1 首曲目
+songs = 首歌曲
+min = 分钟
+
+# Error Messages
+invalid_server_url = 无效的服务器地址
+username_and_password_required = 用户名和密码为必填项
+login_failed = 登录失败：{ $error }
+error_server_not_configured = 服务器未配置或缺少凭据
+error_fetch_songs = 获取专辑“{ $album_id }”的歌曲失败：{ $error }
+unsupported_provider = 已配置 { $service }，但此页面暂不支持该提供方
+unsupported_provider_desc = 针对 { $service } 的提供方专属浏览功能将通过新的服务器抽象添加
+
+# Additional Keys
+no_genres_found = 你的媒体库中没有找到流派。
+jump_back_in = 继续收听
+by_artist = 艺术家
+by_artist_full = 艺术家：{ $artist }
+start_listening = 开始收听
+listen_now = 现在收听
+no_albums_found = 你的媒体库中没有找到专辑。
+no_favorites = 还没有收藏。
+no_tracks_found = 未找到曲目。
+unknown_artist = 未知艺术家
+unknown_album = 未知专辑
+unknown_title = 未知标题
+unknown_genre = 未知
+most_played_local_tracks = 你最常播放的本地曲目。
+no_tracks_in_library = 你的媒体库中没有找到曲目。
+no_songs_here = 这里没有歌曲。
+syncing_with_server = 正在与服务器同步...
+most_played_tracks = 你最常播放的曲目。
+no_more_songs = 队列中没有更多歌曲
+server_playlist = 服务器播放列表
+shuffle_on = 随机播放：开
+shuffle_off = 随机播放：关
+repeat_off = 重复播放：关
+repeat_queue = 重复播放：队列
+repeat_track = 重复播放：单曲
+rescan_library = 重新扫描媒体库
+refresh_music_library = 刷新音乐库
+listenbrainz = ListenBrainz
+album_art_gradient = 渐变专辑封面
+default_theme = 默认
+gruvbox_material = Gruvbox Material
+gruvbox_classic = Gruvbox Classic
+gruvbox_dark_soft = Gruvbox Dark Soft
+dracula = Dracula
+nord = Nord
+catppuccin_mocha = Catppuccin Mocha
+ef_night = Ef Night
+ayu_dark = Ayu Dark
+ayu_mirage = Ayu Mirage
+vague = Vague
+one_dark_pro = One Dark Pro
+osmium = Osmium
+kanagawa_dragon = Kanagawa Dragon
+everforest = Everforest
+rosepine = Rosé Pine
+default_light = 默认浅色
+catppuccin_latte = Catppuccin Latte
+rosepine_dawn = Rosé Pine Dawn
+everforest_light = Everforest Light
+ayu_light = Ayu Light
+one_light = One Light
+gruvbox_light_soft = Gruvbox Light Soft
+
+# Theme Editor
+new_theme = 新主题
+theme_name = 主题名称
+my_custom_theme = 我的自定义主题
+theme_group_dynamic = 动态
+theme_group_dark = 深色
+theme_group_light = 浅色
+theme_group_custom = 自定义
+colors = 颜色
+preview = 预览
+save_theme = 保存主题
+track_title = 曲目标题
+
+# Color Labels
+bg = 背景
+raised = 抬升表面
+surface = 表面
+text = 文本
+text-muted = 弱化文本
+accent = 强调色
+accent-soft = 柔和强调色
+accent-alt = 备用强调色
+accent-deep = 深强调色
+highlight = 高亮
+highlight-dark = 深色高亮
+progress = 进度
+danger = 危险操作


### PR DESCRIPTION
## Summary

Adds Simplified Chinese localization via `locales/zh-CN.ftl`.

## Details

- Adds `language-name = 简体中文` so the language appears in the settings language selector.
- Translates the existing English Fluent keys while preserving all key names and variable placeholders.
- Keeps brand/theme names such as Jellyfin, Subsonic, ListenBrainz, and theme names unchanged where appropriate.

## Validation

- Verified `locales/en.ftl` and `locales/zh-CN.ftl` contain the same localization keys.
- Verified Fluent variable placeholders match the English source.
- Ran `cargo check -p i18n`.
- Ran `cargo check -p kopuz`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Simplified Chinese language support with complete UI translations including navigation, menus, buttons, player controls, playlists, settings, search, error messages, and theme options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->