### PR TITLE
fix: audio thread crashes

### DIFF
--- a/player/src/eq.rs
+++ b/player/src/eq.rs
@@ -162,6 +162,9 @@ impl Equalizer {
                 for band in &mut self.bands {
                     value = band.process(channel, value);
                 }
+                if value.is_nan() {
+                    value = 0.0;
+                }
                 *sample = value.clamp(-1.0, 1.0);
             }
         }
@@ -200,7 +203,10 @@ fn peaking_coefficients(sample_rate: u32, frequency: f32, q: f32, gain_db: f32) 
     let b0 = 1.0 + alpha * a;
     let b1 = -2.0 * cos_omega;
     let b2 = 1.0 - alpha * a;
-    let a0 = 1.0 + alpha / a;
+    let mut a0 = 1.0 + alpha / a;
+    if a0.abs() < 1e-6 {
+        a0 = 1e-6;
+    }
     let a1 = -2.0 * cos_omega;
     let a2 = 1.0 - alpha / a;
 

--- a/player/src/player.rs
+++ b/player/src/player.rs
@@ -349,11 +349,12 @@ impl Player {
                         }
                     }
 
-                    stream_position.fetch_add(
-                        (active_read as u64 * 1_000_000)
-                            / (channels as u64 * device_sample_rate as u64),
-                        Ordering::Relaxed,
-                    );
+                    if channels > 0 && device_sample_rate > 0 {
+                        stream_position.fetch_add(
+                            (read as u64 * 1_000_000) / (channels as u64 * device_sample_rate as u64),
+                            Ordering::Relaxed,
+                        );
+                    }
 
                     for sample in data[..read].iter_mut() {
                         *sample *= volume;
@@ -1004,8 +1005,14 @@ impl Player {
     }
 
     fn resample(samples: &[f32], channels: usize, src_rate: u32, dst_rate: u32) -> Vec<f32> {
+        if channels == 0 || src_rate == 0 || dst_rate == 0 {
+            return samples.to_vec();
+        }
         let src_frames = samples.len() / channels;
         let ratio = dst_rate as f64 / src_rate as f64;
+        if ratio.is_nan() || ratio.is_infinite() {
+            return samples.to_vec();
+        }
         let dst_frames = (src_frames as f64 * ratio).ceil() as usize;
         let mut out = Vec::with_capacity(dst_frames * channels);
 


### PR DESCRIPTION
playing a song on kopuz just crashes it. fixed some division by zero and nan panics in the audio thread/eq. should be good now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio signal processing stability with defensive checks for invalid numerical values in equalizer computations.
  * Enhanced audio output reliability through stricter parameter validation in resampling logic and audio stream operations to handle edge cases gracefully.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/183)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->