### PR TITLE
(fix): harden local cover-art extraction and cache file  handling

### DIFF
--- a/reader/src/metadata.rs
+++ b/reader/src/metadata.rs
@@ -40,17 +40,16 @@ pub fn extract_embedded_cover<'a>(
     tagged_file: &'a TaggedFile,
     tag: Option<&'a Tag>,
 ) -> Option<&'a Picture> {
-    tag.and_then(|tag| tag.get_picture_type(PictureType::CoverFront))
+    let candidate_tags = tag
+        .into_iter()
+        .chain(tagged_file.tags().iter())
+        .collect::<Vec<_>>();
+
+    candidate_tags
+        .iter()
+        .find_map(|tag| tag.get_picture_type(PictureType::CoverFront))
         .or_else(|| {
-            tagged_file
-                .tags()
-                .iter()
-                .find_map(|tag| tag.get_picture_type(PictureType::CoverFront))
-        })
-        .or_else(|| tag.and_then(|tag| select_best_picture(tag.pictures())))
-        .or_else(|| {
-            tagged_file
-                .tags()
+            candidate_tags
                 .iter()
                 .find_map(|tag| select_best_picture(tag.pictures()))
         })

--- a/reader/src/metadata.rs
+++ b/reader/src/metadata.rs
@@ -1,6 +1,7 @@
 use super::models::{Album, Library, Track};
 use super::utils::{find_folder_cover, save_cover};
 use lofty::file::TaggedFileExt;
+use lofty::picture::{Picture, PictureType};
 use lofty::prelude::*;
 use lofty::tag::ItemKey;
 use lofty::{file::TaggedFile, probe::Probe, properties::FileProperties, tag::Tag};
@@ -28,15 +29,31 @@ pub fn make_album_id(album: &str, grouping_key: &str) -> String {
     }
 }
 
-pub fn extract_embedded_cover(tagged_file: &TaggedFile, tag: Option<&Tag>) -> Option<Vec<u8>> {
-    tag.and_then(|tag| tag.pictures().first())
+fn select_best_picture<'a>(pictures: &'a [Picture]) -> Option<&'a Picture> {
+    pictures
+        .iter()
+        .find(|picture| picture.pic_type() == PictureType::CoverFront)
+        .or_else(|| pictures.first())
+}
+
+pub fn extract_embedded_cover<'a>(
+    tagged_file: &'a TaggedFile,
+    tag: Option<&'a Tag>,
+) -> Option<&'a Picture> {
+    tag.and_then(|tag| tag.get_picture_type(PictureType::CoverFront))
         .or_else(|| {
             tagged_file
                 .tags()
                 .iter()
-                .find_map(|tag| tag.pictures().first())
+                .find_map(|tag| tag.get_picture_type(PictureType::CoverFront))
         })
-        .map(|pic| pic.data().to_vec())
+        .or_else(|| tag.and_then(|tag| select_best_picture(tag.pictures())))
+        .or_else(|| {
+            tagged_file
+                .tags()
+                .iter()
+                .find_map(|tag| select_best_picture(tag.pictures()))
+        })
 }
 
 pub fn extract_metadata(
@@ -127,17 +144,21 @@ pub fn read(track_path: &Path, cover_cache: &Path, library: &mut Library) -> Opt
         .map(|s| s.to_string())
         .unwrap_or_else(|| track.artist.clone());
 
-    let album_exists = library.albums.iter().any(|a| a.id == album_id);
+    let album = library.albums.iter().find(|a| a.id == album_id);
+    let album_exists = album.is_some();
+    let needs_cover = album.and_then(|album| album.cover_path.as_ref()).is_none();
+    let mut cover = None;
 
-    if !album_exists {
-        let mut cover = None;
-
-        if let Some(bytes) = extract_embedded_cover(&tagged_file, tag) {
-            cover = save_cover(&album_id, &bytes, cover_cache).ok();
-        } else if let Some(folder_cover) = find_folder_cover(track_path.parent()?) {
+    if needs_cover {
+        if let Some(picture) = extract_embedded_cover(&tagged_file, tag) {
+            let extension = picture.mime_type().and_then(|mime_type| mime_type.ext());
+            cover = save_cover(&album_id, picture.data(), extension, cover_cache).ok();
+        } else if let Some(folder_cover) = track_path.parent().and_then(find_folder_cover) {
             cover = Some(folder_cover);
         }
+    }
 
+    if !album_exists || cover.is_some() {
         let genre = tag
             .and_then(|t| t.genre().map(|g| g.to_string()))
             .unwrap_or_else(|| "Unknown".to_string());

--- a/reader/src/utils.rs
+++ b/reader/src/utils.rs
@@ -1,6 +1,22 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+fn detect_image_extension(data: &[u8]) -> &'static str {
+    if data.len() >= 12 && &data[..8] == b"\x89PNG\r\n\x1a\n" {
+        "png"
+    } else if data.len() >= 3 && data[..3] == [0xFF, 0xD8, 0xFF] {
+        "jpg"
+    } else if data.len() >= 12 && &data[..4] == b"RIFF" && &data[8..12] == b"WEBP" {
+        "webp"
+    } else if data.len() >= 6 && (data[..6] == *b"GIF87a" || data[..6] == *b"GIF89a") {
+        "gif"
+    } else if data.len() >= 2 && data[..2] == [0x42, 0x4D] {
+        "bmp"
+    } else {
+        "jpg"
+    }
+}
+
 pub fn find_folder_cover(dir: &Path) -> Option<PathBuf> {
     let candidates = ["cover.jpg", "cover.png", "folder.jpg", "album.jpg"];
 
@@ -15,9 +31,9 @@ pub fn find_folder_cover(dir: &Path) -> Option<PathBuf> {
 
 pub fn save_cover(album_id: &str, data: &[u8], cache_dir: &Path) -> std::io::Result<PathBuf> {
     fs::create_dir_all(cache_dir)?;
-    let path = cache_dir.join(format!("{album_id}.jpg"));
-    let bytes = data.to_vec();
+    let extension = detect_image_extension(data);
+    let path = cache_dir.join(format!("{album_id}.{extension}"));
 
-    fs::write(&path, bytes)?;
+    fs::write(&path, data)?;
     Ok(path)
 }

--- a/reader/src/utils.rs
+++ b/reader/src/utils.rs
@@ -17,6 +17,15 @@ fn detect_image_extension(data: &[u8]) -> &'static str {
     }
 }
 
+fn remove_stale_cover_variants(album_id: &str, cache_dir: &Path, keep_path: &Path) {
+    for extension in ["jpg", "png", "webp", "gif", "bmp", "tif"] {
+        let candidate = cache_dir.join(format!("{album_id}.{extension}"));
+        if candidate != keep_path {
+            let _ = fs::remove_file(candidate);
+        }
+    }
+}
+
 pub fn find_folder_cover(dir: &Path) -> Option<PathBuf> {
     let candidates = ["cover.jpg", "cover.png", "folder.jpg", "album.jpg"];
 
@@ -29,11 +38,17 @@ pub fn find_folder_cover(dir: &Path) -> Option<PathBuf> {
     None
 }
 
-pub fn save_cover(album_id: &str, data: &[u8], cache_dir: &Path) -> std::io::Result<PathBuf> {
+pub fn save_cover(
+    album_id: &str,
+    data: &[u8],
+    extension: Option<&str>,
+    cache_dir: &Path,
+) -> std::io::Result<PathBuf> {
     fs::create_dir_all(cache_dir)?;
-    let extension = detect_image_extension(data);
+    let extension = extension.unwrap_or_else(|| detect_image_extension(data));
     let path = cache_dir.join(format!("{album_id}.{extension}"));
 
+    remove_stale_cover_variants(album_id, cache_dir, &path);
     fs::write(&path, data)?;
     Ok(path)
 }


### PR DESCRIPTION
## Description

This PR improves how Kopuz extracts and caches local album artwork during library scans.

It makes embedded cover detection more reliable by preferring front-cover artwork when available, falling back across parsed tags, and simplifying the internal selection flow so the lookup order is clearer. It also improves cache file handling by saving covers with the correct detected image extension instead of always assuming JPEG, while cleaning up stale cached variants for the same album id.

## Why

Previously, local cover caching was too rigid: 


  - cached files were always written as .jpg
  - embedded picture selection was less precise
  - cover lookup logic was more repetitive than necessary
  - old cached variants could accumulate for the same album