### PR TITLE
feat(shuffle): add album and artist on-play shuffle

### DIFF
--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -179,16 +179,24 @@ pub fn Rightbar(
             format!("{minutes}:{secs:02}")
         }
     };
-    let up_next_count = queue
-        .read()
-        .len()
-        .saturating_sub(*current_queue_index.read() + 1);
-    let up_next_duration: u64 = queue
-        .read()
-        .iter()
-        .skip(*current_queue_index.read() + 1)
-        .map(|track| track.duration)
-        .sum();
+    let is_shuffle = *ctrl.shuffle.read();
+    let up_next_items: Vec<(usize, reader::Track)> = {
+        let q = queue.read();
+        let current_idx = *current_queue_index.read();
+        if is_shuffle {
+            ctrl.shuffle_order
+                .read()
+                .iter()
+                .filter_map(|&qi| q.get(qi).map(|t| (qi, t.clone())))
+                .collect()
+        } else {
+            (current_idx + 1..q.len())
+                .filter_map(|qi| q.get(qi).map(|t| (qi, t.clone())))
+                .collect()
+        }
+    };
+    let up_next_count = up_next_items.len();
+    let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
     let up_next_summary = format!(
         "{} • {}",
         i18n::t_with("showcase_song_count", &[("count", up_next_count.to_string())]),
@@ -330,18 +338,20 @@ pub fn Rightbar(
                             "{up_next_summary}"
                         }
                     }
-                    for i in (*current_queue_index.read() + 1)..queue.read().len() {
+                    for (list_pos, (queue_idx, track)) in up_next_items.iter().enumerate() {
                         {
-                            let track = queue.read()[i].clone();
+                            let queue_idx = *queue_idx;
+                            let track = track.clone();
                             let cover_url = get_track_cover(&track);
-                            let can_move_up = i > *current_queue_index.read() + 1;
-                            let can_move_down = i + 1 < queue.read().len();
+                            let current_idx = *current_queue_index.read();
+                            let can_move_up = !is_shuffle && queue_idx > current_idx + 1;
+                            let can_move_down = !is_shuffle && queue_idx + 1 < queue.read().len();
                             rsx! {
                                 div {
-                                    key: "{i}",
+                                    key: "{list_pos}",
                                     class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
                                     style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                                    ondoubleclick: move |_| play_song_at_index(i),
+                                    ondoubleclick: move |_| play_song_at_index(queue_idx),
                                     div {
                                         class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
                                         style: "width: 40px; height: 40px;",
@@ -359,12 +369,14 @@ pub fn Rightbar(
                                         div { class: "text-sm text-white truncate font-medium", "{track.title}" }
                                         div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
                                     }
-                                    ReorderButtons {
-                                        can_move_up,
-                                        can_move_down,
-                                        class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
-                                        on_move_up: move |_| move_queue_item(i, i - 1),
-                                        on_move_down: move |_| move_queue_item(i, i + 1),
+                                    if !is_shuffle {
+                                        ReorderButtons {
+                                            can_move_up,
+                                            can_move_down,
+                                            class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
+                                            on_move_up: move |_| move_queue_item(queue_idx, queue_idx - 1),
+                                            on_move_down: move |_| move_queue_item(queue_idx, queue_idx + 1),
+                                        }
                                     }
                                 }
                             }

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -330,7 +330,7 @@ pub fn Rightbar(
                         }
                     }
                 } else if *active_tab.read() == 1 {
-                    if queue.read().len() <= *current_queue_index.read() + 1 {
+                    if up_next_items.is_empty() {
                         div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
                     } else {
                         div {

--- a/components/src/showcase.rs
+++ b/components/src/showcase.rs
@@ -2,6 +2,7 @@ use crate::reorder_buttons::ReorderButtons;
 use crate::track_row::TrackRow;
 use config::{AppConfig, MusicService, MusicSource};
 use dioxus::prelude::*;
+use hooks::use_player_controller::PlayerController;
 use reader::{Library, Track};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -13,6 +14,7 @@ pub struct ShowcaseProps {
     pub cover_url: Option<utils::CoverUrl>,
     pub tracks: Vec<Track>,
     pub library: Signal<Library>,
+    pub on_play_all: EventHandler<()>,
     pub on_play: EventHandler<usize>,
     pub on_add_to_playlist: Option<EventHandler<usize>>,
     pub on_delete_track: Option<EventHandler<usize>>,
@@ -46,6 +48,7 @@ pub struct ShowcaseProps {
 
 #[component]
 pub fn Showcase(props: ShowcaseProps) -> Element {
+    let mut ctrl = use_context::<PlayerController>();
     let config = use_context::<Signal<AppConfig>>();
     let total_seconds: u64 = props.tracks.iter().map(|t| t.duration).sum();
     let duration_min = total_seconds / 60;
@@ -112,9 +115,19 @@ pub fn Showcase(props: ShowcaseProps) -> Element {
 
                 div { class: "flex items-center gap-4",
                      if !props.tracks.is_empty() {
-                         button {
+                        button {
+                            class: format!("w-14 h-14 rounded-full flex items-center justify-center {}", if *ctrl.shuffle.read() { "text-white" } else { "text-slate-400 hover:text-white" }),
+                            title: if *ctrl.shuffle.read() {
+                                i18n::t("shuffle_on").to_string()
+                            } else {
+                                i18n::t("shuffle_off").to_string()
+                            },
+                            onclick: move |_| ctrl.toggle_shuffle(),
+                            i { class: "fa-solid fa-shuffle text-xl ml-1" }
+                        }
+                        button {
                              class: "w-14 h-14 rounded-full bg-indigo-500 hover:bg-indigo-400 text-black flex items-center justify-center transition-transform hover:scale-105",
-                             onclick: move |_| props.on_play.call(0),
+                             onclick: move |_| props.on_play_all.call(()),
                              i { class: "fa-solid fa-play text-xl ml-1" }
                          }
                          if props.on_download_all.is_some() || props.on_delete_all.is_some() {

--- a/components/src/track_list_view.rs
+++ b/components/src/track_list_view.rs
@@ -1,5 +1,6 @@
 use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
+use rand::seq::SliceRandom;
 use reader::{Library, PlaylistStore, Track};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -46,6 +47,7 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
     let tracks_select_all = props.tracks.clone();
     let tracks_long_press = props.tracks.clone();
     let tracks_select = props.tracks.clone();
+    let tracks_play_all = props.tracks.clone();
     let tracks_play = props.tracks.clone();
     let tracks_add = props.tracks.clone();
     let tracks_menu = props.tracks.clone();
@@ -100,6 +102,19 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
                                 is_selection_mode.set(false);
                             }
                         }
+                    }
+                },
+                on_play_all: move |_| {
+                    let is_shuffle = *ctrl.shuffle.peek();
+                    if is_shuffle {
+                        let mut shuffled = tracks_play_all.clone();
+                        shuffled.shuffle(&mut rand::thread_rng());
+                        ctrl.queue.set(shuffled);
+                        ctrl.current_queue_index.set(0);
+                        ctrl.play_track(0);
+                    } else {
+                        ctrl.queue.set(tracks_play_all.clone());
+                        ctrl.play_track(0);
                     }
                 },
                 on_play: move |idx: usize| {

--- a/components/src/track_list_view.rs
+++ b/components/src/track_list_view.rs
@@ -1,6 +1,5 @@
 use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
-use rand::seq::SliceRandom;
 use reader::{Library, PlaylistStore, Track};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -107,14 +106,9 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
                 on_play_all: move |_| {
                     let is_shuffle = *ctrl.shuffle.peek();
                     if is_shuffle {
-                        let mut shuffled = tracks_play_all.clone();
-                        shuffled.shuffle(&mut rand::thread_rng());
-                        ctrl.queue.set(shuffled);
-                        ctrl.current_queue_index.set(0);
-                        ctrl.play_track(0);
+                        ctrl.play_queue_shuffled(tracks_play_all.clone());
                     } else {
-                        ctrl.queue.set(tracks_play_all.clone());
-                        ctrl.play_track(0);
+                        ctrl.play_queue_linear(tracks_play_all.clone());
                     }
                 },
                 on_play: move |idx: usize| {

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1071,10 +1071,15 @@ impl PlayerController {
     }
 
     fn play_next_with_transition(&mut self, allow_crossfade: bool) {
+        if *self.is_loading.peek() {
+            return;
+        }
+
         let idx = *self.current_queue_index.peek();
         let queue_len = self.queue.peek().len();
 
         if queue_len == 0 {
+            self.skip_in_progress.set(false);
             return;
         }
 
@@ -1083,95 +1088,64 @@ impl PlayerController {
 
         match loop_mode {
             LoopMode::Track => {
-                if allow_crossfade {
-                    let current_idx = *self.current_queue_index.peek();
-                    self.history.with_mut(|h| {
-                        if h.last() != Some(&current_idx) {
-                            h.push(current_idx);
-                        }
-                    });
-                    self.play_track_no_history_with_transition(idx, true);
-                } else {
-                    self.play_track_no_history_without_crossfade(idx);
-                }
+                self.play_track_with_history(idx, allow_crossfade);
             }
             _ => {
                 if shuffle && queue_len > 1 {
-                    let next_idx = self.shuffle_order.with_mut(|order| order.pop());
+                    let is_empty = self.shuffle_order.peek().is_empty();
+
+                    // When the shuffled list is exhausted in queue-loop mode,
+                    // rebuild it so playback continues in a new random order
+                    // starting from the next track after the current one.
+                    if is_empty && loop_mode == LoopMode::Queue {
+                        self.rebuild_shuffle_order();
+                    }
+
+                    let next_idx = self.shuffle_order.with_mut(|order| {
+                        if !order.is_empty() {
+                            Some(order.remove(0))
+                        } else {
+                            None
+                        }
+                    });
+
                     match next_idx {
                         Some(i) => {
-                            if allow_crossfade {
-                                let current_idx = *self.current_queue_index.peek();
-                                self.history.with_mut(|h| {
-                                    if h.last() != Some(&current_idx) {
-                                        h.push(current_idx);
-                                    }
-                                });
-                                self.play_track_no_history_with_transition(i, true);
-                            } else {
-                                self.play_track_no_history_without_crossfade(i);
-                            }
+                            self.play_track_with_history(i, allow_crossfade);
                         }
                         None => {
-                            if loop_mode == LoopMode::Queue {
-                                self.rebuild_shuffle_order();
-                                let i = self.shuffle_order.with_mut(|order| order.pop()).unwrap_or(0);
-                                if allow_crossfade {
-                                    let current_idx = *self.current_queue_index.peek();
-                                    self.history.with_mut(|h| {
-                                        if h.last() != Some(&current_idx) {
-                                            h.push(current_idx);
-                                        }
-                                    });
-                                    self.play_track_no_history_with_transition(i, true);
-                                } else {
-                                    self.play_track_no_history_without_crossfade(i);
-                                }
-                            } else {
-                                self.is_playing.set(false);
-                            }
+                            self.skip_in_progress.set(false);
+                            self.player.write().pause();
+                            self.is_playing.set(false);
                         }
                     }
                 } else if shuffle && queue_len == 1 {
-                    if allow_crossfade {
-                        let current_idx = *self.current_queue_index.peek();
-                        self.history.with_mut(|h| {
-                            if h.last() != Some(&current_idx) {
-                                h.push(current_idx);
-                            }
-                        });
-                        self.play_track_no_history_with_transition(0, true);
-                    } else {
-                        self.play_track_no_history_without_crossfade(0);
-                    }
+                    self.play_track_with_history(0, allow_crossfade);
                 } else if idx + 1 < queue_len {
-                    if allow_crossfade {
-                        let current_idx = *self.current_queue_index.peek();
-                        self.history.with_mut(|h| {
-                            if h.last() != Some(&current_idx) {
-                                h.push(current_idx);
-                            }
-                        });
-                        self.play_track_no_history_with_transition(idx + 1, true);
-                    } else {
-                        self.play_track_no_history_without_crossfade(idx + 1);
-                    }
+                    self.play_track_with_history(idx + 1, allow_crossfade);
                 } else if loop_mode == LoopMode::Queue {
-                    if allow_crossfade {
-                        let current_idx = *self.current_queue_index.peek();
-                        self.history.with_mut(|h| {
-                            if h.last() != Some(&current_idx) {
-                                h.push(current_idx);
-                            }
-                        });
-                        self.play_track_no_history_with_transition(0, true);
-                    } else {
-                        self.play_track_no_history_without_crossfade(0);
-                    }
+                    self.play_track_with_history(0, allow_crossfade);
                 } else {
+                    self.skip_in_progress.set(false);
+                    self.player.write().pause();
                     self.is_playing.set(false);
                 }
             }
+        }
+    }
+
+    fn play_track_with_history(&mut self, track_idx: usize, allow_crossfade: bool) {
+        let current_idx = *self.current_queue_index.peek();
+        self.history.with_mut(|h| {
+            if h.last() != Some(&current_idx) {
+                h.push(current_idx);
+            }
+        });
+
+        if allow_crossfade {
+            self.play_track_no_history_with_transition(track_idx, true);
+        } else {
+            self.play_track_no_history_without_crossfade(track_idx);
         }
     }
 
@@ -1180,9 +1154,7 @@ impl PlayerController {
         let back_behavior = self.config.peek().back_behavior;
 
         if back_behavior == BackBehavior::RewindThenPrev && progress > 3 {
-            self.player
-                .write()
-                .seek(std::time::Duration::ZERO);
+            self.player.write().seek(std::time::Duration::ZERO);
             self.current_song_progress.set(0);
             return;
         }
@@ -1206,13 +1178,45 @@ impl PlayerController {
         }
     }
 
-    fn rebuild_shuffle_order(&mut self) {
+    pub fn rebuild_shuffle_order(&mut self) {
         use rand::seq::SliceRandom;
         let queue_len = self.queue.peek().len();
-        let current = *self.current_queue_index.peek();
-        let mut order: Vec<usize> = (0..queue_len).filter(|&i| i != current).collect();
-        order.shuffle(&mut rand::thread_rng());
-        self.shuffle_order.set(order);
+        let current_idx = *self.current_queue_index.peek();
+
+        // Tracks that come after the current position (play these first).
+        let mut ahead: Vec<usize> = (current_idx + 1..queue_len).collect();
+        ahead.shuffle(&mut rand::thread_rng());
+
+        // Tracks that wrap around from the beginning (play after the ahead group).
+        let mut wrapped: Vec<usize> = (0..current_idx).collect();
+        wrapped.shuffle(&mut rand::thread_rng());
+
+        ahead.extend(wrapped);
+        self.shuffle_order.set(ahead);
+    }
+
+    pub fn play_queue_shuffled(&mut self, tracks: Vec<Track>) {
+        use rand::Rng;
+        let queue_len = tracks.len();
+        if queue_len == 0 {
+            return;
+        }
+
+        self.queue.set(tracks);
+
+        let start = rand::thread_rng().gen_range(0..queue_len);
+
+        self.play_track(start);
+        self.rebuild_shuffle_order();
+    }
+
+    pub fn play_queue_linear(&mut self, tracks: Vec<Track>) {
+        if tracks.is_empty() {
+            return;
+        }
+        self.queue.set(tracks);
+        self.shuffle_order.set(Vec::new());
+        self.play_track(0);
     }
 
     pub fn toggle_shuffle(&mut self) {
@@ -1282,6 +1286,8 @@ impl PlayerController {
         queue: Vec<Track>,
         current_queue_index: usize,
         progress_secs: u64,
+        shuffle_order: Vec<usize>,
+        shuffle_enabled: bool,
     ) {
         self.clear_pending_crossfade_ui();
         self.player.write().stop();
@@ -1290,6 +1296,8 @@ impl PlayerController {
         self.skip_in_progress.set(false);
         self.history.set(Vec::new());
         self.queue.set(queue);
+        self.shuffle.set(shuffle_enabled);
+        self.shuffle_order.set(shuffle_order);
 
         let queue_len = self.queue.peek().len();
         if queue_len == 0 {
@@ -1300,7 +1308,9 @@ impl PlayerController {
         }
 
         let idx = current_queue_index.min(queue_len - 1);
-        let track = self.current_track(idx).expect("queue index should be valid");
+        let track = self
+            .current_track(idx)
+            .expect("queue index should be valid");
         let progress_secs = progress_secs.min(track.duration);
 
         self.hydrate_current_track_metadata(idx, progress_secs);

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1178,7 +1178,7 @@ impl PlayerController {
         }
     }
 
-    pub fn rebuild_shuffle_order(&mut self) {
+    fn rebuild_shuffle_order(&mut self) {
         use rand::seq::SliceRandom;
         let queue_len = self.queue.peek().len();
         let current_idx = *self.current_queue_index.peek();

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1072,7 +1072,7 @@ impl PlayerController {
 
     fn play_next_with_transition(&mut self, allow_crossfade: bool) {
         if *self.is_loading.peek() {
-            return;
+            self.skip_in_progress.set(false);
         }
 
         let idx = *self.current_queue_index.peek();

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1203,7 +1203,7 @@ impl PlayerController {
         }
 
         self.queue.set(tracks);
-
+        self.shuffle_order.set(Vec::new());
         let start = rand::thread_rng().gen_range(0..queue_len);
 
         self.play_track(start);

--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -165,6 +165,23 @@ fn sanitize_queue_state(state: PersistedQueueState) -> Option<PersistedQueueStat
             .unwrap_or(0)
     };
 
+    let old_queue_len = survivors
+        .iter()
+        .map(|(old_idx, _)| *old_idx)
+        .max()
+        .map_or(0, |m| m + 1);
+
+    let mut old_to_new_index: Vec<Option<usize>> = vec![None; old_queue_len];
+    for (new_idx, (old_idx, _)) in survivors.iter().enumerate() {
+        old_to_new_index[*old_idx] = Some(new_idx);
+    }
+
+    let shuffle_order: Vec<usize> = state
+        .shuffle_order
+        .into_iter()
+        .filter_map(|old_idx| old_to_new_index.get(old_idx).and_then(|&new_idx| new_idx))
+        .collect();
+
     let queue: Vec<_> = survivors.into_iter().map(|(_, track)| track).collect();
     let progress_secs = if selected_track_survived {
         queue
@@ -180,6 +197,8 @@ fn sanitize_queue_state(state: PersistedQueueState) -> Option<PersistedQueueStat
         queue,
         current_queue_index: restored_index,
         progress_secs,
+        shuffle_order,
+        shuffle_enabled: state.shuffle_enabled,
     })
 }
 
@@ -188,6 +207,8 @@ fn build_queue_state_snapshot(
     current_queue_index: usize,
     current_song_progress: u64,
     is_playing: bool,
+    shuffle_order: &[usize],
+    shuffle_enabled: bool,
 ) -> Option<PersistedQueueState> {
     if queue.is_empty() {
         return None;
@@ -209,6 +230,8 @@ fn build_queue_state_snapshot(
         queue: queue.to_vec(),
         current_queue_index: current_idx,
         progress_secs,
+        shuffle_order: shuffle_order.to_vec(),
+        shuffle_enabled,
     })
 }
 
@@ -221,7 +244,6 @@ fn read_titlebar_mode_from_disk() -> config::TitlebarMode {
         .map(|c| c.titlebar_mode)
         .unwrap_or_default()
 }
-
 
 #[cfg(not(target_arch = "wasm32"))]
 fn thumb_cache_path(file_path: &str) -> std::path::PathBuf {
@@ -784,11 +806,16 @@ fn App() -> Element {
         }
 
         let queue_snapshot = queue.read().clone();
+        let shuffle_order_snapshot = ctrl.shuffle_order.read().clone();
+        let shuffle_enabled_snapshot = *ctrl.shuffle.read();
+
         let queue_state = build_queue_state_snapshot(
             &queue_snapshot,
             *current_queue_index.read(),
             *current_song_progress.read(),
             *is_playing.read(),
+            &shuffle_order_snapshot,
+            shuffle_enabled_snapshot,
         );
 
         if *pending_queue_state_snapshot.peek() != queue_state {
@@ -969,6 +996,8 @@ fn App() -> Element {
                             queue_state.queue,
                             queue_state.current_queue_index,
                             queue_state.progress_secs,
+                            queue_state.shuffle_order,
+                            queue_state.shuffle_enabled,
                         );
                     }
                 }
@@ -1026,6 +1055,8 @@ fn App() -> Element {
                         queue_state.queue,
                         queue_state.current_queue_index,
                         queue_state.progress_secs,
+                        queue_state.shuffle_order,
+                        queue_state.shuffle_enabled,
                     );
                 }
             }

--- a/kopuz/src/queue_state.rs
+++ b/kopuz/src/queue_state.rs
@@ -17,6 +17,10 @@ pub struct PersistedQueueState {
     pub current_queue_index: usize,
     #[serde(default)]
     pub progress_secs: u64,
+    #[serde(default)]
+    pub shuffle_order: Vec<usize>,
+    #[serde(default)]
+    pub shuffle_enabled: bool,
 }
 
 impl Default for PersistedQueueState {
@@ -26,6 +30,8 @@ impl Default for PersistedQueueState {
             queue: Vec::new(),
             current_queue_index: 0,
             progress_secs: 0,
+            shuffle_order: Vec::new(),
+            shuffle_enabled: false,
         }
     }
 }

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -3,6 +3,7 @@ use components::playlist_modal::PlaylistModal;
 use components::selection_bar::SelectionBar;
 use config::{AppConfig, ArtistViewOrder};
 use dioxus::prelude::*;
+use rand::seq::SliceRandom;
 use reader::{Library, PlaylistStore};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -428,6 +429,20 @@ pub fn LocalArtist(
                                                 is_selection_mode.set(false);
                                             }
                                         }
+                                    }
+                                },
+                                on_play_all: move |_| {
+                                    let tracks = artist_tracks();
+                                    let is_shuffle = *ctrl.shuffle.peek();
+                                    if is_shuffle {
+                                        let mut shuffled = tracks.clone();
+                                        shuffled.shuffle(&mut rand::thread_rng());
+                                        queue.set(shuffled);
+                                        current_queue_index.set(0);
+                                        ctrl.play_track(0);
+                                    } else {
+                                        queue.set(tracks.clone());
+                                        ctrl.play_track(0);
                                     }
                                 },
                                 on_play: move |idx: usize| {

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -432,19 +432,13 @@ pub fn LocalArtist(
                                     }
                                 },
                                 on_play_all: move |_| {
-                                    let tracks = artist_tracks();
-                                    let is_shuffle = *ctrl.shuffle.peek();
-                                    if is_shuffle {
-                                        let mut shuffled = tracks.clone();
-                                        shuffled.shuffle(&mut rand::thread_rng());
-                                        queue.set(shuffled);
-                                        current_queue_index.set(0);
-                                        ctrl.play_track(0);
-                                    } else {
-                                        queue.set(tracks.clone());
-                                        ctrl.play_track(0);
-                                    }
-                                },
+                                       let is_shuffle = *ctrl.shuffle.peek();
+                                       if is_shuffle {
+                                           ctrl.play_queue_shuffled(artist_tracks());
+                                       } else {
+                                           ctrl.play_queue_linear(artist_tracks());
+                                       }
+                                   },
                                 on_play: move |idx: usize| {
                                     let tracks = artist_tracks();
                                     queue.set(tracks.clone());

--- a/pages/src/server/album.rs
+++ b/pages/src/server/album.rs
@@ -502,16 +502,11 @@ pub fn JellyfinAlbumDetails(
                                 move |_| {
                                     let is_shuffle = *ctrl.shuffle.peek();
                                     if is_shuffle {
-                                        let mut shuffled = tracks_for_play.clone();
-                                        shuffled.shuffle(&mut rand::thread_rng());
-                                        queue.set(shuffled);
-                                        ctrl.current_queue_index.set(0);
-                                        ctrl.play_track(0);
-                                      } else {
-                                          queue.set(tracks_for_play.clone());
-                                          ctrl.play_track(0);
-                                      }
-                                  }
+                                        ctrl.play_queue_shuffled(tracks_for_play.clone());
+                                    } else {
+                                        ctrl.play_queue_linear(tracks_for_play.clone());
+                                    }
+                                }
                               },
                             i { class: "fa-solid fa-play text-xl ml-1" }
                         }

--- a/pages/src/server/album.rs
+++ b/pages/src/server/album.rs
@@ -5,6 +5,7 @@ use components::selection_bar::SelectionBar;
 use components::track_row::TrackRow;
 use config::{AppConfig, MusicService};
 use dioxus::prelude::*;
+use rand::seq::SliceRandom;
 use reader::{Library, PlaylistStore};
 use server::jellyfin::JellyfinClient;
 use server::subsonic::SubsonicClient;
@@ -485,15 +486,33 @@ pub fn JellyfinAlbumDetails(
                 div { class: "flex items-center gap-4",
                     if !album_tracks().is_empty() {
                         button {
+                            class: format!("w-14 h-14 rounded-full flex items-center justify-center {}", if *ctrl.shuffle.read() { "text-white" } else { "text-slate-400 hover:text-white" }),
+                            title: if *ctrl.shuffle.read() {
+                                i18n::t("shuffle_on").to_string()
+                            } else {
+                                i18n::t("shuffle_off").to_string()
+                            },
+                            onclick: move |_| ctrl.toggle_shuffle(),
+                            i { class: "fa-solid fa-shuffle text-xl ml-1" }
+                        }
+                        button {
                             class: "w-14 h-14 rounded-full bg-indigo-500 hover:bg-indigo-400 text-black flex items-center justify-center transition-transform hover:scale-105",
                             onclick: {
-                                let tracks_for_play: Vec<reader::models::Track> =
-                                    album_tracks().iter().map(|(t, _)| t.clone()).collect();
+                                let tracks_for_play: Vec<reader::models::Track> = album_tracks().iter().map(|(t, _)| t.clone()).collect();
                                 move |_| {
-                                    queue.set(tracks_for_play.clone());
-                                    ctrl.play_track(0);
-                                }
-                            },
+                                    let is_shuffle = *ctrl.shuffle.peek();
+                                    if is_shuffle {
+                                        let mut shuffled = tracks_for_play.clone();
+                                        shuffled.shuffle(&mut rand::thread_rng());
+                                        queue.set(shuffled);
+                                        ctrl.current_queue_index.set(0);
+                                        ctrl.play_track(0);
+                                      } else {
+                                          queue.set(tracks_for_play.clone());
+                                          ctrl.play_track(0);
+                                      }
+                                  }
+                              },
                             i { class: "fa-solid fa-play text-xl ml-1" }
                         }
                         {

--- a/pages/src/server/artist.rs
+++ b/pages/src/server/artist.rs
@@ -4,6 +4,7 @@ use components::playlist_modal::PlaylistModal;
 use components::selection_bar::SelectionBar;
 use config::{AppConfig, ArtistViewOrder, MusicService};
 use dioxus::prelude::*;
+use rand::seq::SliceRandom;
 use reader::{Library, PlaylistStore};
 use server::jellyfin::JellyfinClient;
 use server::subsonic::SubsonicClient;
@@ -687,6 +688,20 @@ pub fn JellyfinArtist(
                                                 is_selection_mode.set(false);
                                             }
                                         }
+                                    }
+                                },
+                                on_play_all: move |_| {
+                                    let tracks = artist_tracks();
+                                    let is_shuffle = *ctrl.shuffle.peek();
+                                    if is_shuffle {
+                                        let mut shuffled = tracks.clone();
+                                        shuffled.shuffle(&mut rand::thread_rng());
+                                        queue.set(shuffled);
+                                        current_queue_index.set(0);
+                                        ctrl.play_track(0);
+                                    } else {
+                                        queue.set(tracks.clone());
+                                        ctrl.play_track(0);
                                     }
                                 },
                                 on_play: move |idx: usize| {

--- a/pages/src/server/artist.rs
+++ b/pages/src/server/artist.rs
@@ -691,19 +691,13 @@ pub fn JellyfinArtist(
                                     }
                                 },
                                 on_play_all: move |_| {
-                                    let tracks = artist_tracks();
-                                    let is_shuffle = *ctrl.shuffle.peek();
-                                    if is_shuffle {
-                                        let mut shuffled = tracks.clone();
-                                        shuffled.shuffle(&mut rand::thread_rng());
-                                        queue.set(shuffled);
-                                        current_queue_index.set(0);
-                                        ctrl.play_track(0);
-                                    } else {
-                                        queue.set(tracks.clone());
-                                        ctrl.play_track(0);
-                                    }
-                                },
+                                      let is_shuffle = *ctrl.shuffle.peek();
+                                      if is_shuffle {
+                                          ctrl.play_queue_shuffled(artist_tracks());
+                                      } else {
+                                          ctrl.play_queue_linear(artist_tracks());
+                                      }
+                                  },
                                 on_play: move |idx: usize| {
                                     let tracks = artist_tracks();
                                     queue.set(tracks.clone());


### PR DESCRIPTION
# Description
Adds on-play shuffle support to album and artist play buttons across both local and server pages. When shuffle is enabled, playback now starts from a random track instead first track and continues in the same shuffled order for the rest of the queue. The shuffle toggle is also now available directly on album and artist pages next to the play button.

This PR also adds a few small playback and queue helpers needed for the new shuffle behavior.

While working on this feature, a few existing queue and shuffle issues were also uncovered and fixed (shown in the attached video). The playback order now properly matches the queue panel, the "Up Next" list stays in sync with the actual shuffled order, playback correctly stops at the end of the queue, and shuffle state is now remembered after restarting the app.

Before: https://file.garden/aYF_ULv7g1z31ci1/OBS/2026-05-12%2023-51-02.mp4
After: https://file.garden/aYF_ULv7g1z31ci1/OBS/2026-05-12%2023-54-30.mp4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shuffle toggle added to showcase, album and artist views
  * "Play All" and Up Next now respect shuffle state (shuffled or linear playback)
  * Shuffle state is persisted and restored across sessions

* **Improvements**
  * Up Next list, counts and durations reflect shuffle ordering
  * Reordering controls are hidden when shuffle is enabled
  * Double-click playback on Up Next uses the correct queued track index

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/181)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->