### PR TITLE
feat(queue): add add-to-queue action

### DIFF
--- a/components/src/folder_detail.rs
+++ b/components/src/folder_detail.rs
@@ -39,6 +39,8 @@ pub fn FolderDetail(
 
     drop(lib);
 
+    let _ = config;
+
     rsx! {
         crate::track_list_view::TrackListView {
             name: folder_name,

--- a/components/src/playlist_detail.rs
+++ b/components/src/playlist_detail.rs
@@ -129,8 +129,7 @@ pub fn PlaylistDetail(
                                         user_id,
                                         token,
                                     );
-                                    if let Ok(items) =
-                                        remote.get_playlist_entries(&pid_clone).await
+                                    if let Ok(items) = remote.get_playlist_entries(&pid_clone).await
                                     {
                                         let mut new_tracks = Vec::new();
                                         for item in items {
@@ -177,10 +176,7 @@ pub fn PlaylistDetail(
                                                 album: item.album.unwrap_or_default(),
                                                 duration: item.duration.unwrap_or(0),
                                                 khz: item.sampling_rate.unwrap_or(0),
-                                                bitrate: item
-                                                    .bit_rate
-                                                    .unwrap_or(0)
-                                                    .min(255) as u8,
+                                                bitrate: item.bit_rate.unwrap_or(0).min(255) as u8,
                                                 track_number: item.track,
                                                 disc_number: item.disc_number,
                                                 musicbrainz_release_id: None,

--- a/components/src/search_genre_detail.rs
+++ b/components/src/search_genre_detail.rs
@@ -53,7 +53,7 @@ pub fn SearchGenreDetail(
                  div {
                      h2 { class: "text-sm font-bold text-white/60 uppercase tracking-widest mb-2", "{i18n::t(\"genre\")}" }
                      h1 { class: "text-5xl font-bold text-white mb-4", "{genre}" }
-                     p { class: "text-slate-400", 
+                     p { class: "text-slate-400",
                          {
                              if genre_tracks.len() == 1 {
                                  i18n::t("track_count_singular").to_string()
@@ -72,6 +72,7 @@ pub fn SearchGenreDetail(
                          let track_key = track.path.display().to_string();
                          let track_menu = track.clone();
                          let track_add = track.clone();
+                         let track_queue = track.clone();
                          let track_delete = track.clone();
                          let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
                          let genre_tracks_list: Vec<Track> = genre_tracks.iter().map(|(t, _)| t.clone()).collect();
@@ -108,6 +109,10 @@ pub fn SearchGenreDetail(
                                  on_add_to_playlist: move |_| {
                                      selected_track_for_playlist.set(Some(track_add.path.clone()));
                                      show_playlist_modal.set(true);
+                                     active_menu_track.set(None);
+                                 },
+                                 on_queue: move |_| {
+                                     queue.write().push(track_queue.clone());
                                      active_menu_track.set(None);
                                  },
                                  on_close_menu: move |_| active_menu_track.set(None),

--- a/components/src/search_results.rs
+++ b/components/src/search_results.rs
@@ -42,6 +42,7 @@ pub fn SearchResults(
                                 let track_key = track.path.display().to_string();
                                 let track_menu = track.clone();
                                 let track_add = track.clone();
+                                let track_queue = track.clone();
                                 let track_delete = track.clone();
                                 let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
                                 let search_queue: Vec<Track> = tracks.iter().map(|(t, _)| t.clone()).collect();
@@ -78,6 +79,10 @@ pub fn SearchResults(
                                         on_add_to_playlist: move |_| {
                                             selected_track_for_playlist.set(Some(track_add.path.clone()));
                                             show_playlist_modal.set(true);
+                                            active_menu_track.set(None);
+                                        },
+                                        on_queue: move |_| {
+                                            queue.write().push(track_queue.clone());
                                             active_menu_track.set(None);
                                         },
                                         on_close_menu: move |_| active_menu_track.set(None),

--- a/components/src/showcase.rs
+++ b/components/src/showcase.rs
@@ -14,6 +14,7 @@ pub struct ShowcaseProps {
     pub tracks: Vec<Track>,
     pub library: Signal<Library>,
     pub on_play: EventHandler<usize>,
+    pub on_queue: Option<EventHandler<usize>>,
     pub on_add_to_playlist: Option<EventHandler<usize>>,
     pub on_delete_track: Option<EventHandler<usize>>,
     pub on_remove_from_playlist: Option<EventHandler<usize>>,
@@ -265,9 +266,14 @@ pub fn Showcase(props: ShowcaseProps) -> Element {
                                                 }
                                              },
                                              on_add_to_playlist: move |_| {
-                                                if let Some(handler) = &props.on_add_to_playlist {
-                                                    handler.call(idx);
-                                                }
+                                                 if let Some(handler) = &props.on_add_to_playlist {
+                                                     handler.call(idx);
+                                                 }
+                                             },
+                                             on_queue: move |_| {
+                                                 if let Some(handler) = &props.on_queue {
+                                                     handler.call(idx);
+                                                 }
                                              },
                                              on_close_menu: move |_| {
                                                 if let Some(handler) = &props.on_close_menu {

--- a/components/src/track_list_view.rs
+++ b/components/src/track_list_view.rs
@@ -48,6 +48,7 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
     let tracks_select = props.tracks.clone();
     let tracks_play = props.tracks.clone();
     let tracks_add = props.tracks.clone();
+    let tracks_queue = props.tracks.clone();
     let tracks_menu = props.tracks.clone();
     let tracks_sel_delete = props.tracks.clone();
 
@@ -110,6 +111,12 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
                     if let Some(t) = tracks_add.get(idx) {
                         selected_track_for_playlist.set(Some(t.path.clone()));
                         show_playlist_modal.set(true);
+                        active_menu_track.set(None);
+                    }
+                },
+                on_queue: move |idx: usize| {
+                    if let Some(t) = tracks_queue.get(idx) {
+                        ctrl.queue.write().push(t.clone());
                         active_menu_track.set(None);
                     }
                 },

--- a/components/src/track_row.rs
+++ b/components/src/track_row.rs
@@ -26,6 +26,7 @@ pub fn TrackRow(
     on_click_menu: EventHandler<()>,
     is_menu_open: bool,
     on_add_to_playlist: EventHandler<()>,
+    on_queue: Option<EventHandler<()>>,
     on_close_menu: EventHandler<()>,
     on_play: EventHandler<()>,
     on_delete: EventHandler<()>,
@@ -39,14 +40,25 @@ pub fn TrackRow(
     #[props(default = false)] is_downloaded: bool,
     #[props(default = false)] is_downloading: bool,
 ) -> Element {
+    let add_to_queue_text = i18n::t("add_to_queue").to_string();
     let add_to_playlist_text = i18n::t("add_to_playlist").to_string();
     let remove_from_playlist_text = i18n::t("remove_from_playlist").to_string();
     let delete_song_text = i18n::t("delete").to_string();
 
-    let mut actions = vec![MenuAction::new(
+    let mut actions = Vec::new();
+
+    let has_queue = on_queue.is_some();
+    if has_queue {
+        actions.push(MenuAction::new(
+            add_to_queue_text.as_str(),
+            "fa-solid fa-list-ul",
+        ));
+    }
+
+    actions.push(MenuAction::new(
         add_to_playlist_text.as_str(),
         "fa-solid fa-plus",
-    )];
+    ));
 
     let has_remove = on_remove_from_playlist.is_some();
     if has_remove {
@@ -76,11 +88,22 @@ pub fn TrackRow(
         actions.push(MenuAction::new(delete_song_text.as_str(), "fa-solid fa-trash").destructive());
     }
 
-    let download_action_idx = if has_remove { 2 } else { 1 };
+    let add_to_queue_idx = if has_queue { Some(0) } else { None };
+    let add_to_playlist_idx = if has_queue { 1 } else { 0 };
+    let remove_action_idx = if has_remove {
+        Some(add_to_playlist_idx + 1)
+    } else {
+        None
+    };
+    let download_action_idx = if has_download {
+        add_to_playlist_idx + 1 + usize::from(has_remove)
+    } else {
+        0
+    };
     let delete_action_idx = if has_download {
         download_action_idx + 1
     } else {
-        download_action_idx
+        add_to_playlist_idx + 1 + usize::from(has_remove)
     };
 
     let mut long_press_task = use_signal(|| None);
@@ -192,11 +215,22 @@ pub fn TrackRow(
                     button_class: "opacity-0 group-hover:opacity-100 focus:opacity-100".to_string(),
                     anchor: "right".to_string(),
                     on_action: move |idx: usize| {
-                        if idx == 0 {
+                        if let Some(queue_idx) = add_to_queue_idx {
+                            if idx == queue_idx {
+                                if let Some(handler) = on_queue {
+                                    handler.call(());
+                                }
+                                return;
+                            }
+                        }
+
+                        if idx == add_to_playlist_idx {
                             on_add_to_playlist.call(());
-                        } else if has_remove && idx == 1 {
-                            if let Some(handler) = on_remove_from_playlist {
-                                handler.call(());
+                        } else if let Some(remove_idx) = remove_action_idx {
+                            if idx == remove_idx {
+                                if let Some(handler) = on_remove_from_playlist {
+                                    handler.call(());
+                                }
                             }
                         } else if has_download && idx == download_action_idx {
                             if let Some(handler) = on_download {

--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -117,6 +117,7 @@ delete = Delete
 delete_song = Delete Song
 delete_album = Delete Album
 delete_playlist = Delete Playlist
+add_all_to_queue = Add All to Queue
 add_all_to_playlist = Add All to Playlist
 select_all = Select all
 select_all_tracks = Select all tracks

--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -110,6 +110,7 @@ ytdlp_error_output_not_writable = Output directory is not writable: { $path }
 # UI Actions & Buttons
 add_to_favorites = Add to Favorites
 remove_from_favorites = Remove from Favorites
+add_to_queue = Add to Queue
 add_to_playlist = Add to Playlist
 remove_from_playlist = Remove from Playlist
 delete = Delete

--- a/pages/src/local/album.rs
+++ b/pages/src/local/album.rs
@@ -116,7 +116,7 @@ pub fn LocalAlbum(
                                                                 .read()
                                                                 .tracks
                                                                 .iter()
-                                                                .filter(|t| t.album == title)
+                                                                .filter(|t| t.album_id == id)
                                                                 .cloned()
                                                                 .collect();
                                                             tracks_for_queue.sort_by(|a, b| {

--- a/pages/src/local/album.rs
+++ b/pages/src/local/album.rs
@@ -32,11 +32,13 @@ pub fn LocalAlbum(
         unique_albums
     });
 
+    let add_all_to_queue_text = i18n::t("add_all_to_queue").to_string();
     let add_all_to_playlist_text = i18n::t("add_all_to_playlist").to_string();
     let delete_album_text = i18n::t("delete_album").to_string();
 
     let album_menu_actions = vec![
-        MenuAction::new(add_all_to_playlist_text.as_str(), "fa-solid fa-list-music"),
+        MenuAction::new(add_all_to_queue_text.as_str(), "fa-solid fa-list-ul"),
+        MenuAction::new(add_all_to_playlist_text.as_str(), "fa-solid fa-plus"),
         MenuAction::new(delete_album_text.as_str(), "fa-solid fa-trash").destructive(),
     ];
 
@@ -110,10 +112,25 @@ pub fn LocalAlbum(
                                                     open_album_menu.set(None);
                                                     match idx {
                                                         0 => {
+                                                            let mut tracks_for_queue: Vec<_> = library
+                                                                .read()
+                                                                .tracks
+                                                                .iter()
+                                                                .filter(|t| t.album == title)
+                                                                .cloned()
+                                                                .collect();
+                                                            tracks_for_queue.sort_by(|a, b| {
+                                                                a.track_number
+                                                                    .cmp(&b.track_number)
+                                                                    .then_with(|| a.title.cmp(&b.title))
+                                                            });
+                                                            queue.write().extend(tracks_for_queue);
+                                                        }
+                                                        1 => {
                                                             pending_album_id_for_playlist.set(Some(id.clone()));
                                                             show_album_playlist_modal.set(true);
                                                         }
-                                                        1 => {
+                                                        2 => {
                                                             let tracks_to_delete: Vec<_> = library
                                                                 .read()
                                                                 .tracks

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -358,40 +358,46 @@ pub fn LocalArtist(
                                                                         open_album_menu.set(None);
                                                                         match idx {
                                                                             0 => {
-                                                                                                                                        let mut tracks_for_queue: Vec<_> = library
-                                                                                                                                            .read()
-                                                                                                                                            .tracks
-                                                                                                                                            .iter()
-                                                                                                                                            .filter(|t| t.album == title)
-                                                                                                                                            .cloned()
-                                                                                                                                            .collect();
-                                                                                                                                        tracks_for_queue.sort_by(|a, b| {
-                                                                                                                                            a.track_number
-                                                                                                                                                .cmp(&b.track_number)
-                                                                                                                                                .then_with(|| a.title.cmp(&b.title))
-                                                                                                                                        });
-                                                                                                                                        queue.write().extend(tracks_for_queue);
-                                                                                                                                    }
-                                                                                                                                    1 => {
-                                                                                                                                        pending_album_id_for_playlist.set(Some(id.clone()));
-                                                                                                                                        show_album_playlist_modal.set(true);
-                                                                                                                                    }
-                                                                                                                                    2 => {
-                                                                                                                                        let tracks_to_delete: Vec<_> = library
-                                                                                                                                            .read()
-                                                                                                                                            .tracks
-                                                                                                                                            .iter()
-                                                                                                                                            .filter(|t| t.album == title)
-                                                                                                                                            .map(|t| t.path.clone())
-                                                                                                                                            .collect();
-                                                                                                                                        for path in &tracks_to_delete {
-                                                                                                                                            let _ = std::fs::remove_file(path);
-                                                                                                                                        }
-                                                                                                                                        let mut lib = library.write();
-                                                                                                                                        lib.albums.retain(|a| a.title != title);
-                                                                                                                                        lib.tracks.retain(|t| t.album != title);
-                                                                                                                                    }
-                                                                                                                                    _ => {}
+                                                                                let mut tracks_for_queue: Vec<_> = library
+                                                                                    .read()
+                                                                                    .tracks
+                                                                                    .iter()
+                                                                                    .filter(|t| t.album_id == id)
+                                                                                    .cloned()
+                                                                                    .collect();
+
+                                                                                tracks_for_queue.sort_by(|a, b| {
+                                                                                    a.track_number
+                                                                                        .cmp(&b.track_number)
+                                                                                        .then_with(|| a.title.cmp(&b.title))
+                                                                                });
+
+                                                                                queue.write().extend(tracks_for_queue);
+                                                                            }
+                                                                            1 => {
+                                                                                pending_album_id_for_playlist.set(Some(id.clone()));
+                                                                                show_album_playlist_modal.set(true);
+                                                                            }
+                                                                            2 => {
+                                                                                let tracks_to_delete: Vec<_> = library
+                                                                                    .read()
+                                                                                    .tracks
+                                                                                    .iter()
+                                                                                    .filter(|t| t.album == title)
+                                                                                    .map(|t| t.path.clone())
+                                                                                    .collect();
+
+                                                                                for path in &tracks_to_delete {
+                                                                                    let _ = std::fs::remove_file(path);
+                                                                                }
+
+                                                                                let mut lib = library.write();
+
+                                                                                lib.albums.retain(|a| a.title != title);
+                                                                                lib.tracks.retain(|t| t.album != title);
+                                                                            }
+
+                                                                            _ => {}
                                                                         }
                                                                     }
                                                                 },

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -451,6 +451,12 @@ pub fn LocalArtist(
                                         active_menu_track.set(None);
                                     }
                                 },
+                                on_queue: move |idx: usize| {
+                                    if let Some(track) = artist_tracks().get(idx) {
+                                        queue.write().push(track.clone());
+                                        active_menu_track.set(None);
+                                    }
+                                },
                                 on_delete_track: move |idx: usize| {
                                     if let Some(track) = artist_tracks().get(idx) {
                                         if std::fs::remove_file(&track.path).is_ok() {

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -291,10 +291,13 @@ pub fn LocalArtist(
                             p { class: "text-slate-500", "{i18n::t(\"no_albums_found\")}" }
                         } else {
                             {
+                                let add_all_to_queue_text = i18n::t("add_all_to_queue").to_string();
                                 let add_all_to_playlist_text = i18n::t("add_all_to_playlist").to_string();
                                 let delete_album_text = i18n::t("delete_album").to_string();
+
                                 let album_menu_actions = vec![
-                                    MenuAction::new(add_all_to_playlist_text.as_str(), "fa-solid fa-list-music"),
+                                    MenuAction::new(add_all_to_queue_text.as_str(), "fa-solid fa-list-ul"),
+                                    MenuAction::new(add_all_to_playlist_text.as_str(), "fa-solid fa-plus"),
                                     MenuAction::new(delete_album_text.as_str(), "fa-solid fa-trash").destructive(),
                                 ];
                                 rsx! {
@@ -303,6 +306,7 @@ pub fn LocalArtist(
                                             {
                                                 let id_for_menu = album.id.clone();
                                                 let id_for_action = album.id.clone();
+                                                let title_for_action = album.title.clone();
                                                 let is_open = open_album_menu.read().as_deref() == Some(&album.id);
                                                 let cover_url = utils::format_artwork_url(album.cover_path.as_ref());
                                                 rsx! {
@@ -349,29 +353,45 @@ pub fn LocalArtist(
                                                                 anchor: "right".to_string(),
                                                                 on_action: {
                                                                     let id = id_for_action.clone();
+                                                                    let title = title_for_action.clone();
                                                                     move |idx: usize| {
                                                                         open_album_menu.set(None);
                                                                         match idx {
                                                                             0 => {
-                                                                                pending_album_id_for_playlist.set(Some(id.clone()));
-                                                                                show_album_playlist_modal.set(true);
-                                                                            }
-                                                                            1 => {
-                                                                                let tracks_to_delete: Vec<_> = library
-                                                                                    .read()
-                                                                                    .tracks
-                                                                                    .iter()
-                                                                                    .filter(|t| t.album_id == id)
-                                                                                    .map(|t| t.path.clone())
-                                                                                    .collect();
-                                                                                for path in &tracks_to_delete {
-                                                                                    let _ = std::fs::remove_file(path);
-                                                                                }
-                                                                                let mut lib = library.write();
-                                                                                lib.albums.retain(|a| a.id != id);
-                                                                                lib.tracks.retain(|t| t.album_id != id);
-                                                                            }
-                                                                            _ => {}
+                                                                                                                                        let mut tracks_for_queue: Vec<_> = library
+                                                                                                                                            .read()
+                                                                                                                                            .tracks
+                                                                                                                                            .iter()
+                                                                                                                                            .filter(|t| t.album == title)
+                                                                                                                                            .cloned()
+                                                                                                                                            .collect();
+                                                                                                                                        tracks_for_queue.sort_by(|a, b| {
+                                                                                                                                            a.track_number
+                                                                                                                                                .cmp(&b.track_number)
+                                                                                                                                                .then_with(|| a.title.cmp(&b.title))
+                                                                                                                                        });
+                                                                                                                                        queue.write().extend(tracks_for_queue);
+                                                                                                                                    }
+                                                                                                                                    1 => {
+                                                                                                                                        pending_album_id_for_playlist.set(Some(id.clone()));
+                                                                                                                                        show_album_playlist_modal.set(true);
+                                                                                                                                    }
+                                                                                                                                    2 => {
+                                                                                                                                        let tracks_to_delete: Vec<_> = library
+                                                                                                                                            .read()
+                                                                                                                                            .tracks
+                                                                                                                                            .iter()
+                                                                                                                                            .filter(|t| t.album == title)
+                                                                                                                                            .map(|t| t.path.clone())
+                                                                                                                                            .collect();
+                                                                                                                                        for path in &tracks_to_delete {
+                                                                                                                                            let _ = std::fs::remove_file(path);
+                                                                                                                                        }
+                                                                                                                                        let mut lib = library.write();
+                                                                                                                                        lib.albums.retain(|a| a.title != title);
+                                                                                                                                        lib.tracks.retain(|t| t.album != title);
+                                                                                                                                    }
+                                                                                                                                    _ => {}
                                                                         }
                                                                     }
                                                                 },

--- a/pages/src/local/favorites.rs
+++ b/pages/src/local/favorites.rs
@@ -65,6 +65,7 @@ pub fn LocalFavorites(
                 let track_path = track.path.clone();
                 let track_select = track.path.clone();
                 let track_add = track.clone();
+                let track_queue = track.clone();
                 let track_delete = track.clone();
                 let queue_source = queue_tracks.clone();
                 let track_key = format!("{}-{}", track.path.display(), idx);
@@ -106,6 +107,10 @@ pub fn LocalFavorites(
                         on_add_to_playlist: move |_| {
                             selected_track_for_playlist.set(Some(track_add.path.clone()));
                             show_playlist_modal.set(true);
+                            active_menu_track.set(None);
+                        },
+                        on_queue: move |_| {
+                            queue.write().push(track_queue.clone());
                             active_menu_track.set(None);
                         },
                         on_close_menu: move |_| active_menu_track.set(None),

--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -107,6 +107,7 @@ pub fn LocalLibrary(
             let track = track.clone();
             let track_menu = track.clone();
             let track_add = track.clone();
+            let track_queue = track.clone();
             let track_delete = track.clone();
             let track_path = track.path.clone();
             let track_select = track.path.clone();
@@ -151,6 +152,10 @@ div {
                         on_add_to_playlist: move |_| {
                             selected_track_for_playlist.set(Some(track_add.path.clone()));
                             show_playlist_modal.set(true);
+                            active_menu_track.set(None);
+                        },
+                        on_queue: move |_| {
+                            queue.write().push(track_queue.clone());
                             active_menu_track.set(None);
                         },
                         on_close_menu: move |_| active_menu_track.set(None),

--- a/pages/src/server/album.rs
+++ b/pages/src/server/album.rs
@@ -93,11 +93,13 @@ pub fn JellyfinAlbum(
             .collect::<Vec<_>>()
     });
 
+    let add_all_to_queue_text = i18n::t("add_all_to_queue").to_string();
     let add_all_to_playlist_text = i18n::t("add_all_to_playlist").to_string();
     let remove_from_cache_text = i18n::t("remove_from_cache").to_string();
 
     let album_menu_actions = vec![
-        MenuAction::new(add_all_to_playlist_text.as_str(), "fa-solid fa-list-music"),
+        MenuAction::new(add_all_to_queue_text.as_str(), "fa-solid fa-list-ul"),
+        MenuAction::new(add_all_to_playlist_text.as_str(), "fa-solid fa-plus"),
         MenuAction::new(remove_from_cache_text.as_str(), "fa-solid fa-trash").destructive(),
     ];
 
@@ -162,10 +164,29 @@ pub fn JellyfinAlbum(
                                                     open_album_menu.set(None);
                                                     match idx {
                                                         0 => {
+                                                            let mut tracks_for_queue: Vec<_> = library
+                                                                .read()
+                                                                .jellyfin_tracks
+                                                                .iter()
+                                                                .filter(|t| t.album_id == id)
+                                                                .cloned()
+                                                                .collect();
+                                                            tracks_for_queue.sort_by(|a, b| {
+                                                                let disc_cmp =
+                                                                    a.disc_number.unwrap_or(1).cmp(&b.disc_number.unwrap_or(1));
+                                                                if disc_cmp == std::cmp::Ordering::Equal {
+                                                                    a.track_number.unwrap_or(0).cmp(&b.track_number.unwrap_or(0))
+                                                                } else {
+                                                                    disc_cmp
+                                                                }
+                                                            });
+                                                            queue.write().extend(tracks_for_queue);
+                                                        }
+                                                        1 => {
                                                             pending_album_id_for_playlist.set(Some(id.clone()));
                                                             show_album_playlist_modal.set(true);
                                                         }
-                                                        1 => {
+                                                        2 => {
                                                             let mut lib = library.write();
                                                             let title = lib.jellyfin_albums.iter()
                                                                 .find(|a| a.id == id)
@@ -600,6 +621,7 @@ pub fn JellyfinAlbumDetails(
                             let track_key = track.path.display().to_string();
                             let track_menu = track.clone();
                             let track_add  = track.clone();
+                            let track_queue = track.clone();
                             let track_path = track.path.clone();
                             let track_select = track.path.clone();
                             let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
@@ -653,6 +675,10 @@ pub fn JellyfinAlbumDetails(
                                     on_add_to_playlist: move |_| {
                                         selected_track_for_playlist.set(Some(track_add.path.clone()));
                                         show_playlist_modal.set(true);
+                                        active_menu_track.set(None);
+                                    },
+                                    on_queue: move |_| {
+                                        queue.write().push(track_queue.clone());
                                         active_menu_track.set(None);
                                     },
                                     on_close_menu: move |_| active_menu_track.set(None),

--- a/pages/src/server/artist.rs
+++ b/pages/src/server/artist.rs
@@ -712,6 +712,12 @@ pub fn JellyfinArtist(
                                         active_menu_track.set(None);
                                     }
                                 },
+                                on_queue: move |idx: usize| {
+                                    if let Some(track) = artist_tracks().get(idx) {
+                                        queue.write().push(track.clone());
+                                        active_menu_track.set(None);
+                                    }
+                                },
                                 on_delete_track: move |_| active_menu_track.set(None),
                                 on_download_track: move |idx: usize| {
                                     if let Some(track) = artist_tracks().get(idx) {

--- a/pages/src/server/favorites.rs
+++ b/pages/src/server/favorites.rs
@@ -138,6 +138,7 @@ pub fn JellyfinFavorites(
             let track_path = track.path.clone();
             let track_select = track.path.clone();
             let track_add = track.clone();
+            let track_queue = track.clone();
             let queue_source = queue_tracks.clone();
             let track_key = format!("{}-{}", track.path.display(), idx);
             let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
@@ -190,6 +191,10 @@ pub fn JellyfinFavorites(
                     on_add_to_playlist: move |_| {
                         selected_track_for_playlist.set(Some(track_add.path.clone()));
                         show_playlist_modal.set(true);
+                        active_menu_track.set(None);
+                    },
+                    on_queue: move |_| {
+                        queue.write().push(track_queue.clone());
                         active_menu_track.set(None);
                     },
                     on_close_menu: move |_| active_menu_track.set(None),

--- a/pages/src/server/library.rs
+++ b/pages/src/server/library.rs
@@ -181,6 +181,7 @@ pub fn JellyfinLibrary(
         .map(|(idx, (track, cover_url))| {
             let track_menu = track.clone();
             let track_add = track.clone();
+            let track_queue = track.clone();
             let track_path = track.path.clone();
             let track_select = track.path.clone();
             let queue_arc = std::sync::Arc::clone(&queue_source);
@@ -238,6 +239,10 @@ pub fn JellyfinLibrary(
                     on_add_to_playlist: move |_| {
                         selected_track_for_playlist.set(Some(track_add.path.clone()));
                         show_playlist_modal.set(true);
+                        active_menu_track.set(None);
+                    },
+                    on_queue: move |_| {
+                        queue.write().push(track_queue.clone());
                         active_menu_track.set(None);
                     },
                     on_close_menu: move |_| active_menu_track.set(None),


### PR DESCRIPTION
small QoL improvements can change peoples lives :steamhappy:

this PR adds "Add to Queue" button for songs and albums

<img width="248" height="239" alt="image" src="https://github.com/user-attachments/assets/5636591b-9a62-42ce-8ade-575dd7afd359" />
<img width="394" height="354" alt="image" src="https://github.com/user-attachments/assets/cb9520b3-d3a9-4def-8cd6-603ddccb0a3f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add "Add to Queue" action to track menus across library, search, favorites, and server views.
  * Add "Add All to Queue" action for albums and artists.
  * Track/menu actions now enqueue items and automatically close the open track menu.

* **Localization**
  * Added UI strings for "Add to Queue" and "Add All to Queue".

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/180)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->