### PR TITLE
feat: add queue reorder controls and fix volume persistence rerenders

### DIFF
--- a/components/src/bottombar.rs
+++ b/components/src/bottombar.rs
@@ -20,6 +20,7 @@ pub fn Bottombar(
     mut current_song_artist: Signal<String>,
     mut current_song_cover_url: Signal<String>,
     mut volume: Signal<f32>,
+    mut persisted_volume: Signal<f32>,
     mut is_rightbar_open: Signal<bool>,
 ) -> Element {
     let mut is_dragging = use_signal(|| false);
@@ -316,14 +317,14 @@ pub fn Bottombar(
                                 let vol = *volume_before_mute.read();
                                 player.write().set_volume(vol);
                                 volume.set(vol);
-                                config.write().volume = vol;
+                                persisted_volume.set(vol);
                                 is_muted.set(false);
                             } else {
                                 // Mute: save current volume and set to 0
                                 volume_before_mute.set(*volume.read());
                                 player.write().set_volume(0.0);
                                 volume.set(0.0);
-                                config.write().volume = 0.0;
+                                persisted_volume.set(0.0);
                                 is_muted.set(true);
                             }
                         },
@@ -347,7 +348,7 @@ pub fn Bottombar(
                             class: "absolute top-0 left-0 w-full h-full opacity-0 cursor-pointer z-10",
                             onchange: move |evt| {
                                 if let Ok(val) = evt.value().parse::<f32>() {
-                                    config.write().volume = val;
+                                    persisted_volume.set(val);
                                     is_muted.set(val == 0.0);
                                 }
                             },

--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -195,9 +195,8 @@ pub fn Fullscreen(
         .map(|track| track.duration)
         .sum();
     let up_next_summary = format!(
-        "{} {} • {}",
-        up_next_count,
-        i18n::t("songs"),
+        "{} • {}",
+        i18n::t_with("showcase_song_count", &[("count", up_next_count.to_string())]),
         format_queue_duration(up_next_duration)
     );
 

--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -54,6 +54,16 @@ pub fn Fullscreen(
         let seconds = seconds % 60;
         format!("{}:{:02}", minutes, seconds)
     };
+    let format_queue_duration = |seconds: u64| {
+        let hours = seconds / 3600;
+        let minutes = (seconds % 3600) / 60;
+        let secs = seconds % 60;
+        if hours > 0 {
+            format!("{hours}:{minutes:02}:{secs:02}")
+        } else {
+            format!("{minutes}:{secs:02}")
+        }
+    };
 
     let progress_percent = if *current_song_duration.read() > 0 {
         (display_progress as f64 / *current_song_duration.read() as f64) * 100.0
@@ -174,6 +184,22 @@ pub fn Fullscreen(
     } else {
         "background-color: var(--color-black); background-image: none;".to_string()
     };
+    let up_next_count = queue
+        .read()
+        .len()
+        .saturating_sub(*current_queue_index.read() + 1);
+    let up_next_duration: u64 = queue
+        .read()
+        .iter()
+        .skip(*current_queue_index.read() + 1)
+        .map(|track| track.duration)
+        .sum();
+    let up_next_summary = format!(
+        "{} {} • {}",
+        up_next_count,
+        i18n::t("songs"),
+        format_queue_duration(up_next_duration)
+    );
 
     rsx! {
         div {
@@ -477,6 +503,11 @@ pub fn Fullscreen(
                     } else if *active_tab.read() == 1 {
                         if queue.read().len() <= *current_queue_index.read() + 1 {
                             div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
+                        } else {
+                            div {
+                                class: "px-4 pt-2 pb-3 text-xs uppercase tracking-[0.18em] text-white/45",
+                                "{up_next_summary}"
+                            }
                         }
                         for i in (*current_queue_index.read() + 1)..queue.read().len() {
                             {

--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -1,3 +1,4 @@
+use crate::reorder_buttons::ReorderButtons;
 use config::AppConfig;
 use dioxus::document::eval;
 use dioxus::prelude::*;
@@ -22,6 +23,7 @@ pub fn Fullscreen(
     mut current_song_cover_url: Signal<String>,
     mut current_song_album: Signal<String>,
     mut volume: Signal<f32>,
+    mut persisted_volume: Signal<f32>,
     palette: Signal<Option<Vec<utils::color::Color>>>,
 ) -> Element {
     let mut is_dragging = use_signal(|| false);
@@ -63,6 +65,9 @@ pub fn Fullscreen(
 
     let mut play_song_at_index = move |index: usize| {
         ctrl.play_track(index);
+    };
+    let mut move_queue_item = move |from: usize, to: usize| {
+        ctrl.move_queue_item(from, to);
     };
 
     let mut config = use_context::<Signal<AppConfig>>();
@@ -347,7 +352,7 @@ pub fn Fullscreen(
                             class: "absolute top-0 left-0 w-full h-full opacity-0 cursor-pointer",
                             onchange: move |evt| {
                                 if let Ok(val) = evt.value().parse::<f32>() {
-                                    config.write().volume = val;
+                                    persisted_volume.set(val);
                                 }
                             },
                             oninput: move |evt| {
@@ -477,6 +482,8 @@ pub fn Fullscreen(
                             {
                                 let track = queue.read()[i].clone();
                                 let cover_url = get_track_cover(&track);
+                                let can_move_up = i > *current_queue_index.read() + 1;
+                                let can_move_down = i + 1 < queue.read().len();
                                 rsx! {
                                     div {
                                         key: "{i}",
@@ -498,6 +505,14 @@ pub fn Fullscreen(
                                             class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
                                             div { class: "text-base text-white truncate font-medium", "{track.title}" }
                                             div { class: "text-sm text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
+                                        }
+                                        ReorderButtons {
+                                            can_move_up,
+                                            can_move_down,
+                                            class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
+                                            icon_class: "text-[10px]".to_string(),
+                                            on_move_up: move |_| move_queue_item(i, i - 1),
+                                            on_move_down: move |_| move_queue_item(i, i + 1),
                                         }
                                     }
                                 }

--- a/components/src/lib.rs
+++ b/components/src/lib.rs
@@ -7,6 +7,7 @@ pub mod fullscreen;
 pub mod playlist_detail;
 pub mod playlist_modal;
 pub mod playlist_popups;
+pub mod reorder_buttons;
 pub mod rightbar;
 pub mod search_bar;
 pub mod search_genre_detail;
@@ -20,4 +21,3 @@ pub mod sidebar;
 pub mod titlebar;
 pub mod stat_card;
 pub mod track_row;
-

--- a/components/src/reorder_buttons.rs
+++ b/components/src/reorder_buttons.rs
@@ -1,0 +1,44 @@
+use dioxus::prelude::*;
+
+#[component]
+pub fn ReorderButtons(
+    can_move_up: bool,
+    can_move_down: bool,
+    on_move_up: EventHandler<MouseEvent>,
+    on_move_down: EventHandler<MouseEvent>,
+    #[props(default = "flex flex-col pr-2 shrink-0".to_string())] class: String,
+    #[props(default = "text-[9px]".to_string())] icon_class: String,
+) -> Element {
+    rsx! {
+        div { class: "{class}",
+            button {
+                class: if can_move_up {
+                    "p-0.5 text-slate-500 hover:text-white transition-colors"
+                } else {
+                    "p-0.5 text-slate-700 cursor-default"
+                },
+                onclick: move |evt| {
+                    evt.stop_propagation();
+                    if can_move_up {
+                        on_move_up.call(evt);
+                    }
+                },
+                i { class: "fa-solid fa-chevron-up {icon_class}" }
+            }
+            button {
+                class: if can_move_down {
+                    "p-0.5 text-slate-500 hover:text-white transition-colors"
+                } else {
+                    "p-0.5 text-slate-700 cursor-default"
+                },
+                onclick: move |evt| {
+                    evt.stop_propagation();
+                    if can_move_down {
+                        on_move_down.call(evt);
+                    }
+                },
+                i { class: "fa-solid fa-chevron-down {icon_class}" }
+            }
+        }
+    }
+}

--- a/components/src/reorder_buttons.rs
+++ b/components/src/reorder_buttons.rs
@@ -12,6 +12,7 @@ pub fn ReorderButtons(
     rsx! {
         div { class: "{class}",
             button {
+                disabled: !can_move_up,
                 class: if can_move_up {
                     "p-0.5 text-slate-500 hover:text-white transition-colors"
                 } else {
@@ -26,6 +27,7 @@ pub fn ReorderButtons(
                 i { class: "fa-solid fa-chevron-up {icon_class}" }
             }
             button {
+                disabled: !can_move_down,
                 class: if can_move_down {
                     "p-0.5 text-slate-500 hover:text-white transition-colors"
                 } else {

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -1,3 +1,4 @@
+use crate::reorder_buttons::ReorderButtons;
 use config::AppConfig;
 use dioxus::document::eval;
 use dioxus::prelude::*;
@@ -126,6 +127,9 @@ pub fn Rightbar(
 
     let mut play_song_at_index = move |index: usize| {
         ctrl.play_track_no_history(index);
+    };
+    let mut move_queue_item = move |from: usize, to: usize| {
+        ctrl.move_queue_item(from, to);
     };
 
     let mut is_resizing = use_signal(|| false);
@@ -298,6 +302,8 @@ pub fn Rightbar(
                         {
                             let track = queue.read()[i].clone();
                             let cover_url = get_track_cover(&track);
+                            let can_move_up = i > *current_queue_index.read() + 1;
+                            let can_move_down = i + 1 < queue.read().len();
                             rsx! {
                                 div {
                                     key: "{i}",
@@ -319,6 +325,13 @@ pub fn Rightbar(
                                         class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
                                         div { class: "text-sm text-white truncate font-medium", "{track.title}" }
                                         div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
+                                    }
+                                    ReorderButtons {
+                                        can_move_up,
+                                        can_move_down,
+                                        class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
+                                        on_move_up: move |_| move_queue_item(i, i - 1),
+                                        on_move_down: move |_| move_queue_item(i, i + 1),
                                     }
                                 }
                             }

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -168,6 +168,32 @@ pub fn Rightbar(
     let back_text = i18n::t("back").to_string().to_uppercase();
     let up_next_text = i18n::t("up_next").to_string();
     let lyrics_text = i18n::t("lyrics").to_string();
+    let format_queue_duration = |seconds: u64| {
+        let hours = seconds / 3600;
+        let minutes = (seconds % 3600) / 60;
+        let secs = seconds % 60;
+        if hours > 0 {
+            format!("{hours}:{minutes:02}:{secs:02}")
+        } else {
+            format!("{minutes}:{secs:02}")
+        }
+    };
+    let up_next_count = queue
+        .read()
+        .len()
+        .saturating_sub(*current_queue_index.read() + 1);
+    let up_next_duration: u64 = queue
+        .read()
+        .iter()
+        .skip(*current_queue_index.read() + 1)
+        .map(|track| track.duration)
+        .sum();
+    let up_next_summary = format!(
+        "{} {} • {}",
+        up_next_count,
+        i18n::t("songs"),
+        format_queue_duration(up_next_duration)
+    );
 
     rsx! {
         div {
@@ -297,6 +323,11 @@ pub fn Rightbar(
                 } else if *active_tab.read() == 1 {
                     if queue.read().len() <= *current_queue_index.read() + 1 {
                         div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
+                    } else {
+                        div {
+                            class: "px-2 pt-1 pb-2 text-[11px] uppercase tracking-[0.18em] text-slate-500",
+                            "{up_next_summary}"
+                        }
                     }
                     for i in (*current_queue_index.read() + 1)..queue.read().len() {
                         {

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -189,9 +189,8 @@ pub fn Rightbar(
         .map(|track| track.duration)
         .sum();
     let up_next_summary = format!(
-        "{} {} • {}",
-        up_next_count,
-        i18n::t("songs"),
+        "{} • {}",
+        i18n::t_with("showcase_song_count", &[("count", up_next_count.to_string())]),
         format_queue_duration(up_next_duration)
     );
 

--- a/components/src/showcase.rs
+++ b/components/src/showcase.rs
@@ -1,3 +1,4 @@
+use crate::reorder_buttons::ReorderButtons;
 use crate::track_row::TrackRow;
 use config::{AppConfig, MusicService, MusicSource};
 use dioxus::prelude::*;
@@ -189,17 +190,11 @@ pub fn Showcase(props: ShowcaseProps) -> Element {
                                          }
                                      }
                                      if props.is_reorderable && !props.is_selection_mode {
-                                         div { class: "flex flex-col pr-2 shrink-0",
-                                             button {
-                                                 class: if can_move_up { "p-0.5 text-slate-500 hover:text-white transition-colors" } else { "p-0.5 text-slate-700 cursor-default" },
-                                                 onclick: move |evt| { evt.stop_propagation(); if can_move_up { props.on_move_up.call(idx); } },
-                                                 i { class: "fa-solid fa-chevron-up text-[9px]" }
-                                             }
-                                             button {
-                                                 class: if can_move_down { "p-0.5 text-slate-500 hover:text-white transition-colors" } else { "p-0.5 text-slate-700 cursor-default" },
-                                                 onclick: move |evt| { evt.stop_propagation(); if can_move_down { props.on_move_down.call(idx); } },
-                                                 i { class: "fa-solid fa-chevron-down text-[9px]" }
-                                             }
+                                         ReorderButtons {
+                                             can_move_up,
+                                             can_move_down,
+                                             on_move_up: move |_| props.on_move_up.call(idx),
+                                             on_move_down: move |_| props.on_move_down.call(idx),
                                          }
                                      }
                                  }

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -53,6 +53,30 @@ pub struct PlayerController {
 }
 
 impl PlayerController {
+    /// Remap a queue index after moving one item within the queue.
+    ///
+    /// `index` is the position to remap, `from` is the original position of the moved item,
+    /// and `to` is its destination after the move.
+    ///
+    /// Returns the new position for `index` after applying the move:
+    /// - if `index == from`, this is the moved item itself, so it now lives at `to`
+    /// - if the item moved forward (`from < to`), every item that was between `from + 1`
+    ///   and `to` shifts left by one slot
+    /// - if the item moved backward (`to < from`), every item that was between `to`
+    ///   and `from - 1` shifts right by one slot
+    /// - all other indices are unaffected
+    fn remap_queue_index(index: usize, from: usize, to: usize) -> usize {
+        if index == from {
+            to
+        } else if from < to && index > from && index <= to {
+            index - 1
+        } else if to < from && index >= to && index < from {
+            index + 1
+        } else {
+            index
+        }
+    }
+
     pub fn play_track(&mut self, idx: usize) {
         let current_idx = *self.current_queue_index.peek();
         self.history.with_mut(|h| {
@@ -633,6 +657,28 @@ impl PlayerController {
         } else {
             self.resume();
         }
+    }
+
+    pub fn move_queue_item(&mut self, from: usize, to: usize) {
+        let len = self.queue.peek().len();
+        if from >= len || to >= len || from == to {
+            return;
+        }
+
+        self.queue.with_mut(|queue| {
+            let track = queue.remove(from);
+            queue.insert(to, track);
+        });
+
+        let current_idx = *self.current_queue_index.peek();
+        self.current_queue_index
+            .set(Self::remap_queue_index(current_idx, from, to));
+
+        self.history.with_mut(|history| {
+            for idx in history.iter_mut() {
+                *idx = Self::remap_queue_index(*idx, from, to);
+            }
+        });
     }
 }
 

--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -33,6 +33,21 @@ const REDUCED_ANIMATIONS_CSS: Asset = asset!("../assets/reduced-animations.css")
 #[cfg(not(target_arch = "wasm32"))]
 static PRESENCE: std::sync::OnceLock<Option<Arc<Presence>>> = std::sync::OnceLock::new();
 
+#[cfg(not(target_arch = "wasm32"))]
+fn persist_config_snapshot(config_snapshot: config::AppConfig, path: std::path::PathBuf) {
+    spawn(async move {
+        let result = tokio::task::spawn_blocking(move || config_snapshot.save(&path)).await;
+        if let Ok(Err(e)) = result {
+            eprintln!("Failed to save config: {}", e);
+        }
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn persist_config_snapshot(config_snapshot: config::AppConfig, _path: std::path::PathBuf) {
+    save_web_config(&config_snapshot);
+}
+
 fn main() {
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -210,6 +225,7 @@ fn App() -> Element {
     let current_song_bitrate = use_signal(|| 0u8);
     let current_song_progress = use_signal(|| 0u64);
     let mut volume = use_signal(|| 1.0f32);
+    let mut persisted_volume = use_signal(|| 1.0f32);
 
     let is_playing = use_signal(|| false);
     let is_fullscreen = use_signal(|| false);
@@ -295,22 +311,20 @@ fn App() -> Element {
         if !*initial_load_done.read() {
             return;
         }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let config_snapshot = config.read().clone();
-            let path = config_path();
-            spawn(async move {
-                let result = tokio::task::spawn_blocking(move || config_snapshot.save(&path)).await;
-                if let Ok(Err(e)) = result {
-                    eprintln!("Failed to save config: {}", e);
-                }
-            });
+        let mut config_snapshot = config.read().clone();
+        config_snapshot.volume = *volume.peek();
+        persist_config_snapshot(config_snapshot, config_path());
+    });
+
+    use_effect(move || {
+        if !*initial_load_done.read() {
+            return;
         }
-        #[cfg(target_arch = "wasm32")]
-        {
-            let cfg_snapshot = config.read().clone();
-            save_web_config(&cfg_snapshot);
-        }
+
+        let committed_volume = *persisted_volume.read();
+        let mut config_snapshot = config.peek().clone();
+        config_snapshot.volume = committed_volume;
+        persist_config_snapshot(config_snapshot, config_path());
     });
 
     use_effect(move || {
@@ -408,6 +422,7 @@ fn App() -> Element {
                 if let Ok(loaded) = cfg_res {
                     config.set(loaded.clone());
                     volume.set(loaded.volume);
+                    persisted_volume.set(loaded.volume);
                     player.write().set_volume(loaded.volume);
                     player.write().set_equalizer(loaded.equalizer.clone());
                     i18n::set_locale(&loaded.language);
@@ -447,6 +462,7 @@ fn App() -> Element {
             let loaded_language = loaded.language.clone();
             config.set(loaded);
             volume.set(loaded_volume);
+            persisted_volume.set(loaded_volume);
             player.write().set_volume(loaded_volume);
             i18n::set_locale(&loaded_language);
 
@@ -876,6 +892,7 @@ fn App() -> Element {
                 current_song_artist: current_song_artist,
                 current_song_cover_url: current_song_cover_url,
                 volume: volume,
+                persisted_volume: persisted_volume,
                 palette: palette,
             }
             Bottombar {
@@ -893,6 +910,7 @@ fn App() -> Element {
                 queue: queue,
                 current_queue_index: current_queue_index,
                 volume: volume,
+                persisted_volume: persisted_volume,
                 is_rightbar_open: is_rightbar_open,
             }
         }

--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -37,8 +37,10 @@ static PRESENCE: std::sync::OnceLock<Option<Arc<Presence>>> = std::sync::OnceLoc
 fn persist_config_snapshot(config_snapshot: config::AppConfig, path: std::path::PathBuf) {
     spawn(async move {
         let result = tokio::task::spawn_blocking(move || config_snapshot.save(&path)).await;
-        if let Ok(Err(e)) = result {
-            eprintln!("Failed to save config: {}", e);
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => eprintln!("Failed to save config: {}", e),
+            Err(e) => eprintln!("Failed to join config save task: {}", e),
         }
     });
 }


### PR DESCRIPTION
- add shared reorder button component and reuse playlist-style controls in queue views
- add queue item move logic to PlayerController, including current-index and history remapping
- allow reordering Up Next tracks from the right sidebar and fullscreen queue
- decouple live volume updates from AppConfig writes to avoid home page rerenders #146 
- add Up Next summary (nr of songs and time) to Fullscreen and Rightbar components

<img width="338" height="326" alt="image" src="https://github.com/user-attachments/assets/8dcdcad2-7d73-489d-9d8b-e79cc7528014" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Queue reordering: Users can now easily rearrange upcoming tracks in the "Up next" queue using intuitive chevron button controls. These controls are available in both the main player interface and the sidebar for convenient access.

**Improvements**
* Enhanced volume persistence mechanism: Audio level settings are now more reliably maintained and restored across user sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->