### PR TITLE
feat: Add yt-dlp dependency for flatpak users.

### DIFF
--- a/com.temidaradev.kopuz.json
+++ b/com.temidaradev.kopuz.json
@@ -36,6 +36,21 @@
             ]
         },
         {
+            "name": "yt-dlp",
+            "buildsystem": "simple",
+            "build-commands": [
+                "install -Dm755 yt-dlp /app/bin/yt-dlp"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp",
+                    "sha256": "3bda0968a01cde70d26720653003b28553c71be14dcb2e5f4c24e9921fdad745",
+                    "dest-filename": "yt-dlp"
+                }
+            ]
+        },
+        {
             "name": "kopuz",
             "buildsystem": "simple",
             "build-commands": [

--- a/com.temidaradev.kopuz.json
+++ b/com.temidaradev.kopuz.json
@@ -44,8 +44,8 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp",
-                    "sha256": "3bda0968a01cde70d26720653003b28553c71be14dcb2e5f4c24e9921fdad745",
+                    "url": "https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux",
+                    "sha256": "c2b0189f581fe4a2ddd41954f1bcb7d327db04b07ed0dea97e4f1b3e09b5dd8e",
                     "dest-filename": "yt-dlp"
                 }
             ]


### PR DESCRIPTION
# Description
---
When using flatpak you couldn't donwload anything using yt-dlp because how flatpak works.
Fixes #149 adding yt-dlp as a dependency in flatpak build.

Before:
<img width="1350" height="800" alt="Captura desde 2026-05-11 13-08-11" src="https://github.com/user-attachments/assets/08b34322-fe82-4a7c-8a51-1fe0bbffbc95" />

After:
<img width="1350" height="800" alt="Captura desde 2026-05-11 13-03-08" src="https://github.com/user-attachments/assets/c8f829e3-4e5a-49b7-9644-040b6d5ef510" />

This makes the app reproducable and portable between different distributions.

# Changes:
---
- Add yt-dlp (ver. 2026.03.17) to flatpak manifest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the yt-dlp tool to the application distribution to enable in-app video downloading support.
  * The included yt-dlp is a pinned, vetted release to ensure consistent and verified behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/171)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->