### PR TITLE
fix(aur): disable lto and debug options

### DIFF
--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = kopuz
 	pkgdesc = A modern music player
 	pkgver = 0.5.0
-	pkgrel = 1
+	pkgrel = 2
 	url = https://github.com/temidaradev/kopuz
 	arch = x86_64
 	license = MIT
@@ -18,6 +18,8 @@ pkgbase = kopuz
 	depends = dbus
 	depends = cmake
 	depends = opus
+	options = !lto
+	options = !debug
 	source = kopuz-0.5.0.tar.gz::https://github.com/temidaradev/kopuz/archive/refs/tags/v0.5.0.tar.gz
 	sha256sums = 100c042a73b436a84f751abf51721bb26b3223d45b5d892ba0c81d41751e4a28
 

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: temidaradev <temidaradev@proton.me>
 pkgname=kopuz
 pkgver=0.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A modern music player"
 arch=('x86_64')
 url="https://github.com/temidaradev/kopuz"
@@ -23,6 +23,7 @@ makedepends=(
     'cargo'
     'git'
 )
+options=(!lto !debug)
 # dioxus-cli must be installed manually or from AUR at version matching dioxus 0.7.x:
 #   cargo install dioxus-cli --version "^0.7"
 source=("$pkgname-$pkgver.tar.gz::https://github.com/temidaradev/kopuz/archive/refs/tags/v$pkgver.tar.gz")


### PR DESCRIPTION
Fix linker errors with opus symbols during makepkg builds that causes installing via aur to fail, cuz makepkg(?) sets some compiler flag, thats why compiling manually works while makepkg doesnt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented package release version to version 2
  * Disabled Link Time Optimization and debug compilation in build configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/temidaradev/kopuz/pull/158)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->