### PR TITLE
feat(search): add click to view album on search (solve: #184)

### DIFF
--- a/components/src/search_results.rs
+++ b/components/src/search_results.rs
@@ -25,6 +25,7 @@ pub fn SearchResults(
     mut active_menu_track: Signal<Option<std::path::PathBuf>>,
     mut show_playlist_modal: Signal<bool>,
     mut selected_track_for_playlist: Signal<Option<std::path::PathBuf>>,
+    on_select_album: EventHandler<String>,
 ) -> Element {
     let mut ctrl = use_context::<PlayerController>();
     let config = use_context::<Signal<AppConfig>>();
@@ -112,25 +113,31 @@ pub fn SearchResults(
                     h2 { class: "text-xl font-semibold text-white/80 mb-4", "{i18n::t(\"albums\")}" }
                     div { class: "grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-4",
                         for (album, cover_url) in &albums {
-                            div {
-                                key: "{album.id}",
-                                class: "p-4 bg-white/5 rounded-xl hover:bg-white/10 transition-colors cursor-pointer group",
-                                div {
-                                    class: "aspect-square rounded-lg bg-black/40 mb-3 overflow-hidden relative",
-                                    if let Some(url) = cover_url {
-                                        img {
-                                            src: "{url.as_ref()}",
-                                            class: "w-full h-full object-cover group-hover:scale-105 transition-transform duration-300",
-                                            decoding: "async", loading: "lazy",
+                            {
+                                let album_id = album.id.clone();
+                                rsx! {
+                                    div {
+                                        key: "{album_id}",
+                                        class: "p-4 bg-white/5 rounded-xl hover:bg-white/10 transition-colors cursor-pointer group",
+                                        onclick: move |_| on_select_album.call(album_id.clone()),
+                                        div {
+                                            class: "aspect-square rounded-lg bg-black/40 mb-3 overflow-hidden relative",
+                                            if let Some(url) = cover_url {
+                                                img {
+                                                    src: "{url.as_ref()}",
+                                                    class: "w-full h-full object-cover group-hover:scale-105 transition-transform duration-300",
+                                                    decoding: "async", loading: "lazy",
+                                                }
+                                            } else {
+                                                div { class: "w-full h-full flex items-center justify-center",
+                                                    i { class: "fa-solid fa-compact-disc text-4xl text-white/20" }
+                                                }
+                                            }
                                         }
-                                    } else {
-                                        div { class: "w-full h-full flex items-center justify-center",
-                                            i { class: "fa-solid fa-compact-disc text-4xl text-white/20" }
-                                        }
+                                        h3 { class: "text-white font-medium truncate", "{album.title}" }
+                                        p { class: "text-sm text-slate-400 truncate", "{album.artist}" }
                                     }
                                 }
-                                h3 { class: "text-white font-medium truncate", "{album.title}" }
-                                p { class: "text-sm text-slate-400 truncate", "{album.artist}" }
                             }
                         }
                     }

--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -1415,6 +1415,10 @@ fn App() -> Element {
                                 current_song_progress: current_song_progress,
                                 queue: queue,
                                 current_queue_index: current_queue_index,
+                                on_select_album: move |id: String| {
+                                    selected_album_id.set(id);
+                                    current_route.set(Route::Album);
+                                },
                             }
                         },
                         Route::Library => rsx! {

--- a/pages/src/local/search.rs
+++ b/pages/src/local/search.rs
@@ -25,6 +25,7 @@ pub fn LocalSearch(
     current_song_progress: Signal<u64>,
     queue: Signal<Vec<reader::models::Track>>,
     current_queue_index: Signal<usize>,
+    on_select_album: EventHandler<String>,
 ) -> Element {
     let data = use_search_data(library, search_query, config);
     let mut selected_genre = use_signal(|| None::<String>);
@@ -145,6 +146,7 @@ pub fn LocalSearch(
                         active_menu_track,
                         show_playlist_modal,
                         selected_track_for_playlist,
+                        on_select_album,
                     }
                 } else {
                     SearchGenres {

--- a/pages/src/search.rs
+++ b/pages/src/search.rs
@@ -22,6 +22,7 @@ pub fn Search(
     current_song_progress: Signal<u64>,
     queue: Signal<Vec<reader::models::Track>>,
     current_queue_index: Signal<usize>,
+    on_select_album: EventHandler<String>,
 ) -> Element {
     let is_server = config.read().active_source == MusicSource::Server;
 
@@ -42,6 +43,7 @@ pub fn Search(
                 current_song_progress,
                 queue,
                 current_queue_index,
+                on_select_album,
             }
         } else {
             LocalSearch {
@@ -59,6 +61,7 @@ pub fn Search(
                 current_song_progress,
                 queue,
                 current_queue_index,
+                on_select_album,
             }
         }
     }

--- a/pages/src/server/search.rs
+++ b/pages/src/server/search.rs
@@ -26,6 +26,7 @@ pub fn JellyfinSearch(
     current_song_progress: Signal<u64>,
     queue: Signal<Vec<reader::models::Track>>,
     current_queue_index: Signal<usize>,
+    on_select_album: EventHandler<String>,
 ) -> Element {
     let data = use_search_data(library, search_query, config);
     let mut selected_genre = use_signal(|| None::<String>);
@@ -221,6 +222,7 @@ pub fn JellyfinSearch(
                         active_menu_track,
                         show_playlist_modal,
                         selected_track_for_playlist,
+                        on_select_album,
                     }
                 } else {
                     SearchGenres {


### PR DESCRIPTION
# Description
Able to view album in search now
solve #184 

https://github.com/user-attachments/assets/a2602259-38c7-488b-9819-b22a01dfc460



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Album selection is now enabled in search results. Clicking an album card will navigate you to the album's dedicated page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/187)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->