### PR TITLE
(fix): embedded artwork handling for album-less tracks and rescan library after downloads

### DIFF
--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -1329,7 +1329,7 @@ fn App() -> Element {
                           }
                         },
                         #[cfg(not(target_arch = "wasm32"))]
-                        Route::Ytdlp => rsx! { pages::ytdlp::YtdlpPage { config } },
+                        Route::Ytdlp => rsx! { pages::ytdlp::YtdlpPage { config, trigger_rescan } },
                         #[cfg(target_arch = "wasm32")]
                         Route::Ytdlp => rsx! { pages::settings::Settings { config } },
                         Route::Settings => rsx! { pages::settings::Settings { config } },

--- a/pages/src/ytdlp.rs
+++ b/pages/src/ytdlp.rs
@@ -317,7 +317,7 @@ fn parse_line(line: &str) -> Option<LineInfo> {
 }
 
 #[component]
-pub fn YtdlpPage(config: Signal<AppConfig>) -> Element {
+pub fn YtdlpPage(config: Signal<AppConfig>, mut trigger_rescan: Signal<usize>) -> Element {
     let mut url_input = use_signal(String::new);
     let mut format = use_signal(|| AudioFormat::BestAudio);
     let mut jobs = use_signal(|| Vec::<DownloadJob>::new());
@@ -472,6 +472,7 @@ pub fn YtdlpPage(config: Signal<AppConfig>) -> Element {
                             cfg.ytdlp_history.insert(0, e);
                             cfg.ytdlp_history.truncate(200);
                         }
+                        *trigger_rescan.write() += 1;
                         break;
                     }
                     LineInfo::Error(msg) => {

--- a/reader/src/metadata.rs
+++ b/reader/src/metadata.rs
@@ -1,23 +1,42 @@
 use super::models::{Album, Library, Track};
 use super::utils::{find_folder_cover, save_cover};
+use lofty::file::TaggedFileExt;
 use lofty::prelude::*;
 use lofty::tag::ItemKey;
-use lofty::{probe::Probe, properties::FileProperties, tag::Tag};
-use std::fs;
+use lofty::{file::TaggedFile, probe::Probe, properties::FileProperties, tag::Tag};
 use std::path::Path;
 
-pub fn make_album_id(album: &str) -> String {
-    format!(
-        "alb_{}",
-        album
-            .to_lowercase()
-            .replace(' ', "_")
-            .replace(|c: char| !c.is_alphanumeric() && c != '_', "")
-    )
+fn slugify_album_key(value: &str) -> String {
+    value
+        .to_lowercase()
+        .replace(' ', "_")
+        .replace(|c: char| !c.is_alphanumeric() && c != '_', "")
 }
 
-pub fn extract_embedded_cover(tag: Option<&Tag>) -> Option<Vec<u8>> {
-    tag?.pictures().first().map(|pic| pic.data().to_vec())
+pub fn make_album_id(album: &str, grouping_key: &str) -> String {
+    let normalized_album = album.trim();
+
+    if !normalized_album.is_empty() {
+        return format!("alb_{}", slugify_album_key(normalized_album));
+    }
+
+    let fallback = slugify_album_key(grouping_key);
+    if fallback.is_empty() {
+        "alb_unknown".to_string()
+    } else {
+        format!("alb_unknown_{fallback}")
+    }
+}
+
+pub fn extract_embedded_cover(tagged_file: &TaggedFile, tag: Option<&Tag>) -> Option<Vec<u8>> {
+    tag.and_then(|tag| tag.pictures().first())
+        .or_else(|| {
+            tagged_file
+                .tags()
+                .iter()
+                .find_map(|tag| tag.pictures().first())
+        })
+        .map(|pic| pic.data().to_vec())
 }
 
 pub fn extract_metadata(
@@ -50,16 +69,14 @@ pub fn extract_metadata(
         })
         .unwrap_or_else(|| vec![artist.clone()]);
 
-    let album_title = tag
-        .and_then(|t| t.album().map(|a| a.to_string()))
-        .unwrap_or_else(|| "Unknown Album".to_string());
+    let album_title = tag.and_then(|t| t.album().map(|a| a.to_string()));
 
     let album_artist = tag
         .and_then(|t| t.get_string(&ItemKey::AlbumArtist))
         .map(|s| s.to_string());
 
     let parent_path = track_path.parent().map(|p| p.to_string_lossy());
-    let _grouping_key = album_artist
+    let grouping_key = album_artist
         .as_deref()
         .or(parent_path.as_deref())
         .unwrap_or(&artist);
@@ -79,11 +96,11 @@ pub fn extract_metadata(
 
     Track {
         path: track_path.to_path_buf(),
-        album_id: make_album_id(&album_title),
+        album_id: make_album_id(album_title.as_deref().unwrap_or(""), grouping_key),
         title,
         artist,
         artists,
-        album: album_title,
+        album: album_title.unwrap_or_else(|| "Unknown Album".to_string()),
         khz: properties.sample_rate().unwrap_or(0),
         bitrate: properties.bit_depth().unwrap_or(0),
         duration: properties.duration().as_secs()
@@ -115,7 +132,7 @@ pub fn read(track_path: &Path, cover_cache: &Path, library: &mut Library) -> Opt
     if !album_exists {
         let mut cover = None;
 
-        if let Some(bytes) = extract_embedded_cover(tag) {
+        if let Some(bytes) = extract_embedded_cover(&tagged_file, tag) {
             cover = save_cover(&album_id, &bytes, cover_cache).ok();
         } else if let Some(folder_cover) = find_folder_cover(track_path.parent()?) {
             cover = Some(folder_cover);


### PR DESCRIPTION
## Description

This PR fixes two library/update issues around local metadata and downloaded tracks.

First, it improves metadata handling for tracks that do not have an album tag. Previously, album-less files could collapse into the same fallback album bucket, which could prevent embedded cover art from being associated correctly. The metadata reader now generates a more specific fallback album ID for those cases and is more robust when extracting embedded artwork. Fix for #166 (probably this was the issue)

Before:
<img width="200" height="300" alt="image" src="https://github.com/user-attachments/assets/efc12e11-2019-43d2-a59f-a15c7b143a9b" />
After: 
<img width="200" height="300" alt="image" src="https://github.com/user-attachments/assets/ff93cd15-25b3-461d-a4c8-ec6a81ba92c1" />



Second, successful yt-dlp downloads now trigger the existing library rescan flow automatically. That means newly downloaded tracks are picked up by the library without requiring a manual rescan.

## Changes 

- Improve fallback album ID generation for files missing an album tag
- Make embedded cover extraction more reliable during metadata scan
- Trigger library rescan automatically after successful yt-dlp downloads
- Wire the rescan signal into YtdlpPage