### PR TITLE
Add queue state management and persistence functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3282,6 +3282,7 @@ dependencies = [
  "player",
  "rand 0.8.5",
  "reader",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -6,6 +6,7 @@ use player::player::{NowPlayingMeta, Player};
 use reader::{Library, Track};
 use scrobble;
 use utils;
+use std::time::Duration;
 
 #[cfg(not(target_arch = "wasm32"))]
 use player::decoder;
@@ -50,9 +51,121 @@ pub struct PlayerController {
     pub library: Signal<Library>,
     pub config: Signal<AppConfig>,
     pub play_generation: Signal<usize>,
+    pending_resume: Signal<Option<PendingResumeState>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct PendingResumeState {
+    track_path: String,
+    progress_secs: u64,
 }
 
 impl PlayerController {
+    fn track_key(track: &Track) -> String {
+        track.path.to_string_lossy().to_string()
+    }
+
+    fn current_track(&self, idx: usize) -> Option<Track> {
+        self.queue.peek().get(idx).cloned()
+    }
+
+    fn cover_url_for_track(&self, track: &Track) -> String {
+        let path_str = Self::track_key(track);
+        let scheme = path_str
+            .split(':')
+            .next()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+
+        match scheme.as_str() {
+            "jellyfin" => self
+                .config
+                .read()
+                .server
+                .as_ref()
+                .and_then(|server| {
+                    utils::jellyfin_image::jellyfin_image_url_from_path(
+                        &path_str,
+                        &server.url,
+                        server.access_token.as_deref(),
+                        800,
+                        90,
+                    )
+                })
+                .unwrap_or_default(),
+            "subsonic" | "custom" => self
+                .config
+                .read()
+                .server
+                .as_ref()
+                .and_then(|server| {
+                    utils::subsonic_image::subsonic_image_url_from_path(
+                        &path_str,
+                        &server.url,
+                        server.access_token.as_deref(),
+                        800,
+                        90,
+                    )
+                })
+                .unwrap_or_default(),
+            _ => self
+                .library
+                .read()
+                .albums
+                .iter()
+                .find(|album| album.id == track.album_id)
+                .and_then(|album| utils::format_artwork_url(album.cover_path.as_ref()))
+                .unwrap_or_default(),
+        }
+    }
+
+    fn clear_current_track_metadata(&mut self) {
+        self.current_song_title.set(String::new());
+        self.current_song_artist.set(String::new());
+        self.current_song_album.set(String::new());
+        self.current_song_khz.set(0);
+        self.current_song_bitrate.set(0);
+        self.current_song_duration.set(0);
+        self.current_song_progress.set(0);
+        self.current_song_cover_url.set(String::new());
+    }
+
+    fn hydrate_current_track_metadata(&mut self, idx: usize, progress_secs: u64) {
+        if let Some(track) = self.current_track(idx) {
+            let progress_secs = progress_secs.min(track.duration);
+            self.current_queue_index.set(idx);
+            self.current_song_title.set(track.title.clone());
+            self.current_song_artist.set(track.artist.clone());
+            self.current_song_album.set(track.album.clone());
+            self.current_song_khz.set(track.khz);
+            self.current_song_bitrate.set(track.bitrate);
+            self.current_song_duration.set(track.duration);
+            self.current_song_progress.set(progress_secs);
+            self.current_song_cover_url.set(self.cover_url_for_track(&track));
+        } else {
+            self.current_queue_index.set(0);
+            self.clear_current_track_metadata();
+        }
+    }
+
+    fn take_pending_resume_seek(&mut self, track: &Track) -> Option<u64> {
+        let pending = self.pending_resume.read().clone();
+        self.pending_resume.set(None);
+
+        pending.and_then(|pending| {
+            if pending.track_path == Self::track_key(track) {
+                Some(pending.progress_secs.min(track.duration))
+            } else {
+                None
+            }
+        })
+    }
+
+    fn apply_restore_seek(&mut self, seek_secs: u64) {
+        self.player.write().seek(Duration::from_secs(seek_secs));
+        self.current_song_progress.set(seek_secs);
+    }
+
     /// Remap a queue index after moving one item within the queue.
     ///
     /// `index` is the position to remap, `from` is the original position of the moved item,
@@ -91,10 +204,9 @@ impl PlayerController {
         self.play_generation.with_mut(|g| *g += 1);
         let current_gen = *self.play_generation.peek();
 
-        let q = self.queue.peek();
-        if idx < q.len() {
-            let track = q[idx].clone();
+        if let Some(track) = self.current_track(idx) {
             let path_str = track.path.to_string_lossy().to_string();
+            let restore_seek_secs = self.take_pending_resume_seek(&track);
             let scheme = path_str
                 .split(':')
                 .next()
@@ -106,9 +218,9 @@ impl PlayerController {
                 let parts: Vec<&str> = path_str.split(':').collect();
                 let id = parts.get(1).unwrap_or(&"").to_string();
 
-                let conf = self.config.read();
-                if let Some(server) = &conf.server {
-                    let (stream_url, cover_url) = match server.service {
+                if let Some((stream_url, cover_url)) = {
+                    let conf = self.config.read();
+                    conf.server.as_ref().map(|server| match server.service {
                         MusicService::Jellyfin => {
                             let mut stream_url =
                                 format!("{}/Audio/{}/stream?static=true", server.url, id);
@@ -157,7 +269,8 @@ impl PlayerController {
 
                             (stream_url, cover_url)
                         }
-                    };
+                    })
+                } {
 
                     if stream_url.is_empty() {
                         self.is_loading.set(false);
@@ -174,15 +287,11 @@ impl PlayerController {
                     let mut skip_in_progress = self.skip_in_progress;
                     let play_generation = self.play_generation;
                     let volume = self.volume;
+                    let mut current_song_progress = self.current_song_progress;
                     let cfg_signal = self.config;
 
-                    self.current_song_title.set(track.title.clone());
-                    self.current_song_artist.set(track.artist.clone());
-                    self.current_song_album.set(track.album.clone());
-                    self.current_song_duration.set(track.duration);
-                    self.current_song_progress.set(0);
+                    self.hydrate_current_track_metadata(idx, 0);
                     self.current_song_cover_url.set(cover_url.clone());
-                    self.current_queue_index.set(idx);
 
                     self.is_loading.set(true);
 
@@ -212,6 +321,12 @@ impl PlayerController {
                                     return;
                                 }
                                 player.write().set_volume(*volume.peek());
+                                if let Some(seek_secs) = restore_seek_secs {
+                                    if seek_secs > 0 {
+                                        player.write().seek(Duration::from_secs(seek_secs));
+                                        current_song_progress.set(seek_secs);
+                                    }
+                                }
                                 is_loading.set(false);
                                 is_playing.set(true);
                                 skip_in_progress.set(false);
@@ -346,6 +461,12 @@ impl PlayerController {
 
                             player.write().play_url(stream_url, meta);
                             player.write().set_volume(*volume.peek());
+                            if let Some(seek_secs) = restore_seek_secs {
+                                if seek_secs > 0 {
+                                    player.write().seek(Duration::from_secs(seek_secs));
+                                    current_song_progress.set(seek_secs);
+                                }
+                            }
                             is_loading.set(false);
                             is_playing.set(true);
                             skip_in_progress.set(false);
@@ -441,13 +562,17 @@ impl PlayerController {
                 #[cfg(not(target_arch = "wasm32"))]
                 if let Ok((source, hint)) = decoder::open_file(&track.path) {
                     {
-                        let lib = self.library.peek();
-                        let album = lib.albums.iter().find(|a| a.id == track.album_id);
-                        let artwork = album.and_then(|a| {
-                            a.cover_path
-                                .as_ref()
-                                .map(|p| p.to_string_lossy().into_owned())
-                        });
+                        let artwork = {
+                            let lib = self.library.peek();
+                            lib.albums
+                                .iter()
+                                .find(|a| a.id == track.album_id)
+                                .and_then(|a| {
+                                    a.cover_path
+                                        .as_ref()
+                                        .map(|p| p.to_string_lossy().into_owned())
+                                })
+                        };
 
                         let meta = NowPlayingMeta {
                             title: track.title.clone(),
@@ -466,26 +591,15 @@ impl PlayerController {
 
                         self.skip_in_progress.set(false);
 
-                        self.current_song_title.set(track.title.clone());
-                        self.current_song_artist.set(track.artist.clone());
-                        self.current_song_album.set(track.album.clone());
-                        self.current_song_khz.set(track.khz);
-                        self.current_song_bitrate.set(track.bitrate);
-                        self.current_song_duration.set(track.duration);
-                        self.current_song_progress.set(0);
-
-                        if let Some(album) = album {
-                            if let Some(url) = utils::format_artwork_url(album.cover_path.as_ref())
-                            {
-                                self.current_song_cover_url.set(url);
-                            } else {
-                                self.current_song_cover_url.set(String::new());
-                            }
-                        } else {
-                            self.current_song_cover_url.set(String::new());
-                        }
+                        self.hydrate_current_track_metadata(idx, 0);
 
                         self.is_playing.set(true);
+
+                        if let Some(seek_secs) = restore_seek_secs {
+                            if seek_secs > 0 {
+                                self.apply_restore_seek(seek_secs);
+                            }
+                        }
 
                         let cfg_signal = self.config;
                         let play_generation_signal = self.play_generation;
@@ -647,6 +761,22 @@ impl PlayerController {
     }
 
     pub fn resume(&mut self) {
+        if !self.player.peek().can_resume() {
+            let idx = *self.current_queue_index.peek();
+            if let Some(track) = self.current_track(idx) {
+                let pending_resume = self.pending_resume.read().clone();
+                if let Some(mut pending) = pending_resume {
+                    if pending.track_path == Self::track_key(&track) {
+                        pending.progress_secs =
+                            (*self.current_song_progress.peek()).min(track.duration);
+                        self.pending_resume.set(Some(pending));
+                    }
+                }
+                self.play_track_no_history(idx);
+            }
+            return;
+        }
+
         self.player.write().play_resume();
         self.is_playing.set(true);
     }
@@ -680,6 +810,42 @@ impl PlayerController {
             }
         });
     }
+
+    pub fn restore_queue_state(
+        &mut self,
+        queue: Vec<Track>,
+        current_queue_index: usize,
+        progress_secs: u64,
+    ) {
+        self.player.write().stop();
+        self.is_playing.set(false);
+        self.is_loading.set(false);
+        self.skip_in_progress.set(false);
+        self.history.set(Vec::new());
+        self.queue.set(queue);
+
+        let queue_len = self.queue.peek().len();
+        if queue_len == 0 {
+            self.current_queue_index.set(0);
+            self.pending_resume.set(None);
+            self.clear_current_track_metadata();
+            return;
+        }
+
+        let idx = current_queue_index.min(queue_len - 1);
+        let track = self.current_track(idx).expect("queue index should be valid");
+        let progress_secs = progress_secs.min(track.duration);
+
+        self.hydrate_current_track_metadata(idx, progress_secs);
+        self.pending_resume.set(if progress_secs > 0 {
+            Some(PendingResumeState {
+                track_path: Self::track_key(&track),
+                progress_secs,
+            })
+        } else {
+            None
+        });
+    }
 }
 
 pub fn use_player_controller(
@@ -705,6 +871,7 @@ pub fn use_player_controller(
     let history = use_signal(|| Vec::new());
     let shuffle = use_signal(|| false);
     let loop_mode = use_signal(|| LoopMode::None);
+    let pending_resume = use_signal(|| None::<PendingResumeState>);
 
     PlayerController {
         player,
@@ -728,5 +895,6 @@ pub fn use_player_controller(
         library,
         config,
         play_generation,
+        pending_resume,
     }
 }

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -148,17 +148,21 @@ impl PlayerController {
         }
     }
 
-    fn take_pending_resume_seek(&mut self, track: &Track) -> Option<u64> {
+    fn pending_resume_seek(&self, track: &Track) -> (Option<u64>, bool) {
         let pending = self.pending_resume.read().clone();
-        self.pending_resume.set(None);
-
-        pending.and_then(|pending| {
+        let restore_seek_secs = pending.as_ref().and_then(|pending| {
             if pending.track_path == Self::track_key(track) {
                 Some(pending.progress_secs.min(track.duration))
             } else {
                 None
             }
-        })
+        });
+
+        (restore_seek_secs, pending.is_some())
+    }
+
+    fn clear_pending_resume(&mut self) {
+        self.pending_resume.set(None);
     }
 
     fn apply_restore_seek(&mut self, seek_secs: u64) {
@@ -206,7 +210,8 @@ impl PlayerController {
 
         if let Some(track) = self.current_track(idx) {
             let path_str = track.path.to_string_lossy().to_string();
-            let restore_seek_secs = self.take_pending_resume_seek(&track);
+            let (restore_seek_secs, clear_pending_resume_on_success) =
+                self.pending_resume_seek(&track);
             let scheme = path_str
                 .split(':')
                 .next()
@@ -288,6 +293,7 @@ impl PlayerController {
                     let play_generation = self.play_generation;
                     let volume = self.volume;
                     let mut current_song_progress = self.current_song_progress;
+                    let mut pending_resume = self.pending_resume;
                     let cfg_signal = self.config;
 
                     self.hydrate_current_track_metadata(idx, 0);
@@ -326,6 +332,9 @@ impl PlayerController {
                                         player.write().seek(Duration::from_secs(seek_secs));
                                         current_song_progress.set(seek_secs);
                                     }
+                                }
+                                if clear_pending_resume_on_success {
+                                    pending_resume.set(None);
                                 }
                                 is_loading.set(false);
                                 is_playing.set(true);
@@ -459,92 +468,105 @@ impl PlayerController {
                                 artwork: Some(cover_url.clone()),
                             };
 
-                            player.write().play_url(stream_url, meta);
-                            player.write().set_volume(*volume.peek());
-                            if let Some(seek_secs) = restore_seek_secs {
-                                if seek_secs > 0 {
-                                    player.write().seek(Duration::from_secs(seek_secs));
-                                    current_song_progress.set(seek_secs);
+                            let started = {
+                                let mut player = player.write();
+                                player.play_url(stream_url, meta);
+                                player.set_volume(*volume.peek());
+                                if let Some(seek_secs) = restore_seek_secs {
+                                    if seek_secs > 0 && player.can_resume() {
+                                        player.seek(Duration::from_secs(seek_secs));
+                                        current_song_progress.set(seek_secs);
+                                    }
                                 }
+                                player.can_resume()
+                            };
+                            if started && clear_pending_resume_on_success {
+                                pending_resume.set(None);
                             }
                             is_loading.set(false);
-                            is_playing.set(true);
+                            is_playing.set(started);
                             skip_in_progress.set(false);
 
-                            let scrobble_track = track.clone();
-                            let scrobble_gen = current_gen;
-                            let scrobble_play_gen = play_generation;
-                            let scrobble_cfg = cfg_signal;
-                            let duration_secs = scrobble_track.duration;
-                            let threshold_secs = std::cmp::min(240, (duration_secs / 2) as u64);
+                            if started {
+                                let scrobble_track = track.clone();
+                                let scrobble_gen = current_gen;
+                                let scrobble_play_gen = play_generation;
+                                let scrobble_cfg = cfg_signal;
+                                let duration_secs = scrobble_track.duration;
+                                let threshold_secs =
+                                    std::cmp::min(240, (duration_secs / 2) as u64);
 
-                            spawn(async move {
-                                let token_raw = scrobble_cfg.read().musicbrainz_token.clone();
-                                if !token_raw.is_empty() {
+                                spawn(async move {
+                                    let token_raw = scrobble_cfg.read().musicbrainz_token.clone();
+                                    if !token_raw.is_empty() {
+                                        let auth = if token_raw.contains(' ') {
+                                            token_raw.clone()
+                                        } else {
+                                            format!("Token {}", token_raw)
+                                        };
+
+                                        let playing_now = scrobble::musicbrainz::make_playing_now(
+                                            &scrobble_track.artist,
+                                            &scrobble_track.title,
+                                            Some(&scrobble_track.album),
+                                        );
+
+                                        if let Err(e) = scrobble::musicbrainz::submit_listens(
+                                            &auth,
+                                            vec![playing_now],
+                                            "playing_now",
+                                        )
+                                        .await
+                                        {
+                                            tracing::warn!(
+                                                "Jellyfin: failed to submit playing_now: {}",
+                                                e
+                                            );
+                                        }
+                                    }
+
+                                    utils::sleep(std::time::Duration::from_secs(threshold_secs))
+                                        .await;
+
+                                    if *scrobble_play_gen.read() != scrobble_gen {
+                                        return;
+                                    }
+
+                                    let token_raw = scrobble_cfg.read().musicbrainz_token.clone();
+                                    if token_raw.is_empty() {
+                                        return;
+                                    }
+
                                     let auth = if token_raw.contains(' ') {
-                                        token_raw.clone()
+                                        token_raw
                                     } else {
                                         format!("Token {}", token_raw)
                                     };
 
-                                    let playing_now = scrobble::musicbrainz::make_playing_now(
+                                    let listen = scrobble::musicbrainz::make_listen(
                                         &scrobble_track.artist,
                                         &scrobble_track.title,
                                         Some(&scrobble_track.album),
                                     );
 
-                                    if let Err(e) = scrobble::musicbrainz::submit_listens(
+                                    match scrobble::musicbrainz::submit_listens(
                                         &auth,
-                                        vec![playing_now],
-                                        "playing_now",
+                                        vec![listen],
+                                        "single",
                                     )
                                     .await
                                     {
-                                        tracing::warn!(
-                                            "Jellyfin: failed to submit playing_now: {}",
-                                            e
-                                        );
+                                        Ok(_) => tracing::info!(
+                                            "Jellyfin scrobbled: {} - {}",
+                                            scrobble_track.artist,
+                                            scrobble_track.title
+                                        ),
+                                        Err(e) => {
+                                            tracing::warn!("Jellyfin scrobble failed: {}", e)
+                                        }
                                     }
-                                }
-
-                                utils::sleep(std::time::Duration::from_secs(threshold_secs)).await;
-
-                                if *scrobble_play_gen.read() != scrobble_gen {
-                                    return;
-                                }
-
-                                let token_raw = scrobble_cfg.read().musicbrainz_token.clone();
-                                if token_raw.is_empty() {
-                                    return;
-                                }
-
-                                let auth = if token_raw.contains(' ') {
-                                    token_raw
-                                } else {
-                                    format!("Token {}", token_raw)
-                                };
-
-                                let listen = scrobble::musicbrainz::make_listen(
-                                    &scrobble_track.artist,
-                                    &scrobble_track.title,
-                                    Some(&scrobble_track.album),
-                                );
-
-                                match scrobble::musicbrainz::submit_listens(
-                                    &auth,
-                                    vec![listen],
-                                    "single",
-                                )
-                                .await
-                                {
-                                    Ok(_) => tracing::info!(
-                                        "Jellyfin scrobbled: {} - {}",
-                                        scrobble_track.artist,
-                                        scrobble_track.title
-                                    ),
-                                    Err(e) => tracing::warn!("Jellyfin scrobble failed: {}", e),
-                                }
-                            });
+                                });
+                            }
                         } else {
                             is_loading.set(false);
                             skip_in_progress.set(false);
@@ -599,6 +621,9 @@ impl PlayerController {
                             if seek_secs > 0 {
                                 self.apply_restore_seek(seek_secs);
                             }
+                        }
+                        if clear_pending_resume_on_success {
+                            self.clear_pending_resume();
                         }
 
                         let cfg_signal = self.config;

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -165,6 +165,13 @@ impl PlayerController {
         self.pending_resume.set(None);
     }
 
+    fn set_pending_resume_for_track(&mut self, track: &Track, progress_secs: u64) {
+        self.pending_resume.set(Some(PendingResumeState {
+            track_path: Self::track_key(track),
+            progress_secs: progress_secs.min(track.duration),
+        }));
+    }
+
     fn apply_restore_seek(&mut self, seek_secs: u64) {
         self.player.write().seek(Duration::from_secs(seek_secs));
         self.current_song_progress.set(seek_secs);
@@ -789,14 +796,8 @@ impl PlayerController {
         if !self.player.peek().can_resume() {
             let idx = *self.current_queue_index.peek();
             if let Some(track) = self.current_track(idx) {
-                let pending_resume = self.pending_resume.read().clone();
-                if let Some(mut pending) = pending_resume {
-                    if pending.track_path == Self::track_key(&track) {
-                        pending.progress_secs =
-                            (*self.current_song_progress.peek()).min(track.duration);
-                        self.pending_resume.set(Some(pending));
-                    }
-                }
+                let progress_secs = (*self.current_song_progress.peek()).min(track.duration);
+                self.set_pending_resume_for_track(&track, progress_secs);
                 self.play_track_no_history(idx);
             }
             return;
@@ -862,14 +863,7 @@ impl PlayerController {
         let progress_secs = progress_secs.min(track.duration);
 
         self.hydrate_current_track_metadata(idx, progress_secs);
-        self.pending_resume.set(if progress_secs > 0 {
-            Some(PendingResumeState {
-                track_path: Self::track_key(&track),
-                progress_secs,
-            })
-        } else {
-            None
-        });
+        self.set_pending_resume_for_track(&track, progress_secs);
     }
 }
 

--- a/kopuz/Cargo.toml
+++ b/kopuz/Cargo.toml
@@ -39,6 +39,7 @@ hooks = { workspace = true }
 percent-encoding = { workspace = true }
 utils = { workspace = true }
 rand = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 i18n = { workspace = true }
 urlencoding = "2.1.3"

--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -35,6 +35,8 @@ const MAIN_CSS: Asset = asset!("../assets/main.css");
 const THEME_CSS: Asset = asset!("../assets/themes.css");
 const TAILWIND_CSS: Asset = asset!("../assets/tailwind.css");
 const REDUCED_ANIMATIONS_CSS: Asset = asset!("../assets/reduced-animations.css");
+const QUEUE_STATE_SAVE_DEBOUNCE_MS: u64 = 1200;
+const QUEUE_STATE_PROGRESS_STEP_SECS: u64 = 5;
 
 #[cfg(not(target_arch = "wasm32"))]
 static PRESENCE: std::sync::OnceLock<Option<Arc<Presence>>> = std::sync::OnceLock::new();
@@ -57,37 +59,35 @@ fn persist_config_snapshot(config_snapshot: config::AppConfig, _path: std::path:
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn persist_queue_state_snapshot(
+async fn persist_queue_state_snapshot(
     queue_state: Option<PersistedQueueState>,
     path: std::path::PathBuf,
 ) {
-    spawn(async move {
-        let result = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-            if let Some(queue_state) = queue_state {
-                queue_state.save(&path)
-            } else {
-                if let Some(parent) = path.parent() {
-                    std::fs::create_dir_all(parent)?;
-                }
-                match std::fs::remove_file(&path) {
-                    Ok(()) => Ok(()),
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-                    Err(e) => Err(e),
-                }
+    let result = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        if let Some(queue_state) = queue_state {
+            queue_state.save(&path)
+        } else {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
             }
-        })
-        .await;
-
-        match result {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => tracing::error!("Failed to save queue state: {}", e),
-            Err(e) => tracing::error!("Failed to join queue state save task: {}", e),
+            match std::fs::remove_file(&path) {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(e) => Err(e),
+            }
         }
-    });
+    })
+    .await;
+
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::error!("Failed to save queue state: {}", e),
+        Err(e) => tracing::error!("Failed to join queue state save task: {}", e),
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
-fn persist_queue_state_snapshot(
+async fn persist_queue_state_snapshot(
     queue_state: Option<PersistedQueueState>,
     _path: std::path::PathBuf,
 ) {
@@ -173,6 +173,35 @@ fn sanitize_queue_state(state: PersistedQueueState) -> Option<PersistedQueueStat
         version: state.version,
         queue,
         current_queue_index: restored_index,
+        progress_secs,
+    })
+}
+
+fn build_queue_state_snapshot(
+    queue: &[reader::Track],
+    current_queue_index: usize,
+    current_song_progress: u64,
+    is_playing: bool,
+) -> Option<PersistedQueueState> {
+    if queue.is_empty() {
+        return None;
+    }
+
+    let current_idx = current_queue_index.min(queue.len() - 1);
+    let progress_secs = queue
+        .get(current_idx)
+        .map(|track| current_song_progress.min(track.duration))
+        .unwrap_or(0);
+    let progress_secs = if is_playing {
+        progress_secs - (progress_secs % QUEUE_STATE_PROGRESS_STEP_SECS)
+    } else {
+        progress_secs
+    };
+
+    Some(PersistedQueueState {
+        version: 1,
+        queue: queue.to_vec(),
+        current_queue_index: current_idx,
         progress_secs,
     })
 }
@@ -383,6 +412,8 @@ fn App() -> Element {
     let is_rightbar_open = use_signal(|| false);
     let rightbar_width = use_signal(|| 320usize);
     let mut palette = use_signal(|| Option::<Vec<utils::color::Color>>::None);
+    let mut pending_queue_state_snapshot = use_signal(|| None::<PersistedQueueState>);
+    let mut pending_queue_state_revision = use_signal(|| 0u64);
 
     #[cfg(all(not(target_arch = "wasm32"), target_os = "macos"))]
     use_effect(move || {
@@ -569,24 +600,46 @@ fn App() -> Element {
         }
 
         let queue_snapshot = queue.read().clone();
-        let queue_state = if queue_snapshot.is_empty() {
-            None
-        } else {
-            let current_idx = (*current_queue_index.read()).min(queue_snapshot.len() - 1);
-            let progress_secs = queue_snapshot
-                .get(current_idx)
-                .map(|track| (*current_song_progress.read()).min(track.duration))
-                .unwrap_or(0);
+        let queue_state = build_queue_state_snapshot(
+            &queue_snapshot,
+            *current_queue_index.read(),
+            *current_song_progress.read(),
+            *is_playing.read(),
+        );
 
-            Some(PersistedQueueState {
-                version: 1,
-                queue: queue_snapshot,
-                current_queue_index: current_idx,
-                progress_secs,
-            })
-        };
+        if *pending_queue_state_snapshot.peek() != queue_state {
+            pending_queue_state_snapshot.set(queue_state);
+            pending_queue_state_revision.with_mut(|revision| *revision += 1);
+        }
+    });
 
-        persist_queue_state_snapshot(queue_state, queue_state_path());
+    use_future(move || {
+        let path = queue_state_path();
+        async move {
+            let mut flushed_revision = 0u64;
+
+            loop {
+                let pending_revision = *pending_queue_state_revision.read();
+                if pending_revision == flushed_revision {
+                    utils::sleep(std::time::Duration::from_millis(250)).await;
+                    continue;
+                }
+
+                utils::sleep(std::time::Duration::from_millis(
+                    QUEUE_STATE_SAVE_DEBOUNCE_MS,
+                ))
+                .await;
+
+                let latest_revision = *pending_queue_state_revision.read();
+                if latest_revision != pending_revision {
+                    continue;
+                }
+
+                let snapshot = pending_queue_state_snapshot.read().clone();
+                persist_queue_state_snapshot(snapshot, path.clone()).await;
+                flushed_revision = latest_revision;
+            }
+        }
     });
 
     use_hook(move || {

--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -1,7 +1,9 @@
 #[cfg(target_arch = "wasm32")]
 use crate::web_storage::{
-    load_web_config, load_web_favorites, load_web_library, load_web_playlists, load_web_ui_state,
-    save_web_config, save_web_favorites, save_web_library, save_web_playlists, save_web_ui_state,
+    clear_web_queue_state, load_web_config, load_web_favorites, load_web_library,
+    load_web_playlists, load_web_queue_state, load_web_ui_state, save_web_config,
+    save_web_favorites, save_web_library, save_web_playlists, save_web_queue_state,
+    save_web_ui_state,
 };
 use components::{
     bottombar::Bottombar, fullscreen::Fullscreen, rightbar::Rightbar, sidebar::Sidebar,
@@ -18,12 +20,14 @@ use dioxus::prelude::*;
 use discord_presence::Presence;
 use kopuz_route::Route;
 use player::player::Player;
+use queue_state::PersistedQueueState;
 use reader::FavoritesStore;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 
+mod queue_state;
 mod web_storage;
 
 const FAVICON: Asset = asset!("../assets/favicon.ico");
@@ -50,6 +54,127 @@ fn persist_config_snapshot(config_snapshot: config::AppConfig, path: std::path::
 #[cfg(target_arch = "wasm32")]
 fn persist_config_snapshot(config_snapshot: config::AppConfig, _path: std::path::PathBuf) {
     save_web_config(&config_snapshot);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn persist_queue_state_snapshot(
+    queue_state: Option<PersistedQueueState>,
+    path: std::path::PathBuf,
+) {
+    spawn(async move {
+        let result = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            if let Some(queue_state) = queue_state {
+                queue_state.save(&path)
+            } else {
+                if let Some(parent) = path.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                match std::fs::remove_file(&path) {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    Err(e) => Err(e),
+                }
+            }
+        })
+        .await;
+
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::error!("Failed to save queue state: {}", e),
+            Err(e) => tracing::error!("Failed to join queue state save task: {}", e),
+        }
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn persist_queue_state_snapshot(
+    queue_state: Option<PersistedQueueState>,
+    _path: std::path::PathBuf,
+) {
+    if let Some(queue_state) = queue_state {
+        save_web_queue_state(&queue_state);
+    } else {
+        clear_web_queue_state();
+    }
+}
+
+fn is_server_queue_track(track: &reader::Track) -> bool {
+    matches!(
+        track
+            .path
+            .to_string_lossy()
+            .split(':')
+            .next()
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "jellyfin" | "subsonic" | "custom"
+    )
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn is_restorable_queue_track(track: &reader::Track) -> bool {
+    is_server_queue_track(track) || track.path.exists()
+}
+
+#[cfg(target_arch = "wasm32")]
+fn is_restorable_queue_track(_track: &reader::Track) -> bool {
+    true
+}
+
+fn sanitize_queue_state(state: PersistedQueueState) -> Option<PersistedQueueState> {
+    if state.queue.is_empty() {
+        return None;
+    }
+
+    let original_index = state.current_queue_index.min(state.queue.len().saturating_sub(1));
+    let mut selected_track_survived = false;
+    let survivors: Vec<(usize, reader::Track)> = state
+        .queue
+        .into_iter()
+        .enumerate()
+        .filter(|(idx, track)| {
+            let keep = is_restorable_queue_track(track);
+            if keep && *idx == original_index {
+                selected_track_survived = true;
+            }
+            keep
+        })
+        .collect();
+
+    if survivors.is_empty() {
+        return None;
+    }
+
+    let restored_index = if selected_track_survived {
+        survivors
+            .iter()
+            .position(|(idx, _)| *idx == original_index)
+            .unwrap_or(0)
+    } else {
+        survivors
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, (idx, _))| (idx.abs_diff(original_index), *idx > original_index))
+            .map(|(restored_idx, _)| restored_idx)
+            .unwrap_or(0)
+    };
+
+    let queue: Vec<_> = survivors.into_iter().map(|(_, track)| track).collect();
+    let progress_secs = if selected_track_survived {
+        queue.get(restored_index)
+            .map(|track| state.progress_secs.min(track.duration))
+            .unwrap_or(0)
+    } else {
+        0
+    };
+
+    Some(PersistedQueueState {
+        version: state.version,
+        queue,
+        current_queue_index: restored_index,
+        progress_secs,
+    })
 }
 
 fn main() {
@@ -231,6 +356,7 @@ fn App() -> Element {
     let mut playlist_store = use_signal(reader::PlaylistStore::default);
     #[allow(unused_variables)]
     let favorites_path = use_memo(move || cache_dir().join("favorites.json"));
+    let queue_state_path = use_memo(move || cache_dir().join("queue_state.json"));
     let mut favorites_store = use_signal(FavoritesStore::default);
     let mut initial_load_done = use_signal(|| false);
     #[allow(unused_variables)]
@@ -297,9 +423,28 @@ fn App() -> Element {
     let mut selected_album_id = use_signal(String::new);
     let mut selected_playlist_id = use_signal(|| None::<String>);
     let mut selected_artist_name = use_signal(String::new);
-    let mut search_query = use_signal(String::new);
+    let search_query = use_signal(String::new);
     let mut last_server_playlist_key = use_signal(|| None::<String>);
     let mut server_playlist_key_initialized = use_signal(|| false);
+    let mut queue = use_signal(Vec::<reader::Track>::new);
+    let current_queue_index = use_signal(|| 0usize);
+    let mut ctrl = hooks::use_player_controller(
+        player,
+        is_playing,
+        queue,
+        current_queue_index,
+        current_song_title,
+        current_song_artist,
+        current_song_album,
+        current_song_khz,
+        current_song_bitrate,
+        current_song_duration,
+        current_song_progress,
+        current_song_cover_url,
+        volume,
+        library,
+        config,
+    );
 
     use_effect(move || {
         if !*initial_load_done.read() {
@@ -418,6 +563,32 @@ fn App() -> Element {
         }
     });
 
+    use_effect(move || {
+        if !*initial_load_done.read() {
+            return;
+        }
+
+        let queue_snapshot = queue.read().clone();
+        let queue_state = if queue_snapshot.is_empty() {
+            None
+        } else {
+            let current_idx = (*current_queue_index.read()).min(queue_snapshot.len() - 1);
+            let progress_secs = queue_snapshot
+                .get(current_idx)
+                .map(|track| (*current_song_progress.read()).min(track.duration))
+                .unwrap_or(0);
+
+            Some(PersistedQueueState {
+                version: 1,
+                queue: queue_snapshot,
+                current_queue_index: current_idx,
+                progress_secs,
+            })
+        };
+
+        persist_queue_state_snapshot(queue_state, queue_state_path());
+    });
+
     use_hook(move || {
         #[cfg(not(target_arch = "wasm32"))]
         {
@@ -425,20 +596,26 @@ fn App() -> Element {
             let config_path = config_path();
             let playlist_path = playlist_path();
             let favorites_path = favorites_path();
+            let queue_state_path = queue_state_path();
+            let mut ctrl = ctrl;
 
             spawn(async move {
                 let lib_path_c = lib_path.clone();
                 let config_path_c = config_path.clone();
                 let playlist_path_c = playlist_path.clone();
                 let favorites_path_c = favorites_path.clone();
+                let queue_state_path_c = queue_state_path.clone();
 
-                let (lib_res, cfg_res, pl_res, fav_res) = tokio::join!(
+                let (lib_res, cfg_res, pl_res, fav_res, queue_res) = tokio::join!(
                     tokio::task::spawn_blocking(move || reader::Library::load(&lib_path_c)),
                     tokio::task::spawn_blocking(move || config::AppConfig::load(&config_path_c)),
                     tokio::task::spawn_blocking(move || reader::PlaylistStore::load(
                         &playlist_path_c
                     )),
                     tokio::task::spawn_blocking(move || FavoritesStore::load(&favorites_path_c)),
+                    tokio::task::spawn_blocking(move || {
+                        PersistedQueueState::load(&queue_state_path_c)
+                    }),
                 );
 
                 if let Ok(Ok(loaded)) = lib_res {
@@ -474,11 +651,22 @@ fn App() -> Element {
                     }
                 }
 
+                if let Ok(Ok(loaded_queue_state)) = queue_res {
+                    if let Some(queue_state) = sanitize_queue_state(loaded_queue_state) {
+                        ctrl.restore_queue_state(
+                            queue_state.queue,
+                            queue_state.current_queue_index,
+                            queue_state.progress_secs,
+                        );
+                    }
+                }
+
                 initial_load_done.set(true);
             });
         }
         #[cfg(target_arch = "wasm32")]
         {
+            let mut ctrl = ctrl;
             let mut loaded = load_web_config().unwrap_or_default();
             if loaded.server.is_none() {
                 loaded.active_source = config::MusicSource::Server;
@@ -514,6 +702,15 @@ fn App() -> Element {
             }
             if let Some(loaded_favorites) = load_web_favorites() {
                 favorites_store.set(loaded_favorites);
+            }
+            if let Some(loaded_queue_state) = load_web_queue_state() {
+                if let Some(queue_state) = sanitize_queue_state(loaded_queue_state) {
+                    ctrl.restore_queue_state(
+                        queue_state.queue,
+                        queue_state.current_queue_index,
+                        queue_state.progress_secs,
+                    );
+                }
             }
 
             initial_load_done.set(true);
@@ -631,26 +828,6 @@ fn App() -> Element {
         );
     });
 
-    let mut queue = use_signal(Vec::<reader::Track>::new);
-    let current_queue_index = use_signal(|| 0usize);
-
-    let mut ctrl = hooks::use_player_controller(
-        player,
-        is_playing,
-        queue,
-        current_queue_index,
-        current_song_title,
-        current_song_artist,
-        current_song_album,
-        current_song_khz,
-        current_song_bitrate,
-        current_song_duration,
-        current_song_progress,
-        current_song_cover_url,
-        volume,
-        library,
-        config,
-    );
     provide_context(ctrl);
     provide_context(config);
 

--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -406,6 +406,7 @@ fn App() -> Element {
     let current_song_progress = use_signal(|| 0u64);
     let mut volume = use_signal(|| 1.0f32);
     let mut persisted_volume = use_signal(|| 1.0f32);
+    let mut configured_music_dirs = use_signal(|| config.peek().music_directory.clone());
 
     let is_playing = use_signal(|| false);
     let is_fullscreen = use_signal(|| false);
@@ -443,6 +444,13 @@ fn App() -> Element {
             });
         } else {
             palette.set(None);
+        }
+    });
+
+    use_effect(move || {
+        let next_dirs = config.read().music_directory.clone();
+        if *configured_music_dirs.peek() != next_dirs {
+            configured_music_dirs.set(next_dirs);
         }
     });
 
@@ -676,6 +684,7 @@ fn App() -> Element {
                 }
                 if let Ok(loaded) = cfg_res {
                     config.set(loaded.clone());
+                    configured_music_dirs.set(loaded.music_directory.clone());
                     volume.set(loaded.volume);
                     persisted_volume.set(loaded.volume);
                     player.write().set_volume(loaded.volume);
@@ -726,6 +735,7 @@ fn App() -> Element {
             }
             let loaded_volume = loaded.volume;
             let loaded_language = loaded.language.clone();
+            configured_music_dirs.set(loaded.music_directory.clone());
             config.set(loaded);
             volume.set(loaded_volume);
             persisted_volume.set(loaded_volume);
@@ -797,7 +807,7 @@ fn App() -> Element {
         if !*initial_load_done.read() {
             return;
         }
-        let configured_dirs = config.read().music_directory.clone();
+        let configured_dirs = configured_music_dirs.read().clone();
         let _ = trigger_rescan.read();
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/kopuz/src/queue_state.rs
+++ b/kopuz/src/queue_state.rs
@@ -1,0 +1,52 @@
+use reader::Track;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::Path;
+
+fn default_queue_state_version() -> u8 {
+    1
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct PersistedQueueState {
+    #[serde(default = "default_queue_state_version")]
+    pub version: u8,
+    #[serde(default)]
+    pub queue: Vec<Track>,
+    #[serde(default)]
+    pub current_queue_index: usize,
+    #[serde(default)]
+    pub progress_secs: u64,
+}
+
+impl Default for PersistedQueueState {
+    fn default() -> Self {
+        Self {
+            version: default_queue_state_version(),
+            queue: Vec::new(),
+            current_queue_index: 0,
+            progress_secs: 0,
+        }
+    }
+}
+
+impl PersistedQueueState {
+    pub fn load(path: &Path) -> std::io::Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let data = fs::read_to_string(path)?;
+        let state = serde_json::from_str(&data)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        Ok(state)
+    }
+
+    pub fn save(&self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let data = serde_json::to_string(self)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+        fs::write(path, data)
+    }
+}

--- a/kopuz/src/web_storage.rs
+++ b/kopuz/src/web_storage.rs
@@ -1,4 +1,6 @@
 #[cfg(target_arch = "wasm32")]
+use crate::queue_state::PersistedQueueState;
+#[cfg(target_arch = "wasm32")]
 use reader::FavoritesStore;
 #[cfg(target_arch = "wasm32")]
 use kopuz_route::Route;
@@ -13,6 +15,8 @@ const WEB_LIBRARY_STORAGE_KEY: &str = "kopuz.library.v1";
 const WEB_PLAYLISTS_STORAGE_KEY: &str = "kopuz.playlists.v1";
 #[cfg(target_arch = "wasm32")]
 const WEB_FAVORITES_STORAGE_KEY: &str = "kopuz.favorites.v1";
+#[cfg(target_arch = "wasm32")]
+const WEB_QUEUE_STATE_STORAGE_KEY: &str = "kopuz.queue-state.v1";
 
 #[cfg(target_arch = "wasm32")]
 fn route_to_storage(route: Route) -> &'static str {
@@ -197,5 +201,36 @@ pub fn save_web_favorites(store: &FavoritesStore) {
         serde_json::to_string(store),
     ) {
         let _ = storage.set_item(WEB_FAVORITES_STORAGE_KEY, &raw);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn load_web_queue_state() -> Option<PersistedQueueState> {
+    let storage = web_sys::window()
+        .and_then(|w| w.local_storage().ok())
+        .flatten()?;
+    let raw = storage.get_item(WEB_QUEUE_STATE_STORAGE_KEY).ok().flatten()?;
+    serde_json::from_str::<PersistedQueueState>(&raw).ok()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn save_web_queue_state(state: &PersistedQueueState) {
+    if let (Some(storage), Ok(raw)) = (
+        web_sys::window()
+            .and_then(|w| w.local_storage().ok())
+            .flatten(),
+        serde_json::to_string(state),
+    ) {
+        let _ = storage.set_item(WEB_QUEUE_STATE_STORAGE_KEY, &raw);
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn clear_web_queue_state() {
+    if let Some(storage) = web_sys::window()
+        .and_then(|w| w.local_storage().ok())
+        .flatten()
+    {
+        let _ = storage.remove_item(WEB_QUEUE_STATE_STORAGE_KEY);
     }
 }

--- a/player/src/player.rs
+++ b/player/src/player.rs
@@ -702,6 +702,11 @@ impl Player {
         st.paused
     }
 
+    pub fn can_resume(&self) -> bool {
+        let st = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        !st.stopped && !st.finished && self._stream.is_some()
+    }
+
     pub fn stop(&mut self) {
         self.stop_internal();
         self.now_playing = None;
@@ -951,6 +956,10 @@ impl Player {
 
     pub fn is_paused(&self) -> bool {
         self.audio.paused()
+    }
+
+    pub fn can_resume(&self) -> bool {
+        self.has_source && !self.audio.ended() && self.audio.error().is_none()
     }
 
     pub fn get_position(&self) -> Duration {


### PR DESCRIPTION
- Added a dedicated persisted queue state model with `queue`, `current_queue_index`, and `progress_secs`
- Save/load now follows the same pattern as other runtime cache data:
  - desktop: `cache_dir()/queue_state.json`
  - web: `localStorage["kopuz.queue-state.v1"]`
- Restore hydrates the queue and current track into the UI on startup without autoplay
 - Missing local tracks are dropped during restore while keeping the rest of the queue
 - Pressing play after restore now cold-starts the restored track and seeks once to the
    saved timestamp, instead of attempting to resume an empty player state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue and playback-position persistence: queue snapshots are saved to disk/localStorage, debounced and flushed automatically, and restored on startup.
  * Manual queue restore: load and restore a provided queue and clamped progress snapshot.
  * Improved resume detection: player exposes a resume-capability check used to decide restoration behavior.

* **Bug Fixes**
  * More reliable application of restore seeks, metadata hydration (including artwork) for local files, and clearing of pending resume state after successful playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->