### PR TITLE
Bump symphonia-adapter-libopus to 0.2, disable bundled libopus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,15 +622,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cocoa"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4320,13 +4311,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "opusic-sys"
-version = "0.5.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f43c183739dc81651487e7c9f3e4330fe4a3fd26c0fa961c788ce5fb21fa75b"
-dependencies = [
- "cmake",
- "libc",
-]
+checksum = "dc3280fe5b6f97ac1a35a0ac003e2fb0b92f8e4bdf2b2057e1bf9b87acca5696"
 
 [[package]]
 name = "ordered-stream"
@@ -5915,10 +5902,11 @@ dependencies = [
 
 [[package]]
 name = "symphonia-adapter-libopus"
-version = "0.1.2"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a630acf003f3d39d93eaaa3b8d09c872170ea202ff39bef2248c96682de1a4"
+checksum = "b9d17450685dda0e87467eddf3e0f9c0b2a1707fc5c3234c111f70d46c6e4494"
 dependencies = [
+ "log",
  "opusic-sys",
  "symphonia-core",
 ]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cpal = { workspace = true }
 symphonia = { workspace = true }
-symphonia-adapter-libopus = "0.1"
+symphonia-adapter-libopus = { version = "0.2", default-features = false }
 rb = { workspace = true }
 tokio = { workspace = true }
 


### PR DESCRIPTION
## Summary

Bumps `symphonia-adapter-libopus` from 0.1 to 0.2 in `player/`, and disables its `bundled` default feature. Resolves the link failure when building on distros that enable LTO by default for package builds (Arch `makepkg` with `OPTIONS=(lto)`, etc.).

## The bug

```
rust-lld: error: undefined symbol: opus_decoder_destroy
rust-lld: error: undefined symbol: opus_decode
rust-lld: error: undefined symbol: opus_decoder_create
```

Reproduces deterministically with `yay -S kopuz` on Arch/CachyOS. Root cause is in `opusic-sys` (the transitive C bindings crate kopuz pulls via `symphonia-adapter-libopus`): its bundled cmake build of `libopus.a` inherits ambient `CFLAGS`. When those contain `-flto` (which Arch's `makepkg` injects via `LTOFLAGS="-flto=auto"` when `OPTIONS=(lto)`), GCC emits *slim LTO* object files — empty `.text`, code only in `.gnu.lto_*` sections, marked with `__gnu_lto_slim`. rustc bundles those into the rlib (cargo's `+bundle` modifier on `cargo:rustc-link-lib=static=opus`); rust-lld then can't resolve the opus symbols because the bytecode requires an LTO plugin it isn't given.

`opusic-sys` 0.7.3 fixes this upstream (DoumanAsh/opusic-sys#22) by stripping `-flto*` from inherited CFLAGS before invoking cmake. But `symphonia-adapter-libopus` 0.1.x caps at `opusic-sys ^0.5`, so that fix never reaches kopuz on the current pin.

## What this PR does

1. Bump `symphonia-adapter-libopus` to `0.2` — same crate, now uses `opusic-sys ^0.6`. `OpusDecoder::try_new(&CodecParameters, &DecoderOptions) -> Result<Self>` API is unchanged, so no source changes in `player/src/player.rs`.
2. Set `default-features = false` to drop `bundled`. opusic-sys then dynamically links against system libopus (`libopus.so` on Linux), which sidesteps the cmake build path entirely — no LTO bytecode issue, no cmake build-time dep.

## Verification

Reproduced the failure first with the exact makepkg env, then patched and rebuilt:

```sh
LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,pack-relative-relocs" \
CFLAGS="-march=native -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=3 -Wformat \
  -Werror=format-security -fstack-clash-protection -fcf-protection -flto=auto" \
CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS" \
dx build --release --platform desktop -p kopuz
```

After the bump:
- builds cleanly (665/665 crates, no cmake step)
- `ldd target/dx/kopuz/release/linux/app/kopuz` shows `libopus.so.0 => /usr/lib/libopus.so.0`
- `nm -D` shows `U opus_decoder_create` (resolved at runtime, not embedded)
- no `target/.../build/opusic-sys-*/out` artifacts (no bundled libopus build)

## Trade-off / note for packagers

`opus` becomes a runtime dependency on all targets:
- **Linux**: `opus` is in repos on all major distros (already a transitive dep of gstreamer, ffmpeg, pipewire, etc.) — should be present on any audio-capable system. Arch users will want `opus` added to `depends` in the AUR PKGBUILD.
- **macOS**: `brew install opus`.
- **Windows**: would need libopus.dll alongside the binary or installed system-wide.

Removes `cmake` as a build-time dependency in exchange.

## Test plan
- [x] Linker error reproduces on master with Arch makepkg CFLAGS
- [x] Build succeeds end-to-end after the bump under the same CFLAGS
- [x] Final binary dynamically links system libopus (verified via `ldd` and `nm -D`)
- [x] Smoke-test playback of an opus stream (haven't run the desktop app — couldn't be sure my system has all the GTK/webkit deps configured for headless dx run)

## References

- Upstream root-cause fix: https://github.com/DoumanAsh/opusic-sys/pull/22 (merged, opusic-sys 0.7.3)
- `symphonia-adapter-libopus` 0.1 → 0.2 changelog: https://github.com/aschey/symphonia-adapters/releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated audio processing library to the latest compatible version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->