### PR TITLE
Revert "Bump symphonia-adapter-libopus to 0.2, disable bundled libopus"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4311,9 +4320,13 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "opusic-sys"
-version = "0.6.0"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3280fe5b6f97ac1a35a0ac003e2fb0b92f8e4bdf2b2057e1bf9b87acca5696"
+checksum = "8f43c183739dc81651487e7c9f3e4330fe4a3fd26c0fa961c788ce5fb21fa75b"
+dependencies = [
+ "cmake",
+ "libc",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -5903,11 +5916,10 @@ dependencies = [
 
 [[package]]
 name = "symphonia-adapter-libopus"
-version = "0.2.7"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d17450685dda0e87467eddf3e0f9c0b2a1707fc5c3234c111f70d46c6e4494"
+checksum = "a5a630acf003f3d39d93eaaa3b8d09c872170ea202ff39bef2248c96682de1a4"
 dependencies = [
- "log",
  "opusic-sys",
  "symphonia-core",
 ]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -9,7 +9,7 @@ config = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cpal = { workspace = true }
 symphonia = { workspace = true }
-symphonia-adapter-libopus = { version = "0.2", default-features = false }
+symphonia-adapter-libopus = "0.1"
 rb = { workspace = true }
 tokio = { workspace = true }
 


### PR DESCRIPTION
Reverts temidaradev/kopuz#140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated audio library dependency version for non-web platform builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->