### PR TITLE
feat(discord_rpc): add iTunes fallback for cover url retrieval

### DIFF
--- a/discord-presence/src/cover_art.rs
+++ b/discord-presence/src/cover_art.rs
@@ -2,7 +2,13 @@ use serde::Deserialize;
 
 const MUSICBRAINZ_API: &str = "https://musicbrainz.org/ws/2";
 const COVER_ART_ARCHIVE: &str = "https://coverartarchive.org";
+const ITUNES: &str = "https://itunes.apple.com/search";
+const DEEZER: &str = "https://api.deezer.com/search/album";
 const USER_AGENT: &str = "Kopuz/0.5.0 (https://github.com/temidaradev/kopuz)";
+
+fn build_client() -> Result<reqwest::Client, reqwest::Error> {
+    reqwest::Client::builder().user_agent(USER_AGENT).build()
+}
 
 #[derive(Debug, Deserialize)]
 struct ReleaseSearchResponse {
@@ -17,10 +23,6 @@ struct ReleaseSearchResult {
 
 pub fn cover_art_url(release_mbid: &str) -> String {
     format!("{}/release/{}/front", COVER_ART_ARCHIVE, release_mbid)
-}
-
-fn build_client() -> Result<reqwest::Client, reqwest::Error> {
-    reqwest::Client::builder().user_agent(USER_AGENT).build()
 }
 
 fn escape_lucene(input: &str) -> String {
@@ -47,14 +49,12 @@ async fn search_release_mbid(
     }
 
     let mut query_parts: Vec<String> = Vec::new();
-
     if !album.is_empty() {
         query_parts.push(format!("release:\"{}\"", escape_lucene(album)));
     }
     if !artist.is_empty() {
         query_parts.push(format!("artist:\"{}\"", escape_lucene(artist)));
     }
-
     let query = query_parts.join(" AND ");
 
     let client = build_client()?;
@@ -73,7 +73,6 @@ async fn search_release_mbid(
     }
 
     let body: ReleaseSearchResponse = resp.json().await?;
-
     if let Some(releases) = body.releases {
         if let Some(first) = releases.first() {
             let score = first.score.unwrap_or(0);
@@ -95,6 +94,100 @@ async fn search_release_mbid(
     Ok(None)
 }
 
+#[derive(Debug, Deserialize)]
+struct ItunesSearchResponse {
+    #[serde(rename = "resultCount")]
+    result_count: u32,
+    results: Vec<ItunesResult>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ItunesResult {
+    #[serde(rename = "artworkUrl100")]
+    artwork_url_100: Option<String>,
+}
+
+async fn resolve_via_itunes(
+    artist: &str,
+    album: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
+    if artist.is_empty() && album.is_empty() {
+        return Ok(None);
+    }
+
+    let term = format!("{} {}", artist, album);
+    let client = build_client()?;
+    let resp = client
+        .get(ITUNES)
+        .query(&[("term", term.as_str()), ("entity", "album"), ("limit", "1")])
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        println!("[cover_art] iTunes returned HTTP {}", resp.status());
+        return Ok(None);
+    }
+
+    let body: ItunesSearchResponse = resp.json().await?;
+    if body.result_count == 0 {
+        return Ok(None);
+    }
+
+    if let Some(result) = body.results.first() {
+        if let Some(url) = &result.artwork_url_100 {
+            let hires = url.replace("100x100bb", "600x600bb");
+            println!("[cover_art] iTunes match -> {}", hires);
+            return Ok(Some(hires));
+        }
+    }
+
+    Ok(None)
+}
+
+#[derive(Debug, Deserialize)]
+struct DeezerSearchResponse {
+    data: Option<Vec<DeezerAlbum>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeezerAlbum {
+    cover_xl: Option<String>,
+}
+
+async fn resolve_via_deezer(
+    artist: &str,
+    album: &str,
+) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
+    if artist.is_empty() && album.is_empty() {
+        return Ok(None);
+    }
+
+    let query = format!("{} {}", artist, album);
+    let client = build_client()?;
+    let resp = client
+        .get(DEEZER)
+        .query(&[("q", query.as_str()), ("limit", "1")])
+        .send()
+        .await?;
+
+    if !resp.status().is_success() {
+        println!("[cover_art] Deezer returned HTTP {}", resp.status());
+        return Ok(None);
+    }
+
+    let body: DeezerSearchResponse = resp.json().await?;
+    if let Some(data) = body.data {
+        if let Some(album) = data.first() {
+            if let Some(url) = &album.cover_xl {
+                println!("[cover_art] Deezer match -> {}", url);
+                return Ok(Some(url.clone()));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
 async fn verify_cover_exists(
     release_mbid: &str,
 ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
@@ -104,6 +197,7 @@ async fn verify_cover_exists(
     let status = resp.status();
     Ok(status.is_success() || status.is_redirection())
 }
+
 pub async fn resolve_cover_art_url(
     mbid: Option<&str>,
     artist: &str,
@@ -117,15 +211,11 @@ pub async fn resolve_cover_art_url(
                     println!("[cover_art] Resolved via embedded MBID -> {}", url);
                     return Some(url);
                 }
-                Ok(false) => {
-                    println!(
-                        "[cover_art] Embedded MBID {} has no front cover, falling back to search",
-                        id
-                    );
-                }
-                Err(e) => {
-                    println!("[cover_art] Error verifying MBID {}: {}", id, e);
-                }
+                Ok(false) => println!(
+                    "[cover_art] Embedded MBID {} has no front cover, falling back",
+                    id
+                ),
+                Err(e) => println!("[cover_art] Error verifying MBID {}: {}", id, e),
             }
         }
     }
@@ -134,31 +224,36 @@ pub async fn resolve_cover_art_url(
         Ok(Some(release_id)) => match verify_cover_exists(&release_id).await {
             Ok(true) => {
                 let url = cover_art_url(&release_id);
-                println!("[cover_art] Resolved via search -> {}", url);
-                Some(url)
+                println!("[cover_art] Resolved via MusicBrainz search -> {}", url);
+                return Some(url);
             }
-            Ok(false) => {
-                println!(
-                    "[cover_art] Release {} found but has no front cover",
-                    release_id
-                );
-                None
-            }
-            Err(e) => {
-                println!("[cover_art] Error verifying release {}: {}", release_id, e);
-                None
-            }
+            Ok(false) => println!("[cover_art] Release {} has no front cover", release_id),
+            Err(e) => println!("[cover_art] Error verifying release {}: {}", release_id, e),
         },
-        Ok(None) => {
-            println!(
-                "[cover_art] No match for artist=\"{}\" album=\"{}\"",
-                artist, album
-            );
-            None
-        }
-        Err(e) => {
-            println!("[cover_art] MusicBrainz search failed: {}", e);
-            None
-        }
+        Ok(None) => println!(
+            "[cover_art] No MusicBrainz match for artist=\"{}\" album=\"{}\"",
+            artist, album
+        ),
+        Err(e) => println!("[cover_art] MusicBrainz search failed: {}", e),
     }
+
+    // Fallback: iTunes
+    match resolve_via_itunes(artist, album).await {
+        Ok(Some(url)) => return Some(url),
+        Ok(None) => println!("[cover_art] No iTunes match"),
+        Err(e) => println!("[cover_art] iTunes error: {}", e),
+    }
+
+    // Fallback: Deezer
+    match resolve_via_deezer(artist, album).await {
+        Ok(Some(url)) => return Some(url),
+        Ok(None) => println!("[cover_art] No Deezer match"),
+        Err(e) => println!("[cover_art] Deezer error: {}", e),
+    }
+
+    println!(
+        "[cover_art] All sources exhausted for artist=\"{}\" album=\"{}\"",
+        artist, album
+    );
+    None
 }

--- a/discord-presence/src/cover_art.rs
+++ b/discord-presence/src/cover_art.rs
@@ -144,50 +144,6 @@ async fn resolve_via_itunes(
     Ok(None)
 }
 
-#[derive(Debug, Deserialize)]
-struct DeezerSearchResponse {
-    data: Option<Vec<DeezerAlbum>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct DeezerAlbum {
-    cover_xl: Option<String>,
-}
-
-async fn resolve_via_deezer(
-    artist: &str,
-    album: &str,
-) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
-    if artist.is_empty() && album.is_empty() {
-        return Ok(None);
-    }
-
-    let query = format!("{} {}", artist, album);
-    let client = build_client()?;
-    let resp = client
-        .get(DEEZER)
-        .query(&[("q", query.as_str()), ("limit", "1")])
-        .send()
-        .await?;
-
-    if !resp.status().is_success() {
-        println!("[cover_art] Deezer returned HTTP {}", resp.status());
-        return Ok(None);
-    }
-
-    let body: DeezerSearchResponse = resp.json().await?;
-    if let Some(data) = body.data {
-        if let Some(album) = data.first() {
-            if let Some(url) = &album.cover_xl {
-                println!("[cover_art] Deezer match -> {}", url);
-                return Ok(Some(url.clone()));
-            }
-        }
-    }
-
-    Ok(None)
-}
-
 async fn verify_cover_exists(
     release_mbid: &str,
 ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
@@ -242,13 +198,6 @@ pub async fn resolve_cover_art_url(
         Ok(Some(url)) => return Some(url),
         Ok(None) => println!("[cover_art] No iTunes match"),
         Err(e) => println!("[cover_art] iTunes error: {}", e),
-    }
-
-    // Fallback: Deezer
-    match resolve_via_deezer(artist, album).await {
-        Ok(Some(url)) => return Some(url),
-        Ok(None) => println!("[cover_art] No Deezer match"),
-        Err(e) => println!("[cover_art] Deezer error: {}", e),
     }
 
     println!(

--- a/discord-presence/src/cover_art.rs
+++ b/discord-presence/src/cover_art.rs
@@ -3,7 +3,6 @@ use serde::Deserialize;
 const MUSICBRAINZ_API: &str = "https://musicbrainz.org/ws/2";
 const COVER_ART_ARCHIVE: &str = "https://coverartarchive.org";
 const ITUNES: &str = "https://itunes.apple.com/search";
-const DEEZER: &str = "https://api.deezer.com/search/album";
 const USER_AGENT: &str = "Kopuz/0.5.0 (https://github.com/temidaradev/kopuz)";
 
 fn build_client() -> Result<reqwest::Client, reqwest::Error> {


### PR DESCRIPTION
# Description 
This PR adds an iTunes fallback for cover art retrieval used in RPC covers.
If MusicBrainz fails to find matching metadata or cover art, the application will attempt to fetch the cover from iTunes instead.

```
02:21:32 [linux] [cover_art] MusicBrainz search failed: error sending request for url (https://musicbrainz.org/ws/2/release/?query=release%3A%22ENDER+LILIES%5C%3A+Quietus+of+the+Knights+Original+Soundtrack%22+AND+artist%3A%22Binary+Haze+Interactive%2C+Mili%22&fmt=json&limit=1)

02:21:33 [linux] [cover_art] iTunes match -> https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/60/5a/55/605a55ac-756d-9c29-8c5f-7647dd0033f6/859756980216_cover.jpg/600x600bb.jpg
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added iTunes as an additional fallback source for cover art resolution to improve coverage.

* **Improvements**
  * Enhanced search character handling for better compatibility.
  * Expanded logging for improved troubleshooting and visibility into cover art resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/173)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->