### PR TITLE
fix : Moved package-level Cargo profiles to the workspace root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,4 +54,22 @@ discord-presence = { path = "./discord-presence" }
 scrobble = { path = "./scrobble" }
 
 [profile.release]
-strip = "debuginfo"
+strip = "symbols"
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+panic = "abort"
+
+[profile.dev.package."*"]
+opt-level = 3
+
+[profile.wasm-dev]
+inherits = "dev"
+opt-level = 1
+
+[profile.server-dev]
+inherits = "dev"
+
+[profile.android-dev]
+inherits = "dev"
+

--- a/kopuz/Cargo.toml
+++ b/kopuz/Cargo.toml
@@ -74,24 +74,3 @@ winres = "0.1"
 
 [features]
 default = []
-
-[profile]
-[profile.dev.package."*"]
-opt-level = 3
-
-[profile.release]
-opt-level = 3
-lto = "thin"
-codegen-units = 1
-strip = "symbols"
-panic = "abort"
-
-[profile.wasm-dev]
-inherits = "dev"
-opt-level = 1
-
-[profile.server-dev]
-inherits = "dev"
-
-[profile.android-dev]
-inherits = "dev"


### PR DESCRIPTION
Fix workspace Cargo profiles

Moved Cargo profile settings from the kopuz crate to the workspace root so they are applied correctly during workspace builds.

Fixes #145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Optimized build profiles for improved runtime performance and compilation efficiency
  - Enhanced release build with aggressive code optimization and reduced binary size
  - Configured panic behavior to abort in release builds for consistent error handling
  - Introduced platform-specific development profiles for various target environments
  - Updated default feature configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/175)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->