### PR TITLE
docs: add documentation for build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,24 @@ You can also click on the file and open it with an app provider, for example KDE
 
 ### Build from Source
 
+#### Dependencies
+**Arch Linux Based Systems**
+```bash
+sudo pacman -S rust cargo dioxus-cli base-devel pkgconf opus alsa-lib xdotool webkit2gtk-4.1 gtk3 libsoup3 openssl
+```
+**Debian Based Systems**
+```bash
+sudo apt install rustc cargo build-essential pkg-config libopus-dev libasound2-dev libxdo-dev libwebkit2gtk-4.1-dev libgtk-3-dev libsoup-3.0-dev libssl-dev
+cargo install dioxus-cli
+```
+**Fedora Based Systems**
+```bash
+sudo dnf groupinstall "Development Tools" "Development Libraries"
+sudo dnf install rust cargo pkgconf-pkg-config opus-devel alsa-lib-devel libxdo-devel webkit2gtk4.1-devel gtk3-devel libsoup3-devel openssl-devel
+cargo install dioxus-cli
+```
+
+
 ```bash
 git clone https://github.com/temidaradev/kopuz
 cd kopuz


### PR DESCRIPTION
The necessary dependencies and installation commands for Arch Linux, Fedora, and Debian based distributions have been added to the README file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added distribution-specific dependency installation instructions for building from source on Debian and Fedora, including system packages and development tools required for the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->