### PR TITLE
fix(queue): fix shuffle queue sync and add-to-queue behavior

### DIFF
--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -572,7 +572,8 @@ pub fn Fullscreen(
                             {
                                 let track = queue.read()[i].clone();
                                 let cover_url = get_track_cover(&track);
-                                let can_move_up = i > *current_queue_index.read() + 1;
+                                let list_pos = i - (*current_queue_index.read() + 1);
+                                let can_move_up = list_pos > 0;
                                 let can_move_down = i + 1 < queue.read().len();
                                 rsx! {
                                     div {
@@ -601,8 +602,8 @@ pub fn Fullscreen(
                                             can_move_down,
                                             class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
                                             icon_class: "text-[10px]".to_string(),
-                                            on_move_up: move |_| move_queue_item(i, i - 1),
-                                            on_move_down: move |_| move_queue_item(i, i + 1),
+                                            on_move_up: move |_| move_queue_item(list_pos, list_pos - 1),
+                                            on_move_down: move |_| move_queue_item(list_pos, list_pos + 1),
                                         }
                                     }
                                 }

--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -220,21 +220,30 @@ pub fn Fullscreen(
         }
     };
 
+    let is_shuffle = *ctrl.shuffle.read();
+    let up_next_items: Vec<(usize, reader::Track)> = {
+        let q = queue.read();
+        let current_idx = *current_queue_index.read();
+        if is_shuffle {
+            ctrl.shuffle_order
+                .read()
+                .iter()
+                .filter_map(|&qi| q.get(qi).map(|t| (qi, t.clone())))
+                .collect()
+        } else {
+            (current_idx + 1..q.len())
+                .filter_map(|qi| q.get(qi).map(|t| (qi, t.clone())))
+                .collect()
+        }
+    };
+
     let background_style = if config.read().theme == "album-art" {
         utils::color::get_background_style(palette.read().as_deref())
     } else {
         "background-color: var(--color-black); background-image: none;".to_string()
     };
-    let up_next_count = queue
-        .read()
-        .len()
-        .saturating_sub(*current_queue_index.read() + 1);
-    let up_next_duration: u64 = queue
-        .read()
-        .iter()
-        .skip(*current_queue_index.read() + 1)
-        .map(|track| track.duration)
-        .sum();
+    let up_next_count = up_next_items.len();
+    let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
     let up_next_summary = format!(
         "{} • {}",
         i18n::t_with("showcase_song_count", &[("count", up_next_count.to_string())]),
@@ -560,7 +569,7 @@ pub fn Fullscreen(
                             }
                         }
                     } else if *active_tab.read() == 1 {
-                        if queue.read().len() <= *current_queue_index.read() + 1 {
+                        if up_next_items.is_empty() {
                             div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
                         } else {
                             div {
@@ -568,18 +577,18 @@ pub fn Fullscreen(
                                 "{up_next_summary}"
                             }
                         }
-                        for i in (*current_queue_index.read() + 1)..queue.read().len() {
+                        for (list_pos, (queue_idx, track)) in up_next_items.iter().enumerate() {
                             {
-                                let track = queue.read()[i].clone();
+                                let queue_idx = *queue_idx;
+                                let track = track.clone();
                                 let cover_url = get_track_cover(&track);
-                                let list_pos = i - (*current_queue_index.read() + 1);
                                 let can_move_up = list_pos > 0;
-                                let can_move_down = i + 1 < queue.read().len();
+                                let can_move_down = list_pos + 1 < up_next_items.len();
                                 rsx! {
                                     div {
-                                        key: "{i}",
+                                        key: "{list_pos}",
                                         class: "flex items-center gap-4 px-4 py-3 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
-                                        onclick: move |_| play_song_at_index(i),
+                                        onclick: move |_| play_song_at_index(queue_idx),
                                         div {
                                             class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
                                             style: "width: 48px; height: 48px;",

--- a/components/src/reorder_buttons.rs
+++ b/components/src/reorder_buttons.rs
@@ -24,6 +24,7 @@ pub fn ReorderButtons(
                         on_move_up.call(evt);
                     }
                 },
+                ondoubleclick: move |evt| evt.stop_propagation(),
                 i { class: "fa-solid fa-chevron-up {icon_class}" }
             }
             button {
@@ -39,6 +40,7 @@ pub fn ReorderButtons(
                         on_move_down.call(evt);
                     }
                 },
+                ondoubleclick: move |evt| evt.stop_propagation(),
                 i { class: "fa-solid fa-chevron-down {icon_class}" }
             }
         }

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -347,14 +347,14 @@ pub fn Rightbar(
                             if back_items.is_empty() {
                                 div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
                             } else {
-                                for (qi, track) in back_items.iter() {
+                                for (list_pos, (qi, track)) in back_items.iter().enumerate() {
                                     {
                                         let qi = *qi;
                                         let track = track.clone();
                                         let cover_url = get_track_cover(&track);
                                         rsx! {
                                             div {
-                                                key: "{qi}",
+                                                key: "{list_pos}-{qi}",
                                                 class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
                                             style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
                                             ondoubleclick: move |_| play_song_at_index(qi),

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -382,9 +382,9 @@ pub fn Rightbar(
                             let queue_idx = *queue_idx;
                             let track = track.clone();
                             let cover_url = get_track_cover(&track);
-                            let current_idx = *current_queue_index.read();
-                            let can_move_up = !is_shuffle && queue_idx > current_idx + 1;
-                            let can_move_down = !is_shuffle && queue_idx + 1 < queue.read().len();
+                            let _current_idx = *current_queue_index.read();
+                            let can_move_up = list_pos > 0;
+                            let can_move_down = list_pos + 1 < up_next_items.len();
                             rsx! {
                                 div {
                                     key: "{list_pos}",
@@ -408,14 +408,12 @@ pub fn Rightbar(
                                         div { class: "text-sm text-white truncate font-medium", "{track.title}" }
                                         div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
                                     }
-                                    if !is_shuffle {
-                                        ReorderButtons {
-                                            can_move_up,
-                                            can_move_down,
-                                            class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
-                                            on_move_up: move |_| move_queue_item(queue_idx, queue_idx - 1),
-                                            on_move_down: move |_| move_queue_item(queue_idx, queue_idx + 1),
-                                        }
+                                    ReorderButtons {
+                                        can_move_up,
+                                        can_move_down,
+                                        class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
+                                        on_move_up: move |_| ctrl.move_queue_item(list_pos, list_pos - 1),
+                                        on_move_down: move |_| ctrl.move_queue_item(list_pos, list_pos + 1),
                                     }
                                 }
                             }

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -234,6 +234,15 @@ pub fn Rightbar(
                 .collect()
         }
     };
+    let back_items: Vec<(usize, reader::Track)> = if is_shuffle {
+        ctrl.history.read().iter().rev()
+            .filter_map(|&qi| queue.read().get(qi).map(|t| (qi, t.clone())))
+            .collect()
+    } else {
+        (0..*current_queue_index.read())
+            .filter_map(|i| queue.read().get(i).map(|t| (i, t.clone())))
+            .collect()
+    };
     let up_next_count = up_next_items.len();
     let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
     let up_next_summary = format!(
@@ -334,35 +343,39 @@ pub fn Rightbar(
                         }
                     }
                 } else if *active_tab.read() == 0 {
-                    if *current_queue_index.read() == 0 {
-                        div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
-                    }
-                    for i in 0..*current_queue_index.read() {
-                        {
-                            let track = queue.read()[i].clone();
-                            let cover_url = get_track_cover(&track);
-                            rsx! {
-                                div {
-                                    key: "{i}",
-                                    class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
-                                    style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                                    ondoubleclick: move |_| play_song_at_index(i),
-                                    div {
-                                        class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
-                                        style: "width: 40px; height: 40px;",
-                                        if let Some(ref url) = cover_url {
-                                            img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
-                                        } else {
+                        div {
+                            if back_items.is_empty() {
+                                div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
+                            } else {
+                                for (qi, track) in back_items.iter() {
+                                    {
+                                        let qi = *qi;
+                                        let track = track.clone();
+                                        let cover_url = get_track_cover(&track);
+                                        rsx! {
                                             div {
-                                                class: "w-full h-full flex items-center justify-center",
-                                                i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
+                                                key: "{qi}",
+                                                class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
+                                            style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
+                                            ondoubleclick: move |_| play_song_at_index(qi),
+                                            div {
+                                                class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
+                                                style: "width: 40px; height: 40px;",
+                                                if let Some(ref url) = cover_url {
+                                                    img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
+                                                } else {
+                                                    div {
+                                                        class: "w-full h-full flex items-center justify-center",
+                                                        i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
+                                                    }
+                                                }
+                                            }
+                                            div {
+                                                class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
+                                                div { class: "text-sm text-white truncate font-medium", "{track.title}" }
+                                                div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
                                             }
                                         }
-                                    }
-                                    div {
-                                        class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
-                                        div { class: "text-sm text-white truncate font-medium", "{track.title}" }
-                                        div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
                                     }
                                 }
                             }
@@ -382,7 +395,7 @@ pub fn Rightbar(
                             let queue_idx = *queue_idx;
                             let track = track.clone();
                             let cover_url = get_track_cover(&track);
-                            let _current_idx = *current_queue_index.read();
+                            let current_idx = *current_queue_index.read();
                             let can_move_up = list_pos > 0;
                             let can_move_down = list_pos + 1 < up_next_items.len();
                             rsx! {

--- a/components/src/search_genre_detail.rs
+++ b/components/src/search_genre_detail.rs
@@ -112,7 +112,7 @@ pub fn SearchGenreDetail(
                                      active_menu_track.set(None);
                                  },
                                  on_queue: move |_| {
-                                     queue.write().push(track_queue.clone());
+                                     ctrl.add_to_queue(vec![track_queue.clone()]);
                                      active_menu_track.set(None);
                                  },
                                  on_close_menu: move |_| active_menu_track.set(None),

--- a/components/src/search_results.rs
+++ b/components/src/search_results.rs
@@ -82,7 +82,7 @@ pub fn SearchResults(
                                             active_menu_track.set(None);
                                         },
                                         on_queue: move |_| {
-                                            queue.write().push(track_queue.clone());
+                                            ctrl.add_to_queue(vec![track_queue.clone()]);
                                             active_menu_track.set(None);
                                         },
                                         on_close_menu: move |_| active_menu_track.set(None),

--- a/components/src/track_list_view.rs
+++ b/components/src/track_list_view.rs
@@ -125,7 +125,7 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
                 },
                 on_queue: move |idx: usize| {
                     if let Some(t) = tracks_queue.get(idx) {
-                        ctrl.queue.write().push(t.clone());
+                        ctrl.add_to_queue(vec![t.clone()]);
                         active_menu_track.set(None);
                     }
                 },

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1176,14 +1176,16 @@ impl PlayerController {
 
         if idx > 0 {
             if *self.shuffle.peek() {
-                self.shuffle_order.with_mut(|so| so.insert(0, idx));
+                self.play_track_no_history_without_crossfade(idx);
+            } else {
+                self.play_track_no_history_without_crossfade(idx - 1);
             }
-            self.play_track_no_history_without_crossfade(idx - 1);
         } else if *self.loop_mode.peek() == LoopMode::Queue {
             if *self.shuffle.peek() {
-                self.shuffle_order.with_mut(|so| so.insert(0, idx));
+                self.play_track_no_history_without_crossfade(idx);
+            } else {
+                self.play_track_no_history_without_crossfade(queue_len - 1);
             }
-            self.play_track_no_history_without_crossfade(queue_len - 1);
         }
     }
 
@@ -1320,7 +1322,7 @@ impl PlayerController {
                 *idx = Self::remap_queue_index(*idx, from, to);
             }
         });
-        
+
         self.shuffle_order.with_mut(|shuffle_order| {
             for idx in shuffle_order.iter_mut() {
                 *idx = Self::remap_queue_index(*idx, from, to);

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1275,7 +1275,23 @@ impl PlayerController {
         }
     }
 
-    pub fn move_queue_item(&mut self, from: usize, to: usize) {
+    pub fn move_queue_item(&mut self, from_list_pos: usize, to_list_pos: usize) {
+        if *self.shuffle.peek() {
+            self.shuffle_order.with_mut(|so| {
+                if from_list_pos < so.len() && to_list_pos < so.len() {
+                    let item = so.remove(from_list_pos);
+                    so.insert(to_list_pos, item);
+                }
+            });
+        } else {
+            let current_idx = *self.current_queue_index.peek();
+            let from_queue_idx = current_idx + 1 + from_list_pos;
+            let to_queue_idx = current_idx + 1 + to_list_pos;
+            self.move_physical_queue_item(from_queue_idx, to_queue_idx);
+        }
+    }
+
+    fn move_physical_queue_item(&mut self, from: usize, to: usize) {
         let len = self.queue.peek().len();
         if from >= len || to >= len || from == to {
             return;
@@ -1292,6 +1308,12 @@ impl PlayerController {
 
         self.history.with_mut(|history| {
             for idx in history.iter_mut() {
+                *idx = Self::remap_queue_index(*idx, from, to);
+            }
+        });
+        
+        self.shuffle_order.with_mut(|shuffle_order| {
+            for idx in shuffle_order.iter_mut() {
                 *idx = Self::remap_queue_index(*idx, from, to);
             }
         });

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1167,13 +1167,22 @@ impl PlayerController {
         }
 
         if let Some(prev_idx) = self.history.with_mut(|h| h.pop()) {
+            if *self.shuffle.peek() {
+                self.shuffle_order.with_mut(|so| so.insert(0, idx));
+            }
             self.play_track_no_history_without_crossfade(prev_idx);
             return;
         }
 
         if idx > 0 {
+            if *self.shuffle.peek() {
+                self.shuffle_order.with_mut(|so| so.insert(0, idx));
+            }
             self.play_track_no_history_without_crossfade(idx - 1);
         } else if *self.loop_mode.peek() == LoopMode::Queue {
+            if *self.shuffle.peek() {
+                self.shuffle_order.with_mut(|so| so.insert(0, idx));
+            }
             self.play_track_no_history_without_crossfade(queue_len - 1);
         }
     }

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1219,6 +1219,22 @@ impl PlayerController {
         self.play_track(0);
     }
 
+    pub fn add_to_queue(&mut self, tracks: impl IntoIterator<Item = Track>) {
+        let tracks: Vec<Track> = tracks.into_iter().collect();
+        let count = tracks.len();
+        if count == 0 { return; }
+
+        self.queue.with_mut(|q| q.extend(tracks));
+
+        if *self.shuffle.peek() {
+            let q_len = self.queue.peek().len();
+            let start_idx = q_len - count;
+            self.shuffle_order.with_mut(|so| {
+                (start_idx..q_len).for_each(|idx| so.push(idx));
+            });
+        }
+    }
+
     pub fn toggle_shuffle(&mut self) {
         let now_on = !*self.shuffle.peek();
         self.shuffle.set(now_on);

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -293,12 +293,14 @@ impl PlayerController {
     }
 
     pub fn play_track(&mut self, idx: usize) {
-        let current_idx = *self.current_queue_index.peek();
-        self.history.with_mut(|h| {
-            if h.last() != Some(&current_idx) {
-                h.push(current_idx);
-            }
-        });
+        if *self.is_playing.peek() || self.player.peek().can_resume() {
+            let current_idx = *self.current_queue_index.peek();
+            self.history.with_mut(|h| {
+                if h.last() != Some(&current_idx) {
+                    h.push(current_idx);
+                }
+            });
+        }
         self.play_track_no_history_without_crossfade(idx);
     }
 
@@ -1174,18 +1176,12 @@ impl PlayerController {
             return;
         }
 
-        if idx > 0 {
-            if *self.shuffle.peek() {
-                self.play_track_no_history_without_crossfade(idx);
-            } else {
-                self.play_track_no_history_without_crossfade(idx - 1);
-            }
+        if *self.shuffle.peek() {
+            self.play_track_no_history_without_crossfade(idx);
+        } else if idx > 0 {
+            self.play_track_no_history_without_crossfade(idx - 1);
         } else if *self.loop_mode.peek() == LoopMode::Queue {
-            if *self.shuffle.peek() {
-                self.play_track_no_history_without_crossfade(idx);
-            } else {
-                self.play_track_no_history_without_crossfade(queue_len - 1);
-            }
+            self.play_track_no_history_without_crossfade(queue_len - 1);
         }
     }
 
@@ -1215,9 +1211,10 @@ impl PlayerController {
 
         self.queue.set(tracks);
         self.shuffle_order.set(Vec::new());
+        self.history.set(Vec::new());
         let start = rand::thread_rng().gen_range(0..queue_len);
 
-        self.play_track(start);
+        self.play_track_no_history(start);
         self.rebuild_shuffle_order();
     }
 
@@ -1227,7 +1224,8 @@ impl PlayerController {
         }
         self.queue.set(tracks);
         self.shuffle_order.set(Vec::new());
-        self.play_track(0);
+        self.history.set(Vec::new());
+        self.play_track_no_history(0);
     }
 
     pub fn add_to_queue(&mut self, tracks: impl IntoIterator<Item = Track>) {

--- a/pages/src/local/album.rs
+++ b/pages/src/local/album.rs
@@ -32,6 +32,8 @@ pub fn LocalAlbum(
         unique_albums
     });
 
+    let mut ctrl = use_context::<hooks::use_player_controller::PlayerController>();
+
     let add_all_to_queue_text = i18n::t("add_all_to_queue").to_string();
     let add_all_to_playlist_text = i18n::t("add_all_to_playlist").to_string();
     let delete_album_text = i18n::t("delete_album").to_string();
@@ -124,7 +126,7 @@ pub fn LocalAlbum(
                                                                     .cmp(&b.track_number)
                                                                     .then_with(|| a.title.cmp(&b.title))
                                                             });
-                                                            queue.write().extend(tracks_for_queue);
+                                                            ctrl.add_to_queue(tracks_for_queue);
                                                         }
                                                         1 => {
                                                             pending_album_id_for_playlist.set(Some(id.clone()));

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -3,7 +3,6 @@ use components::playlist_modal::PlaylistModal;
 use components::selection_bar::SelectionBar;
 use config::{AppConfig, ArtistViewOrder};
 use dioxus::prelude::*;
-use rand::seq::SliceRandom;
 use reader::{Library, PlaylistStore};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -373,7 +373,7 @@ pub fn LocalArtist(
                                                                                         .then_with(|| a.title.cmp(&b.title))
                                                                                 });
 
-                                                                                queue.write().extend(tracks_for_queue);
+                                                                                ctrl.add_to_queue(tracks_for_queue);
                                                                             }
                                                                             1 => {
                                                                                 pending_album_id_for_playlist.set(Some(id.clone()));
@@ -488,7 +488,7 @@ pub fn LocalArtist(
                                 },
                                 on_queue: move |idx: usize| {
                                     if let Some(track) = artist_tracks().get(idx) {
-                                        queue.write().push(track.clone());
+                                        ctrl.add_to_queue(vec![track.clone()]);
                                         active_menu_track.set(None);
                                     }
                                 },

--- a/pages/src/local/favorites.rs
+++ b/pages/src/local/favorites.rs
@@ -110,7 +110,7 @@ pub fn LocalFavorites(
                             active_menu_track.set(None);
                         },
                         on_queue: move |_| {
-                            queue.write().push(track_queue.clone());
+                            ctrl.add_to_queue(vec![track_queue.clone()]);
                             active_menu_track.set(None);
                         },
                         on_close_menu: move |_| active_menu_track.set(None),

--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -155,7 +155,7 @@ div {
                             active_menu_track.set(None);
                         },
                         on_queue: move |_| {
-                            queue.write().push(track_queue.clone());
+                            ctrl.add_to_queue(vec![track_queue.clone()]);
                             active_menu_track.set(None);
                         },
                         on_close_menu: move |_| active_menu_track.set(None),

--- a/pages/src/server/album.rs
+++ b/pages/src/server/album.rs
@@ -5,7 +5,6 @@ use components::selection_bar::SelectionBar;
 use components::track_row::TrackRow;
 use config::{AppConfig, MusicService};
 use dioxus::prelude::*;
-use rand::seq::SliceRandom;
 use reader::{Library, PlaylistStore};
 use server::jellyfin::JellyfinClient;
 use server::subsonic::SubsonicClient;

--- a/pages/src/server/album.rs
+++ b/pages/src/server/album.rs
@@ -36,6 +36,7 @@ pub fn JellyfinAlbum(
                 .cmp(&b.title.trim().to_lowercase())
         });
 
+
         let mut unique_albums = Vec::new();
         let mut seen_titles = std::collections::HashSet::new();
 
@@ -93,6 +94,8 @@ pub fn JellyfinAlbum(
             })
             .collect::<Vec<_>>()
     });
+
+    let mut ctrl = use_context::<hooks::use_player_controller::PlayerController>();
 
     let add_all_to_queue_text = i18n::t("add_all_to_queue").to_string();
     let add_all_to_playlist_text = i18n::t("add_all_to_playlist").to_string();
@@ -181,7 +184,7 @@ pub fn JellyfinAlbum(
                                                                     disc_cmp
                                                                 }
                                                             });
-                                                            queue.write().extend(tracks_for_queue);
+                                                            ctrl.add_to_queue(tracks_for_queue);
                                                         }
                                                         1 => {
                                                             pending_album_id_for_playlist.set(Some(id.clone()));

--- a/pages/src/server/album.rs
+++ b/pages/src/server/album.rs
@@ -694,7 +694,7 @@ pub fn JellyfinAlbumDetails(
                                         active_menu_track.set(None);
                                     },
                                     on_queue: move |_| {
-                                        queue.write().push(track_queue.clone());
+                                        ctrl.add_to_queue(vec![track_queue.clone()]);
                                         active_menu_track.set(None);
                                     },
                                     on_close_menu: move |_| active_menu_track.set(None),

--- a/pages/src/server/artist.rs
+++ b/pages/src/server/artist.rs
@@ -4,7 +4,6 @@ use components::playlist_modal::PlaylistModal;
 use components::selection_bar::SelectionBar;
 use config::{AppConfig, ArtistViewOrder, MusicService};
 use dioxus::prelude::*;
-use rand::seq::SliceRandom;
 use reader::{Library, PlaylistStore};
 use server::jellyfin::JellyfinClient;
 use server::subsonic::SubsonicClient;

--- a/pages/src/server/artist.rs
+++ b/pages/src/server/artist.rs
@@ -723,7 +723,7 @@ pub fn JellyfinArtist(
                                 },
                                 on_queue: move |idx: usize| {
                                     if let Some(track) = artist_tracks().get(idx) {
-                                        queue.write().push(track.clone());
+                                        ctrl.add_to_queue(vec![track.clone()]);
                                         active_menu_track.set(None);
                                     }
                                 },

--- a/pages/src/server/favorites.rs
+++ b/pages/src/server/favorites.rs
@@ -194,7 +194,7 @@ pub fn JellyfinFavorites(
                         active_menu_track.set(None);
                     },
                     on_queue: move |_| {
-                        queue.write().push(track_queue.clone());
+                        ctrl.add_to_queue(vec![track_queue.clone()]);
                         active_menu_track.set(None);
                     },
                     on_close_menu: move |_| active_menu_track.set(None),

--- a/pages/src/server/library.rs
+++ b/pages/src/server/library.rs
@@ -242,7 +242,7 @@ pub fn JellyfinLibrary(
                         active_menu_track.set(None);
                     },
                     on_queue: move |_| {
-                        queue.write().push(track_queue.clone());
+                        ctrl.add_to_queue(vec![track_queue.clone()]);
                         active_menu_track.set(None);
                     },
                     on_close_menu: move |_| active_menu_track.set(None),


### PR DESCRIPTION
# Description
Several shuffle and queue bugs found after compiling the latest commit are fixed in this PR (mainly for queue).

- "Add to Queue" now works when shuffle is on, added tracks go into the shuffle order so they actually get played.
- The "Up Next" panel in both the fullscreen view and sidebar now shows the correct order when shuffle is enabled.
- Reordering tracks while shuffle is on works correctly.
- Pressing previous with no history now restarts the current track.
- Double-clicking a reorder button no longer starts playback.

Also introduces add_to_queue() as a helper on PlayerController to ensure shuffle order is always kept in sync when tracks are added. All existing call that wrote to the queue directly are updated to use it instead.

```rust
// before
ctrl.queue.write().push(track);

// after
ctrl.add_to_queue(vec![track]);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Up Next displays correct upcoming tracks, counts, and total duration in both shuffle and linear modes.
  * Reordering and previous/rewind behavior now operate correctly when shuffle is enabled.
  * Reorder buttons ignore accidental double-clicks to prevent unintended moves.

* **Refactor**
  * Queue operations unified through the player controller for consistent enqueueing and moving across the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/185)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->