### PR TITLE
fix(discord_rpc): ignore local dioxus URLs for Discord cover

### DIFF
--- a/hooks/src/use_player_task.rs
+++ b/hooks/src/use_player_task.rs
@@ -376,7 +376,7 @@ pub fn use_player_task(ctrl: PlayerController) {
                             discord_cover_url.set(None);
                             discord_cover_sent.set(false);
 
-                            if cover.starts_with("http") {
+                            if cover.starts_with("http") && !cover.contains("dioxus.localhost") {
                                 discord_cover_url.set(Some(cover.clone()));
                             } else {
                                 let mbid = {
@@ -411,7 +411,7 @@ pub fn use_player_task(ctrl: PlayerController) {
                                 let resolved = discord_cover_url.read().clone();
                                 let cover_ref = if let Some(ref url) = resolved {
                                     Some(url.as_str())
-                                } else if cover.starts_with("http") {
+                                } else if cover.starts_with("http") && !cover.contains("dioxus.localhost") {
                                     Some(cover.as_str())
                                 } else {
                                     None


### PR DESCRIPTION
On Windows, Discord RPC was still using cached Dioxus local artwork URLs, and this temporarily fixes it

Before:
<img width="1222" height="45" alt="image" src="https://github.com/user-attachments/assets/7816ed87-b4be-463a-847f-2cd3bc04d9ab" />

After:
<img width="1218" height="46" alt="image" src="https://github.com/user-attachments/assets/080b855d-d415-4940-ad69-061176d65f2f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Discord cover-art URL handling to properly ignore local references when determining whether to process and display cover artwork. This prevents incorrect cover-art resolution in certain scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/182)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->