### PR TITLE
Add yt-dlp preflight checks and duplicate download guards

### DIFF
--- a/locales/ar.ftl
+++ b/locales/ar.ftl
@@ -297,8 +297,13 @@ ytdlp_status_processing = جارٍ المعالجة...
 ytdlp_status_completed = اكتمل
 ytdlp_status_waiting = قيد الانتظار...
 ytdlp_error_not_found = لم يتم العثور على yt-dlp في PATH. قم بتثبيته: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = لم يتم العثور على ffmpeg في PATH. قم بتثبيته لكي تعمل المعالجة اللاحقة في yt-dlp.
 ytdlp_error_start = فشل بدء yt-dlp: { $error }
 ytdlp_error_exit = خرج yt-dlp: { $status }
+ytdlp_error_duplicate_active = يجري تنزيل هذا الرابط بالفعل.
+ytdlp_error_output_not_directory = مسار الإخراج ليس مجلدًا: { $path }
+ytdlp_error_output_prepare = تعذر تجهيز مجلد الإخراج: { $error }
+ytdlp_error_output_not_writable = لا يمكن الكتابة إلى مجلد الإخراج: { $path }
 
 channel_mode = وضع القناة
 channel_mode_stereo = ستيريو

--- a/locales/de.ftl
+++ b/locales/de.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = Wird verarbeitet…
 ytdlp_status_completed = Abgeschlossen
 ytdlp_status_waiting = Warten…
 ytdlp_error_not_found = yt-dlp im PATH nicht gefunden. Installieren: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg im PATH nicht gefunden. Installieren Sie es, damit die Nachbearbeitung von yt-dlp funktioniert.
 ytdlp_error_start = yt-dlp konnte nicht gestartet werden: { $error }
 ytdlp_error_exit = yt-dlp beendet: { $status }
+ytdlp_error_duplicate_active = Diese URL wird bereits heruntergeladen.
+ytdlp_error_output_not_directory = Der Ausgabepfad ist kein Verzeichnis: { $path }
+ytdlp_error_output_prepare = Ausgabeverzeichnis konnte nicht vorbereitet werden: { $error }
+ytdlp_error_output_not_writable = Auf das Ausgabeverzeichnis kann nicht geschrieben werden: { $path }
 
 channel_mode = Kanalmodus
 channel_mode_stereo = Stereo

--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -99,8 +99,13 @@ ytdlp_status_processing = Processing…
 ytdlp_status_completed = Completed
 ytdlp_status_waiting = Waiting…
 ytdlp_error_not_found = yt-dlp not found in PATH. Install it: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg not found in PATH. Install it so yt-dlp post-processing can work.
 ytdlp_error_start = Failed to start yt-dlp: { $error }
 ytdlp_error_exit = yt-dlp exited: { $status }
+ytdlp_error_duplicate_active = This URL is already downloading.
+ytdlp_error_output_not_directory = Output path is not a directory: { $path }
+ytdlp_error_output_prepare = Failed to prepare output directory: { $error }
+ytdlp_error_output_not_writable = Output directory is not writable: { $path }
 
 # UI Actions & Buttons
 add_to_favorites = Add to Favorites

--- a/locales/es.ftl
+++ b/locales/es.ftl
@@ -292,8 +292,13 @@ ytdlp_status_processing = Procesando…
 ytdlp_status_completed = Completado
 ytdlp_status_waiting = Esperando…
 ytdlp_error_not_found = yt-dlp no encontrado en PATH. Instálalo: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg no encontrado en PATH. Instálalo para que el posprocesado de yt-dlp funcione.
 ytdlp_error_start = Fallo al iniciar yt-dlp: { $error }
 ytdlp_error_exit = yt-dlp salió: { $status }
+ytdlp_error_duplicate_active = Esta URL ya se está descargando.
+ytdlp_error_output_not_directory = La ruta de salida no es un directorio: { $path }
+ytdlp_error_output_prepare = No se pudo preparar el directorio de salida: { $error }
+ytdlp_error_output_not_writable = El directorio de salida no tiene permisos de escritura: { $path }
 
 channel_mode = Modo de canal
 channel_mode_stereo = Estéreo

--- a/locales/fr.ftl
+++ b/locales/fr.ftl
@@ -266,8 +266,13 @@ ytdlp_status_processing = Traitement en cours...
 ytdlp_status_completed = Terminé
 ytdlp_status_waiting = En attente...
 ytdlp_error_not_found = yt-dlp introuvable dans le PATH. Installez-le : https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg introuvable dans le PATH. Installez-le pour que le post-traitement de yt-dlp fonctionne.
 ytdlp_error_start = Échec du démarrage de yt-dlp : { $error }
 ytdlp_error_exit = yt-dlp s'est arrêté : { $status }
+ytdlp_error_duplicate_active = Cette URL est déjà en cours de téléchargement.
+ytdlp_error_output_not_directory = Le chemin de sortie n'est pas un dossier : { $path }
+ytdlp_error_output_prepare = Impossible de préparer le dossier de sortie : { $error }
+ytdlp_error_output_not_writable = Le dossier de sortie n'est pas accessible en écriture : { $path }
 
 featured_album = Album en vedette
 minimize = Réduire

--- a/locales/gr.ftl
+++ b/locales/gr.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = Επεξεργασία…
 ytdlp_status_completed = Ολοκληρώθηκε
 ytdlp_status_waiting = Αναμονή…
 ytdlp_error_not_found = Το yt-dlp δεν βρέθηκε. Εγκαταστήστε το: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = Δεν βρέθηκε το ffmpeg στο PATH. Εγκαταστήστε το ώστε να λειτουργεί η μετεπεξεργασία του yt-dlp.
 ytdlp_error_start = Αποτυχία εκκίνησης yt-dlp: { $error }
 ytdlp_error_exit = Το yt-dlp τερματίστηκε: { $status }
+ytdlp_error_duplicate_active = Αυτό το URL κατεβαίνει ήδη.
+ytdlp_error_output_not_directory = Η διαδρομή εξόδου δεν είναι φάκελος: { $path }
+ytdlp_error_output_prepare = Αποτυχία προετοιμασίας του φακέλου εξόδου: { $error }
+ytdlp_error_output_not_writable = Δεν υπάρχει άδεια εγγραφής στον φάκελο εξόδου: { $path }
 
 channel_mode = Λειτουργία καναλιού
 channel_mode_stereo = Στέρεο

--- a/locales/he.ftl
+++ b/locales/he.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = מעבד…
 ytdlp_status_completed = הושלם
 ytdlp_status_waiting = ממתין…
 ytdlp_error_not_found = yt-dlp לא נמצא ב-PATH. ניתן להתקין דרך: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg לא נמצא ב-PATH. התקן אותו כדי שעיבוד ההמשך של yt-dlp יעבוד.
 ytdlp_error_start = נכשל בהפעלת yt-dlp: { $error }
 ytdlp_error_exit = yt-dlp סיים: { $status }
+ytdlp_error_duplicate_active = הכתובת הזו כבר בהורדה.
+ytdlp_error_output_not_directory = נתיב הפלט אינו תיקייה: { $path }
+ytdlp_error_output_prepare = לא ניתן להכין את תיקיית הפלט: { $error }
+ytdlp_error_output_not_writable = אין הרשאת כתיבה לתיקיית הפלט: { $path }
 
 channel_mode = מצב ערוץ
 channel_mode_stereo = סטריאו

--- a/locales/hu.ftl
+++ b/locales/hu.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = Feldolgozás…
 ytdlp_status_completed = Befejezve
 ytdlp_status_waiting = Várakozás…
 ytdlp_error_not_found = Az yt-dlp nem található a PATH-ban. Telepítés: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = Az ffmpeg nem található a PATH-ban. Telepítse, hogy az yt-dlp utófeldolgozása működjön.
 ytdlp_error_start = Nem sikerült elindítani az yt-dlp-t: { $error }
 ytdlp_error_exit = Az yt-dlp kilépett: { $status }
+ytdlp_error_duplicate_active = Ez az URL már letöltés alatt áll.
+ytdlp_error_output_not_directory = A kimeneti útvonal nem könyvtár: { $path }
+ytdlp_error_output_prepare = Nem sikerült előkészíteni a kimeneti könyvtárat: { $error }
+ytdlp_error_output_not_writable = A kimeneti könyvtár nem írható: { $path }
 
 channel_mode = Csatorna mód
 channel_mode_stereo = Sztereó

--- a/locales/id.ftl
+++ b/locales/id.ftl
@@ -91,8 +91,13 @@ ytdlp_status_processing = Sedang memproses…
 ytdlp_status_completed = Selesai
 ytdlp_status_waiting = Menunggu…
 ytdlp_error_not_found = yt-dlp tidak ditemukan di PATH. Install: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg tidak ditemukan di PATH. Instal agar post-processing yt-dlp dapat bekerja.
 ytdlp_error_start = Gagal untuk memulai yt-dlp: { $error }
 ytdlp_error_exit = yt-dlp gagal: { $status }
+ytdlp_error_duplicate_active = URL ini sudah sedang diunduh.
+ytdlp_error_output_not_directory = Path output bukan direktori: { $path }
+ytdlp_error_output_prepare = Gagal menyiapkan direktori output: { $error }
+ytdlp_error_output_not_writable = Direktori output tidak dapat ditulisi: { $path }
 
 # UI Actions & Buttons
 add_to_favorites = Tambah ke Favorit

--- a/locales/ja.ftl
+++ b/locales/ja.ftl
@@ -297,8 +297,13 @@ ytdlp_status_processing = 処理中…
 ytdlp_status_completed = 完了
 ytdlp_status_waiting = 待機中…
 ytdlp_error_not_found = PATH に yt-dlp が見つかりませんでした。インストールしてください: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = PATH に ffmpeg が見つかりませんでした。yt-dlp の後処理を動作させるためにインストールしてください。
 ytdlp_error_start = yt-dlp の起動に失敗しました: { $error }
 ytdlp_error_exit = yt-dlp が終了しました: { $status }
+ytdlp_error_duplicate_active = この URL はすでにダウンロード中です。
+ytdlp_error_output_not_directory = 出力先のパスはディレクトリではありません: { $path }
+ytdlp_error_output_prepare = 出力先ディレクトリを準備できませんでした: { $error }
+ytdlp_error_output_not_writable = 出力先ディレクトリに書き込めません: { $path }
 
 channel_mode = チャンネルモード
 channel_mode_stereo = ステレオ

--- a/locales/ko.ftl
+++ b/locales/ko.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = 처리 중…
 ytdlp_status_completed = 완료됨
 ytdlp_status_waiting = 대기 중…
 ytdlp_error_not_found = PATH에서 yt-dlp를 찾을 수 없습니다. 설치: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = PATH에서 ffmpeg를 찾을 수 없습니다. yt-dlp 후처리가 동작하도록 설치하세요.
 ytdlp_error_start = yt-dlp 시작 실패: { $error }
 ytdlp_error_exit = yt-dlp 종료됨: { $status }
+ytdlp_error_duplicate_active = 이 URL은 이미 다운로드 중입니다.
+ytdlp_error_output_not_directory = 출력 경로가 폴더가 아닙니다: { $path }
+ytdlp_error_output_prepare = 출력 폴더를 준비하지 못했습니다: { $error }
+ytdlp_error_output_not_writable = 출력 폴더에 쓸 수 없습니다: { $path }
 
 channel_mode = 채널 모드
 channel_mode_stereo = 스테레오

--- a/locales/pl.ftl
+++ b/locales/pl.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = Przetwarzanie…
 ytdlp_status_completed = Ukończono
 ytdlp_status_waiting = Oczekiwanie…
 ytdlp_error_not_found = yt-dlp nie znaleziono w PATH. Zainstaluj oprogramowanie: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = Nie znaleziono ffmpeg w PATH. Zainstaluj go, aby przetwarzanie końcowe yt-dlp działało.
 ytdlp_error_start = Błąd podczas uruchamiania yt-dlp: { $error }
 ytdlp_error_exit = yt-dlp opuścił z błędem: { $status }
+ytdlp_error_duplicate_active = Ten adres URL jest już pobierany.
+ytdlp_error_output_not_directory = Ścieżka wyjściowa nie jest katalogiem: { $path }
+ytdlp_error_output_prepare = Nie udało się przygotować katalogu wyjściowego: { $error }
+ytdlp_error_output_not_writable = Katalog wyjściowy nie ma uprawnień do zapisu: { $path }
 
 channel_mode = Tryb kanału
 channel_mode_stereo = Stereo

--- a/locales/pt-BR.ftl
+++ b/locales/pt-BR.ftl
@@ -91,8 +91,13 @@ ytdlp_status_processing = Processando…
 ytdlp_status_completed = Concluído
 ytdlp_status_waiting = Aguardando…
 ytdlp_error_not_found = yt-dlp não encontrado no PATH. Instale-o: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg não encontrado no PATH. Instale-o para que o pós-processamento do yt-dlp funcione.
 ytdlp_error_start = Falha ao iniciar o yt-dlp: { $error }
 ytdlp_error_exit = yt-dlp saiu: { $status }
+ytdlp_error_duplicate_active = Esta URL já está sendo baixada.
+ytdlp_error_output_not_directory = O caminho de saída não é uma pasta: { $path }
+ytdlp_error_output_prepare = Falha ao preparar a pasta de saída: { $error }
+ytdlp_error_output_not_writable = Sem permissão de escrita na pasta de saída: { $path }
 
 # UI Actions & Buttons
 add_to_favorites = Adicionar aos favoritos

--- a/locales/ro.ftl
+++ b/locales/ro.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = Procesare…
 ytdlp_status_completed = Finalizat
 ytdlp_status_waiting = Se Așteaptă…
 ytdlp_error_not_found = yt-dlp nu a fost găsit în sistemul PATH. Instalați yt-dlp: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg nu a fost găsit în PATH. Instalați-l pentru ca post-procesarea yt-dlp să funcționeze.
 ytdlp_error_start = yt-dlp nu s-a pornit: { $error }
 ytdlp_error_exit = yt-dlp a ieșit: { $status }
+ytdlp_error_duplicate_active = Acest URL se descarcă deja.
+ytdlp_error_output_not_directory = Calea de ieșire nu este un director: { $path }
+ytdlp_error_output_prepare = Nu s-a putut pregăti directorul de ieșire: { $error }
+ytdlp_error_output_not_writable = Directorul de ieșire nu este inscriptibil: { $path }
 
 channel_mode = Mod canal
 channel_mode_stereo = Stereo

--- a/locales/ru.ftl
+++ b/locales/ru.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = Обработка…
 ytdlp_status_completed = Завершено
 ytdlp_status_waiting = Ожидание…
 ytdlp_error_not_found = yt-dlp не найден в PATH. Установите: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg не найден в PATH. Установите его, чтобы постобработка yt-dlp работала.
 ytdlp_error_start = Ошибка запуска yt-dlp: { $error }
 ytdlp_error_exit = yt-dlp завершил работу: { $status }
+ytdlp_error_duplicate_active = Этот URL уже скачивается.
+ytdlp_error_output_not_directory = Путь вывода не является каталогом: { $path }
+ytdlp_error_output_prepare = Не удалось подготовить каталог вывода: { $error }
+ytdlp_error_output_not_writable = Каталог вывода недоступен для записи: { $path }
 
 channel_mode = Режим канала
 channel_mode_stereo = Стерео

--- a/locales/tok-SP.ftl
+++ b/locales/tok-SP.ftl
@@ -266,8 +266,13 @@ ytdlp_status_processing = 󱤏 󱥔 󱤦...
 ytdlp_status_completed = 󱥛
 ytdlp_status_waiting = 󱥎 󱤈...
 ytdlp_error_not_found = 󱤏 yt-dlp 󱤮 󱤳 󱤂. 󱥎 󱥸 󱤱: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ilo ffmpeg li lon ala lon PATH. o pana e ona tawa ni: ilo yt-dlp li ken pali e ante pini.
 ytdlp_error_start = yt-dlp 󱤮 󱤎 󱥒: { $error }
 ytdlp_error_exit = yt-dlp 󱤮 󱦃: { $status }
+ytdlp_error_duplicate_active = URL ni li lon pali jo.
+ytdlp_error_output_not_directory = nasin pi weka lipu li tomo ala: { $path }
+ytdlp_error_output_prepare = ken ala pona e tomo pi weka lipu: { $error }
+ytdlp_error_output_not_writable = ken ala sitelen tawa tomo pi weka lipu: { $path }
 
 featured_album = 󱥯 󱤶 󱥬
 minimize = 󱥬 󱤴

--- a/locales/tok.ftl
+++ b/locales/tok.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = ilo pali la...
 ytdlp_status_completed = pini
 ytdlp_status_waiting = o awen...
 ytdlp_error_not_found = ilo yt-dlp li lon ala. o toki lipu: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ilo ffmpeg li lon ala lon PATH. o pana e ona tawa ni: ilo yt-dlp li ken pali e ante pini.
 ytdlp_error_start = yt-dlp li ike open: { $error }
 ytdlp_error_exit = yt-dlp li weka: { $status }
+ytdlp_error_duplicate_active = URL ni li lon pali jo.
+ytdlp_error_output_not_directory = nasin pi weka lipu li tomo ala: { $path }
+ytdlp_error_output_prepare = ken ala pona e tomo pi weka lipu: { $error }
+ytdlp_error_output_not_writable = ken ala sitelen tawa tomo pi weka lipu: { $path }
 
 channel_mode = nasin kalama
 channel_mode_stereo = kalama tu

--- a/locales/tr.ftl
+++ b/locales/tr.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = İşleniyor…
 ytdlp_status_completed = Tamamlandı
 ytdlp_status_waiting = Bekleniyor…
 ytdlp_error_not_found = yt-dlp PATH içinde bulunamadı. Buradan indirin: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg PATH içinde bulunamadı. yt-dlp son işlemenin çalışması için yükleyin.
 ytdlp_error_start = yt-dlp başlatılamadı: { $error }
 ytdlp_error_exit = yt-dlp sonlandı: { $status }
+ytdlp_error_duplicate_active = Bu URL zaten indiriliyor.
+ytdlp_error_output_not_directory = Çıkış yolu bir klasör değil: { $path }
+ytdlp_error_output_prepare = Çıkış klasörü hazırlanamadı: { $error }
+ytdlp_error_output_not_writable = Çıkış klasörüne yazılamıyor: { $path }
 
 channel_mode = Kanal Modu
 channel_mode_stereo = Stereo

--- a/locales/uk.ftl
+++ b/locales/uk.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = Обробка...
 ytdlp_status_completed = Завершено
 ytdlp_status_waiting = Очікування...
 ytdlp_error_not_found = yt-dlp не знайдено у PATH. Встановіть його: https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = ffmpeg не знайдено у PATH. Встановіть його, щоб післяобробка yt-dlp працювала.
 ytdlp_error_start = Помилка запуску yt-dlp: { $error }
 ytdlp_error_exit = yt-dlp завершив роботу: { $status }
+ytdlp_error_duplicate_active = Ця URL-адреса вже завантажується.
+ytdlp_error_output_not_directory = Шлях виводу не є каталогом: { $path }
+ytdlp_error_output_prepare = Не вдалося підготувати каталог виводу: { $error }
+ytdlp_error_output_not_writable = Каталог виводу недоступний для запису: { $path }
 
 channel_mode = Режим каналу
 channel_mode_stereo = Стерео

--- a/locales/zh-CN.ftl
+++ b/locales/zh-CN.ftl
@@ -291,8 +291,13 @@ ytdlp_status_processing = 正在处理…
 ytdlp_status_completed = 已完成
 ytdlp_status_waiting = 等待中…
 ytdlp_error_not_found = PATH 中未找到 yt-dlp。请安装：https://github.com/yt-dlp/yt-dlp
+ytdlp_error_ffmpeg_not_found = PATH 中未找到 ffmpeg。请安装它以便 yt-dlp 的后处理正常工作。
 ytdlp_error_start = 启动 yt-dlp 失败：{ $error }
 ytdlp_error_exit = yt-dlp 返回状态异常：{ $status }
+ytdlp_error_duplicate_active = 此 URL 已在下载中。
+ytdlp_error_output_not_directory = 输出路径不是目录：{ $path }
+ytdlp_error_output_prepare = 准备输出目录失败：{ $error }
+ytdlp_error_output_not_writable = 输出目录不可写：{ $path }
 
 channel_mode = 声道模式
 channel_mode_stereo = 立体声

--- a/pages/src/ytdlp.rs
+++ b/pages/src/ytdlp.rs
@@ -1,6 +1,8 @@
 use config::{AppConfig, YtdlpOptions};
 use dioxus::prelude::*;
+use std::fs::{self, OpenOptions};
 use std::io::BufRead;
+use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct DownloadJob {
@@ -107,26 +109,101 @@ fn find_ytdlp() -> String {
         }
     }
 
-    let extra_path = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
-    if let Ok(out) = std::process::Command::new("sh")
-        .args(["-c", "which yt-dlp"])
-        .env(
-            "PATH",
-            format!(
-                "{}:{}",
-                extra_path,
-                std::env::var("PATH").unwrap_or_default()
-            ),
-        )
-        .output()
-    {
-        let found = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        if !found.is_empty() && std::path::Path::new(&found).exists() {
-            return found;
-        }
+    if let Some(found) = find_in_augmented_path("yt-dlp") {
+        return found;
     }
 
     "yt-dlp".to_string()
+}
+
+fn augmented_path() -> String {
+    format!(
+        "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:{}",
+        std::env::var("PATH").unwrap_or_default()
+    )
+}
+
+fn find_in_augmented_path(binary: &str) -> Option<String> {
+    let binary_path = Path::new(binary);
+    if binary_path.is_absolute() && binary_path.exists() {
+        return Some(binary.to_string());
+    }
+
+    let candidates = vec![binary.to_string()];
+    #[cfg(target_os = "windows")]
+    if !binary.ends_with(".exe") {
+        candidates.push(format!("{binary}.exe"));
+    }
+
+    for dir in std::env::split_paths(&augmented_path()) {
+        for candidate in &candidates {
+            let path = dir.join(candidate);
+            if path.exists() {
+                return Some(path.to_string_lossy().into_owned());
+            }
+        }
+    }
+
+    None
+}
+
+fn validate_output_directory(out_dir: &str) -> Result<(), String> {
+    let trimmed = out_dir.trim();
+    if trimmed.is_empty() {
+        return Ok(());
+    }
+
+    let path = PathBuf::from(trimmed);
+    if path.exists() && !path.is_dir() {
+        return Err(i18n::t_with(
+            "ytdlp_error_output_not_directory",
+            &[("path", trimmed.to_string())],
+        ));
+    }
+
+    fs::create_dir_all(&path).map_err(|error| {
+        i18n::t_with(
+            "ytdlp_error_output_prepare",
+            &[("error", error.to_string())],
+        )
+    })?;
+
+    let probe_path = path.join(format!(".kopuz-write-test-{}", uuid::Uuid::new_v4()));
+    OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe_path)
+        .map_err(|_| {
+            i18n::t_with(
+                "ytdlp_error_output_not_writable",
+                &[("path", trimmed.to_string())],
+            )
+        })?;
+    let _ = fs::remove_file(probe_path);
+
+    Ok(())
+}
+
+fn run_preflight_checks(url: &str, out_dir: &str, jobs: &[DownloadJob]) -> Result<(), String> {
+    if jobs.iter().any(|job| {
+        job.url.trim() == url
+            && matches!(
+                job.status,
+                JobStatus::Pending | JobStatus::Downloading | JobStatus::Processing
+            )
+    }) {
+        return Err(i18n::t("ytdlp_error_duplicate_active"));
+    }
+
+    if find_in_augmented_path(&find_ytdlp()).is_none() {
+        return Err(i18n::t("ytdlp_error_not_found"));
+    }
+
+    if find_in_augmented_path("ffmpeg").is_none() {
+        return Err(i18n::t("ytdlp_error_ffmpeg_not_found"));
+    }
+
+    validate_output_directory(out_dir)
 }
 
 fn build_command(
@@ -137,12 +214,7 @@ fn build_command(
 ) -> std::process::Command {
     let binary = find_ytdlp();
     let mut cmd = std::process::Command::new(&binary);
-
-    let augmented_path = format!(
-        "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:{}",
-        std::env::var("PATH").unwrap_or_default()
-    );
-    cmd.env("PATH", augmented_path);
+    cmd.env("PATH", augmented_path());
 
     cmd.arg("--newline")
         .arg("--no-warnings")
@@ -323,6 +395,7 @@ pub fn YtdlpPage(config: Signal<AppConfig>, mut trigger_rescan: Signal<usize>) -
     let mut jobs = use_signal(|| Vec::<DownloadJob>::new());
     let mut out_dir = use_signal(|| config.peek().ytdlp_output_dir.clone());
     let mut show_opts = use_signal(|| false);
+    let mut preflight_error = use_signal(|| Option::<String>::None);
 
     use_hook(move || {
         let history = config.peek().ytdlp_history.clone();
@@ -350,6 +423,13 @@ pub fn YtdlpPage(config: Signal<AppConfig>, mut trigger_rescan: Signal<usize>) -
     let mut do_download = move || {
         let url = url_input().trim().to_string();
         if url.is_empty() {
+            return;
+        }
+
+        preflight_error.set(None);
+
+        if let Err(error) = run_preflight_checks(&url, &out_dir(), &jobs.read()) {
+            preflight_error.set(Some(error));
             return;
         }
 
@@ -528,7 +608,10 @@ pub fn YtdlpPage(config: Signal<AppConfig>, mut trigger_rescan: Signal<usize>) -
                     class: "flex-1 bg-white/5 border border-white/10 rounded-xl px-4 py-3 text-white placeholder-slate-500 focus:outline-none focus:border-white/30 transition-colors text-sm",
                     placeholder: "{i18n::t(\"ytdlp_url_placeholder\")}",
                     value: "{url_input}",
-                    oninput: move |e| url_input.set(e.value()),
+                    oninput: move |e| {
+                        preflight_error.set(None);
+                        url_input.set(e.value());
+                    },
                     onkeydown: move |e| {
                         if e.key() == dioxus::prelude::Key::Enter { do_download(); }
                     }
@@ -555,6 +638,13 @@ pub fn YtdlpPage(config: Signal<AppConfig>, mut trigger_rescan: Signal<usize>) -
                 }
             }
 
+            if let Some(error) = preflight_error.read().clone() {
+                div { class: "mb-4 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-200 whitespace-pre-wrap",
+                    i { class: "fa-solid fa-triangle-exclamation mr-2 text-red-300" }
+                    "{error}"
+                }
+            }
+
             div { class: "flex items-center gap-2 mb-5",
                 i { class: "fa-solid fa-folder text-slate-600 text-sm shrink-0" }
                 input {
@@ -562,6 +652,7 @@ pub fn YtdlpPage(config: Signal<AppConfig>, mut trigger_rescan: Signal<usize>) -
                     placeholder: "{i18n::t(\"ytdlp_output_dir_placeholder\")}",
                     value: "{out_dir}",
                     oninput: move |e| {
+                        preflight_error.set(None);
                         out_dir.set(e.value());
                         config.write().ytdlp_output_dir = e.value();
                     }

--- a/pages/src/ytdlp.rs
+++ b/pages/src/ytdlp.rs
@@ -129,7 +129,7 @@ fn find_in_augmented_path(binary: &str) -> Option<String> {
         return Some(binary.to_string());
     }
 
-    let candidates = vec![binary.to_string()];
+    let mut candidates = vec![binary.to_string()];
     #[cfg(target_os = "windows")]
     if !binary.ends_with(".exe") {
         candidates.push(format!("{binary}.exe"));


### PR DESCRIPTION
Adds downloader preflight validation to the yt-dlp page. Before starting a job, Kopuz now checks for required binaries (yt-dlp and ffmpeg), verifies that the output path exists and is writable, and blocks duplicate active downloads for the same URL. The page also shows inline error messages instead of creating broken download jobs when these checks fail.

<img width="500" height="205" alt="image" src="https://github.com/user-attachments/assets/589a7e71-5168-45f8-98c1-385cb84c05ea" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preflight validation before starting downloads: blocks duplicates, detects missing ffmpeg/yt-dlp, and validates/prepares output directories; errors are shown in the UI.

* **Localization**
  * Expanded download-related error messages across many languages (added ffmpeg, duplicate-download, output-path/prep/writability errors).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/174)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->