### PR TITLE
docs: use correct `trusted-public-keys` for cachix

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ nix.settings = {
   substituters      = [ "https://cache.nixos.org" "https://kopuz.cachix.org" ];
   trusted-public-keys = [
     "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-    "kopuz.cachix.org-1:WXMpGpamblLUiJtcoxBxGGGGwIcWxGPJBUxarLiqWmw="
+    "kopuz.cachix.org-1:J2X3AnAYhKTJW5S3aCLoA1ckonQXVNZMQvhZA0YAufw="
   ];
 };
 ```


### PR DESCRIPTION
Hi, I was trying to use the cachix cache via:

```bash
NIX_CONFIG='
substituters = https://cache.nixos.org https://kopuz.cachix.org
trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= kopuz.cachix.org-1:WXMpGpamblLUiJtcoxBxGGGGwIcWxGPJBUxarLiqWmw=
' nix run github:temidaradev/kopuz
```

But I got:

```ansi
warning: ignoring substitute for '/nix/store/...' from 'https://kopuz.cachix.org', as it's not signed by any of the keys in 'trusted-public-keys'
```

I notcied that key in the [cachix page](https://app.cachix.org/cache/kopuz) is diffrent.

```diff
# On README
- kopuz.cachix.org-1:WXMpGpamblLUiJtcoxBxGGGGwIcWxGPJBUxarLiqWmw=
# On cachix page
+ kopuz.cachix.org-1:J2X3AnAYhKTJW5S3aCLoA1ckonQXVNZMQvhZA0YAufw=

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NixOS installation instructions with a new Cachix public key configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->