### PR TITLE
feat: improve equalizer presets, graph polish

### DIFF
--- a/components/src/settings_items.rs
+++ b/components/src/settings_items.rs
@@ -407,8 +407,10 @@ pub fn EqualizerPanel(
     let config = use_context::<Signal<AppConfig>>();
     let mut draft = use_signal(|| current.clone());
     let mut dragging_band = use_signal(|| None::<usize>);
+    let mut hovered_band = use_signal(|| None::<usize>);
     let mut displayed_bands = use_signal(|| current.resolved_bands());
     let mut animation_token = use_signal(|| 0_u64);
+    let reduce_animations = config.read().reduce_animations;
     let enabled = draft.read().enabled;
     let resolved_bands = *displayed_bands.read();
     let slider_style = if enabled {
@@ -429,6 +431,13 @@ pub fn EqualizerPanel(
         "text-slate-500 hover:text-slate-300"
     };
     let active_drag_band = *dragging_band.read();
+    let active_hover_band = *hovered_band.read();
+    let highlighted_band = active_drag_band.or(active_hover_band);
+    let graph_class = if active_drag_band.is_some() {
+        "block mx-auto cursor-grabbing"
+    } else {
+        "block mx-auto cursor-row-resize"
+    };
 
     let graph_path = resolved_bands
         .iter()
@@ -443,6 +452,49 @@ pub fn EqualizerPanel(
         })
         .collect::<Vec<_>>()
         .join(" ");
+    let graph_fill_path = format!(
+        "{} L {:.2} {:.2} L {:.2} {:.2} Z",
+        graph_path,
+        eq_band_x(BAND_LABELS.len().saturating_sub(1), BAND_LABELS.len()),
+        EQ_GRAPH_HEIGHT - EQ_GRAPH_PAD_BOTTOM,
+        eq_band_x(0, BAND_LABELS.len()),
+        EQ_GRAPH_HEIGHT - EQ_GRAPH_PAD_BOTTOM
+    );
+    let curve_fill_style = {
+        let opacity = if enabled {
+            if highlighted_band.is_some() { 0.94 } else { 0.82 }
+        } else {
+            0.22
+        };
+
+        if reduce_animations {
+            format!("fill: url(#eq-curve-fill); opacity: {opacity:.2};")
+        } else {
+            format!(
+                "fill: url(#eq-curve-fill); opacity: {opacity:.2}; transition: opacity 160ms ease-out;"
+            )
+        }
+    };
+    let curve_stroke_style = if enabled {
+        if highlighted_band.is_some() {
+            if reduce_animations {
+                "stroke: var(--color-indigo-400);".to_string()
+            } else {
+                "stroke: var(--color-indigo-400); transition: stroke 140ms ease-out;"
+                    .to_string()
+            }
+        } else if reduce_animations {
+            "stroke: var(--color-indigo-500);".to_string()
+        } else {
+            "stroke: var(--color-indigo-500); transition: stroke 140ms ease-out;".to_string()
+        }
+    } else if reduce_animations {
+        "stroke: color-mix(in oklab, var(--color-indigo-500) 52%, var(--color-slate-400));"
+            .to_string()
+    } else {
+        "stroke: color-mix(in oklab, var(--color-indigo-500) 52%, var(--color-slate-400)); transition: stroke 180ms ease-out;"
+            .to_string()
+    };
 
     rsx! {
         div { class: "flex flex-col gap-4 w-full",
@@ -494,7 +546,7 @@ pub fn EqualizerPanel(
                             draft.set(next.clone());
                             let token = *animation_token.read() + 1;
                             animation_token.set(token);
-                            if config.read().reduce_animations {
+                            if reduce_animations {
                                 displayed_bands.set(next_bands);
                             } else {
                                 spawn(async move {
@@ -569,13 +621,14 @@ pub fn EqualizerPanel(
                 class: "rounded-2xl border border-white/8 bg-white/5 p-4 select-none overflow-x-auto",
                 style: "background: color-mix(in oklab, var(--color-neutral-900) 78%, transparent); border-color: color-mix(in oklab, var(--color-white) 8%, transparent);",
                 svg {
-                    class: "block mx-auto cursor-row-resize",
+                    class: "{graph_class}",
                     style: "width: 760px; height: 280px; min-width: 760px;",
                     view_box: "0 0 760 280",
                     onmousedown: move |evt: MouseEvent| {
                         let point = evt.element_coordinates();
                         let index = eq_nearest_band(point.x, BAND_LABELS.len());
                         dragging_band.set(Some(index));
+                        hovered_band.set(Some(index));
                         let next = eq_apply_drag(&draft.peek().clone(), index, point.y);
                         draft.set(next.clone());
                         let token = *animation_token.read() + 1;
@@ -584,8 +637,10 @@ pub fn EqualizerPanel(
                         on_preview.call(next);
                     },
                     onmousemove: move |evt: MouseEvent| {
+                        let point = evt.element_coordinates();
+                        let index = eq_nearest_band(point.x, BAND_LABELS.len());
+                        hovered_band.set(Some(index));
                         if let Some(index) = *dragging_band.read() {
-                            let point = evt.element_coordinates();
                             let next = eq_apply_drag(&draft.peek().clone(), index, point.y);
                             draft.set(next.clone());
                             displayed_bands.set(next.resolved_bands());
@@ -597,13 +652,32 @@ pub fn EqualizerPanel(
                             on_commit.call(draft.peek().clone());
                         }
                         dragging_band.set(None);
+                        hovered_band.set(None);
                     },
                     onmouseleave: move |_| {
                         if dragging_band.peek().is_some() {
                             on_commit.call(draft.peek().clone());
                         }
                         dragging_band.set(None);
+                        hovered_band.set(None);
                     },
+                    defs {
+                        linearGradient {
+                            id: "eq-curve-fill",
+                            x1: "0",
+                            y1: "0",
+                            x2: "0",
+                            y2: "1",
+                            stop {
+                                offset: "0%",
+                                style: "stop-color: color-mix(in oklab, var(--color-indigo-400) 34%, transparent); stop-opacity: 1;",
+                            }
+                            stop {
+                                offset: "100%",
+                                style: "stop-color: color-mix(in oklab, var(--color-indigo-500) 3%, transparent); stop-opacity: 1;",
+                            }
+                        }
+                    }
                     for db in [-12.0_f64, -6.0, 0.0, 6.0, 12.0] {
                         line {
                             x1: "{EQ_GRAPH_PAD_X}",
@@ -647,35 +721,88 @@ pub fn EqualizerPanel(
                         }
                     }
                     path {
+                        d: "{graph_fill_path}",
+                        style: "{curve_fill_style}",
+                    }
+                    if let Some(index) = highlighted_band {
+                        line {
+                            x1: "{eq_band_x(index, BAND_LABELS.len())}",
+                            x2: "{eq_band_x(index, BAND_LABELS.len())}",
+                            y1: "{EQ_GRAPH_PAD_TOP}",
+                            y2: "{EQ_GRAPH_HEIGHT - EQ_GRAPH_PAD_BOTTOM}",
+                            stroke_width: "1.5",
+                            style: if reduce_animations {
+                                "stroke: color-mix(in oklab, var(--color-indigo-400) 34%, transparent);"
+                            } else {
+                                "stroke: color-mix(in oklab, var(--color-indigo-400) 34%, transparent); transition: stroke 140ms ease-out;"
+                            },
+                        }
+                    }
+                    path {
                         d: "{graph_path}",
                         fill: "none",
                         stroke_width: "2.5",
                         stroke_linecap: "round",
                         stroke_linejoin: "round",
-                        style: "stroke: var(--color-indigo-500);",
+                        style: "{curve_stroke_style}",
                     }
                     for (index, gain) in resolved_bands.iter().enumerate() {
-                        circle {
-                            cx: "{eq_band_x(index, BAND_LABELS.len())}",
-                            cy: "{eq_gain_to_y(*gain)}",
-                            r: if active_drag_band == Some(index) { "8" } else { "6" },
-                            style: if active_drag_band == Some(index) {
-                                "fill: var(--color-indigo-400);"
-                            } else {
-                                "fill: var(--color-white);"
-                            },
-                        }
-                        circle {
-                            cx: "{eq_band_x(index, BAND_LABELS.len())}",
-                            cy: "{eq_gain_to_y(*gain)}",
-                            r: "14",
-                            fill: "transparent",
-                            stroke_width: "1",
-                            style: if active_drag_band == Some(index) {
-                                "stroke: color-mix(in oklab, var(--color-indigo-400) 40%, transparent);"
-                            } else {
-                                "stroke: color-mix(in oklab, var(--color-white) 10%, transparent);"
-                            },
+                        {
+                            let is_highlighted = highlighted_band == Some(index);
+                            rsx! {
+                                circle {
+                                    cx: "{eq_band_x(index, BAND_LABELS.len())}",
+                                    cy: "{eq_gain_to_y(*gain)}",
+                                    r: if active_drag_band == Some(index) {
+                                        "8"
+                                    } else if is_highlighted {
+                                        "7"
+                                    } else {
+                                        "6"
+                                    },
+                                    style: if active_drag_band == Some(index) {
+                                        if reduce_animations {
+                                            "fill: var(--color-indigo-400);"
+                                        } else {
+                                            "fill: var(--color-indigo-400); transition: r 140ms ease-out, fill 140ms ease-out;"
+                                        }
+                                    } else if is_highlighted {
+                                        if reduce_animations {
+                                            "fill: var(--color-indigo-400);"
+                                        } else {
+                                            "fill: var(--color-indigo-400); transition: r 140ms ease-out, fill 140ms ease-out;"
+                                        }
+                                    } else if reduce_animations {
+                                        "fill: var(--color-white);"
+                                    } else {
+                                        "fill: var(--color-white); transition: r 140ms ease-out, fill 140ms ease-out;"
+                                    },
+                                }
+                                circle {
+                                    cx: "{eq_band_x(index, BAND_LABELS.len())}",
+                                    cy: "{eq_gain_to_y(*gain)}",
+                                    r: if is_highlighted { "16" } else { "14" },
+                                    fill: "transparent",
+                                    stroke_width: "1",
+                                    style: if active_drag_band == Some(index) {
+                                        if reduce_animations {
+                                            "stroke: color-mix(in oklab, var(--color-indigo-400) 40%, transparent);"
+                                        } else {
+                                            "stroke: color-mix(in oklab, var(--color-indigo-400) 40%, transparent); transition: r 140ms ease-out, stroke 140ms ease-out;"
+                                        }
+                                    } else if is_highlighted {
+                                        if reduce_animations {
+                                            "stroke: color-mix(in oklab, var(--color-indigo-400) 28%, transparent);"
+                                        } else {
+                                            "stroke: color-mix(in oklab, var(--color-indigo-400) 28%, transparent); transition: r 140ms ease-out, stroke 140ms ease-out;"
+                                        }
+                                    } else if reduce_animations {
+                                        "stroke: color-mix(in oklab, var(--color-white) 10%, transparent);"
+                                    } else {
+                                        "stroke: color-mix(in oklab, var(--color-white) 10%, transparent); transition: r 140ms ease-out, stroke 140ms ease-out;"
+                                    },
+                                }
+                            }
                         }
                     }
                     if let Some(index) = active_drag_band {

--- a/components/src/settings_items.rs
+++ b/components/src/settings_items.rs
@@ -375,6 +375,16 @@ fn eq_apply_drag(base: &EqualizerConfig, index: usize, y: f64) -> EqualizerConfi
     eq_apply_band_gain(base, index, eq_y_to_gain(y))
 }
 
+fn eq_interpolate_bands(from: [f32; 5], to: [f32; 5], progress: f32) -> [f32; 5] {
+    std::array::from_fn(|index| from[index] + (to[index] - from[index]) * progress)
+}
+
+fn eq_drag_readout_position(index: usize, gain: f32, total: usize) -> (f64, f64) {
+    let x = eq_band_x(index, total).clamp(76.0, EQ_GRAPH_WIDTH - 76.0);
+    let y = (eq_gain_to_y(gain) - 30.0).clamp(18.0, EQ_GRAPH_HEIGHT - EQ_GRAPH_PAD_BOTTOM - 18.0);
+    (x, y)
+}
+
 fn eq_preset_label(preset: EqPreset) -> String {
     match preset {
         EqPreset::Flat => i18n::t("eq_preset_flat"),
@@ -394,10 +404,13 @@ pub fn EqualizerPanel(
 ) -> Element {
     const BAND_LABELS: [&str; 5] = ["60 Hz", "250 Hz", "1 kHz", "4 kHz", "12 kHz"];
 
+    let config = use_context::<Signal<AppConfig>>();
     let mut draft = use_signal(|| current.clone());
     let mut dragging_band = use_signal(|| None::<usize>);
+    let mut displayed_bands = use_signal(|| current.resolved_bands());
+    let mut animation_token = use_signal(|| 0_u64);
     let enabled = draft.read().enabled;
-    let resolved_bands = draft.read().resolved_bands();
+    let resolved_bands = *displayed_bands.read();
     let slider_style = if enabled {
         "inset-inline-start: 4px; width: calc(50% - 4px);"
     } else {
@@ -415,6 +428,7 @@ pub fn EqualizerPanel(
     } else {
         "text-slate-500 hover:text-slate-300"
     };
+    let active_drag_band = *dragging_band.read();
 
     let graph_path = resolved_bands
         .iter()
@@ -470,8 +484,38 @@ pub fn EqualizerPanel(
                         value: "{draft.read().preset.as_storage()}",
                         onchange: move |evt| {
                             let mut next = draft.peek().clone();
-                            next.preset = EqPreset::from_storage(&evt.value());
+                            let preset = EqPreset::from_storage(&evt.value());
+                            let previous_bands = *displayed_bands.peek();
+                            next.preset = preset;
+                            if let Some(default_preamp_db) = preset.default_preamp_db() {
+                                next.preamp_db = default_preamp_db;
+                            }
+                            let next_bands = next.resolved_bands();
                             draft.set(next.clone());
+                            let token = *animation_token.read() + 1;
+                            animation_token.set(token);
+                            if config.read().reduce_animations {
+                                displayed_bands.set(next_bands);
+                            } else {
+                                spawn(async move {
+                                    const STEPS: u32 = 10;
+                                    const FRAME_MS: u64 = 18;
+                                    for step in 1..=STEPS {
+                                        if *animation_token.read() != token {
+                                            return;
+                                        }
+                                        let progress = step as f32 / STEPS as f32;
+                                        displayed_bands.set(eq_interpolate_bands(
+                                            previous_bands,
+                                            next_bands,
+                                            progress,
+                                        ));
+                                        if step < STEPS {
+                                            utils::sleep(std::time::Duration::from_millis(FRAME_MS)).await;
+                                        }
+                                    }
+                                });
+                            }
                             on_preview.call(next.clone());
                             on_commit.call(next);
                         },
@@ -534,6 +578,9 @@ pub fn EqualizerPanel(
                         dragging_band.set(Some(index));
                         let next = eq_apply_drag(&draft.peek().clone(), index, point.y);
                         draft.set(next.clone());
+                        let token = *animation_token.read() + 1;
+                        animation_token.set(token);
+                        displayed_bands.set(next.resolved_bands());
                         on_preview.call(next);
                     },
                     onmousemove: move |evt: MouseEvent| {
@@ -541,6 +588,7 @@ pub fn EqualizerPanel(
                             let point = evt.element_coordinates();
                             let next = eq_apply_drag(&draft.peek().clone(), index, point.y);
                             draft.set(next.clone());
+                            displayed_bands.set(next.resolved_bands());
                             on_preview.call(next);
                         }
                     },
@@ -610,8 +658,8 @@ pub fn EqualizerPanel(
                         circle {
                             cx: "{eq_band_x(index, BAND_LABELS.len())}",
                             cy: "{eq_gain_to_y(*gain)}",
-                            r: if *dragging_band.read() == Some(index) { "8" } else { "6" },
-                            style: if *dragging_band.read() == Some(index) {
+                            r: if active_drag_band == Some(index) { "8" } else { "6" },
+                            style: if active_drag_band == Some(index) {
                                 "fill: var(--color-indigo-400);"
                             } else {
                                 "fill: var(--color-white);"
@@ -623,11 +671,40 @@ pub fn EqualizerPanel(
                             r: "14",
                             fill: "transparent",
                             stroke_width: "1",
-                            style: if *dragging_band.read() == Some(index) {
+                            style: if active_drag_band == Some(index) {
                                 "stroke: color-mix(in oklab, var(--color-indigo-400) 40%, transparent);"
                             } else {
                                 "stroke: color-mix(in oklab, var(--color-white) 10%, transparent);"
                             },
+                        }
+                    }
+                    if let Some(index) = active_drag_band {
+                        {
+                            let gain = resolved_bands[index];
+                            let (tooltip_x, tooltip_y) =
+                                eq_drag_readout_position(index, gain, BAND_LABELS.len());
+                            rsx! {
+                                rect {
+                                    x: "{tooltip_x - 34.0}",
+                                    y: "{tooltip_y - 12.0}",
+                                    rx: "10",
+                                    ry: "10",
+                                    width: "68",
+                                    height: "24",
+                                    style: "fill: color-mix(in oklab, var(--color-neutral-900) 92%, transparent); stroke: color-mix(in oklab, var(--color-indigo-400) 26%, transparent);",
+                                    stroke_width: "1",
+                                }
+                                text {
+                                    x: "{tooltip_x}",
+                                    y: "{tooltip_y + 3.5}",
+                                    text_anchor: "middle",
+                                    font_size: "11",
+                                    font_family: "JetBrains Mono, monospace",
+                                    font_weight: "700",
+                                    style: "fill: var(--color-white);",
+                                    {format!("{gain:+.1} dB")}
+                                }
+                            }
                         }
                     }
                 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -221,6 +221,17 @@ impl EqPreset {
             Self::Loudness => [4.0, 2.0, 0.5, 2.5, 4.0],
         }
     }
+
+    pub const fn default_preamp_db(self) -> Option<f32> {
+        match self {
+            Self::Flat => Some(0.0),
+            Self::BassBoost => Some(-4.0),
+            Self::TrebleBoost => Some(-2.0),
+            Self::VocalBoost => Some(-1.5),
+            Self::Loudness => Some(-5.0),
+            Self::Custom => None,
+        }
+    }
 }
 
 fn default_eq_bands() -> [f32; 5] {

--- a/player/src/player.rs
+++ b/player/src/player.rs
@@ -159,6 +159,7 @@ impl Player {
         let stream_state = state.clone();
         let stream_consumer = consumer.clone();
         let stream_position = position_micros.clone();
+        let stream_equalizer = self.equalizer.clone();
 
         let host = cpal::default_host();
         let device = host
@@ -184,6 +185,12 @@ impl Player {
                     let cons = stream_consumer.lock().unwrap_or_else(|e| e.into_inner());
                     let read = cons.read(data).unwrap_or(0);
                     drop(cons);
+
+                    if read > 0 {
+                        if let Ok(mut eq) = stream_equalizer.lock() {
+                            eq.process_in_place(&mut data[..read]);
+                        }
+                    }
 
                     stream_position.fetch_add(
                         (read as u64 * 1_000_000) / (channels as u64 * device_sample_rate as u64),
@@ -421,10 +428,6 @@ impl Player {
                 source_sample_rate,
                 target_sample_rate,
             );
-
-            if let Ok(mut eq) = equalizer.lock() {
-                eq.process_in_place(&mut samples);
-            }
 
             let mut offset = 0;
             while offset < samples.len() {


### PR DESCRIPTION
- add preset default preamp values and apply them when selecting EQ presets
- add live dB readout while dragging EQ bands
- animate EQ preset graph transitions, respecting reduce-animations
- move native EQ processing to the output callback for faster audible preset changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Equalizer UI with smooth animations and interactive tooltips.
  * Added hover highlighting and visual feedback for band adjustments.

* **Improvements**
  * Optimized Equalizer processing for better audio playback performance.
  * Improved drag-and-drop interactions with respect to animation preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->