### PR TITLE
fix: queue behavior in shuffle mode

### DIFF
--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -237,11 +237,15 @@ pub fn Fullscreen(
 
     let (back_items, up_next_items): (Vec<_>, Vec<_>) = if is_shuffle {
         let order = ctrl.shuffle_order.read();
-        let back = order[..current_idx]
+        let back = order
+            .get(..current_idx)
+            .unwrap_or_default()
             .iter()
             .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
             .collect();
-        let next = order[current_idx + 1..]
+        let next = order
+            .get(..current_idx)
+            .unwrap_or_default()
             .iter()
             .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
             .collect();
@@ -587,7 +591,7 @@ pub fn Fullscreen(
                             }
                         }
                     } else if *active_tab.read() == 1 {
-                        if current_idx == q.len() - 1 {
+                        if q.is_empty() || current_idx == q.len() - 1 {
                             div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
                         } else {
                             div {

--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -75,7 +75,7 @@ pub fn Fullscreen(
     let volume_percent = *volume.read() * 100.0;
 
     let mut play_song_at_index = move |index: usize| {
-        ctrl.play_track(index);
+        ctrl.play_track_no_history(index);
     };
     let mut move_queue_item = move |from: usize, to: usize| {
         ctrl.move_queue_item(from, to);
@@ -108,7 +108,11 @@ pub fn Fullscreen(
         let (server_url, server_token, server_user_id) = {
             let conf = config.peek();
             if let Some(server) = &conf.server {
-                (Some(server.url.clone()), server.access_token.clone(), server.user_id.clone())
+                (
+                    Some(server.url.clone()),
+                    server.access_token.clone(),
+                    server.user_id.clone(),
+                )
             } else {
                 (None, None, None)
             }
@@ -136,7 +140,9 @@ pub fn Fullscreen(
             .await;
             if *fetch_gen.peek() == fetch_id {
                 let display = result.or_else(|| {
-                    Some(utils::lyrics::Lyrics::Plain(i18n::t("lyrics_not_found").to_string()))
+                    Some(utils::lyrics::Lyrics::Plain(
+                        i18n::t("lyrics_not_found").to_string(),
+                    ))
                 });
                 lyrics.set(Some(display));
             }
@@ -225,19 +231,39 @@ pub fn Fullscreen(
     } else {
         "background-color: var(--color-black); background-image: none;".to_string()
     };
-    let up_next_count = queue
-        .read()
-        .len()
-        .saturating_sub(*current_queue_index.read() + 1);
-    let up_next_duration: u64 = queue
-        .read()
-        .iter()
-        .skip(*current_queue_index.read() + 1)
-        .map(|track| track.duration)
-        .sum();
+    let q = queue.read();
+    let current_idx = *current_queue_index.read();
+    let is_shuffle = *ctrl.shuffle.read();
+
+    let (back_items, up_next_items): (Vec<_>, Vec<_>) = if is_shuffle {
+        let order = ctrl.shuffle_order.read();
+        let back = order[..current_idx]
+            .iter()
+            .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        let next = order[current_idx + 1..]
+            .iter()
+            .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        (back, next)
+    } else {
+        let back = (0..current_idx)
+            .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        let next = (current_idx + 1..q.len())
+            .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        (back, next)
+    };
+
+    let up_next_count = up_next_items.len();
+    let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
     let up_next_summary = format!(
         "{} • {}",
-        i18n::t_with("showcase_song_count", &[("count", up_next_count.to_string())]),
+        i18n::t_with(
+            "showcase_song_count",
+            &[("count", up_next_count.to_string())]
+        ),
         format_queue_duration(up_next_duration)
     );
 
@@ -529,15 +555,16 @@ pub fn Fullscreen(
                         if *current_queue_index.read() == 0 {
                             div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
                         }
-                        for i in 0..*current_queue_index.read() {
+                        for (list_pos, (queue_idx, track)) in back_items.iter().enumerate() {
                             {
-                                let track = queue.read()[i].clone();
+                                let queue_idx = *queue_idx;
+                                let track_idx = list_pos;
                                 let cover_url = get_track_cover(&track);
                                 rsx! {
                                     div {
-                                        key: "{i}",
+                                        key: "{queue_idx}",
                                         class: "flex items-center gap-4 px-4 py-3 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
-                                        onclick: move |_| play_song_at_index(i),
+                                        onclick: move |_| play_song_at_index(track_idx),
                                         div {
                                             class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
                                             style: "width: 48px; height: 48px;",
@@ -560,7 +587,7 @@ pub fn Fullscreen(
                             }
                         }
                     } else if *active_tab.read() == 1 {
-                        if queue.read().len() <= *current_queue_index.read() + 1 {
+                        if current_idx == q.len() - 1 {
                             div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
                         } else {
                             div {
@@ -568,17 +595,18 @@ pub fn Fullscreen(
                                 "{up_next_summary}"
                             }
                         }
-                        for i in (*current_queue_index.read() + 1)..queue.read().len() {
+                        for (list_pos, (queue_idx, track)) in up_next_items.iter().enumerate() {
                             {
-                                let track = queue.read()[i].clone();
+                                let queue_idx = *queue_idx;
                                 let cover_url = get_track_cover(&track);
-                                let can_move_up = i > *current_queue_index.read() + 1;
-                                let can_move_down = i + 1 < queue.read().len();
+                                let track_idx = current_idx + 1 + list_pos;
+                                let can_move_up = track_idx > current_idx + 1;
+                                let can_move_down = track_idx + 1 < q.len();
                                 rsx! {
                                     div {
-                                        key: "{i}",
+                                        key: "{queue_idx}",
                                         class: "flex items-center gap-4 px-4 py-3 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
-                                        onclick: move |_| play_song_at_index(i),
+                                        onclick: move |_| play_song_at_index(track_idx),
                                         div {
                                             class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
                                             style: "width: 48px; height: 48px;",
@@ -601,8 +629,8 @@ pub fn Fullscreen(
                                             can_move_down,
                                             class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
                                             icon_class: "text-[10px]".to_string(),
-                                            on_move_up: move |_| move_queue_item(i, i - 1),
-                                            on_move_down: move |_| move_queue_item(i, i + 1),
+                                            on_move_up: move |_| move_queue_item(track_idx, track_idx - 1),
+                                            on_move_down: move |_| move_queue_item(track_idx, track_idx + 1),
                                         }
                                     }
                                 }

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -230,11 +230,15 @@ pub fn Rightbar(
 
     let (back_items, up_next_items): (Vec<_>, Vec<_>) = if is_shuffle {
         let order = ctrl.shuffle_order.read();
-        let back = order[..current_idx]
+        let back = order
+            .get(..current_idx)
+            .unwrap_or_default()
             .iter()
             .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
             .collect();
-        let next = order[current_idx + 1..]
+        let next = order
+            .get(..current_idx)
+            .unwrap_or_default()
             .iter()
             .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
             .collect();
@@ -388,7 +392,7 @@ pub fn Rightbar(
                         }
                     }
                 } else if *active_tab.read() == 1 {
-                    if current_idx == q.len() - 1 {
+                    if q.is_empty() || current_idx == q.len() - 1 {
                         div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
                     } else {
                         div {

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -61,7 +61,11 @@ pub fn Rightbar(
         let (server_url, server_token, server_user_id) = {
             let conf = config.peek();
             if let Some(server) = &conf.server {
-                (Some(server.url.clone()), server.access_token.clone(), server.user_id.clone())
+                (
+                    Some(server.url.clone()),
+                    server.access_token.clone(),
+                    server.user_id.clone(),
+                )
             } else {
                 (None, None, None)
             }
@@ -89,7 +93,9 @@ pub fn Rightbar(
             .await;
             if *fetch_gen.peek() == fetch_id {
                 let display = result.or_else(|| {
-                    Some(utils::lyrics::Lyrics::Plain(i18n::t("lyrics_not_found").to_string()))
+                    Some(utils::lyrics::Lyrics::Plain(
+                        i18n::t("lyrics_not_found").to_string(),
+                    ))
                 });
                 lyrics.set(Some(display));
             }
@@ -218,27 +224,39 @@ pub fn Rightbar(
             format!("{minutes}:{secs:02}")
         }
     };
+    let q = queue.read();
+    let current_idx = *current_queue_index.read();
     let is_shuffle = *ctrl.shuffle.read();
-    let up_next_items: Vec<(usize, reader::Track)> = {
-        let q = queue.read();
-        let current_idx = *current_queue_index.read();
-        if is_shuffle {
-            ctrl.shuffle_order
-                .read()
-                .iter()
-                .filter_map(|&qi| q.get(qi).map(|t| (qi, t.clone())))
-                .collect()
-        } else {
-            (current_idx + 1..q.len())
-                .filter_map(|qi| q.get(qi).map(|t| (qi, t.clone())))
-                .collect()
-        }
+
+    let (back_items, up_next_items): (Vec<_>, Vec<_>) = if is_shuffle {
+        let order = ctrl.shuffle_order.read();
+        let back = order[..current_idx]
+            .iter()
+            .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        let next = order[current_idx + 1..]
+            .iter()
+            .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        (back, next)
+    } else {
+        let back = (0..current_idx)
+            .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        let next = (current_idx + 1..q.len())
+            .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        (back, next)
     };
+
     let up_next_count = up_next_items.len();
     let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
     let up_next_summary = format!(
         "{} • {}",
-        i18n::t_with("showcase_song_count", &[("count", up_next_count.to_string())]),
+        i18n::t_with(
+            "showcase_song_count",
+            &[("count", up_next_count.to_string())]
+        ),
         format_queue_duration(up_next_duration)
     );
 
@@ -334,19 +352,20 @@ pub fn Rightbar(
                         }
                     }
                 } else if *active_tab.read() == 0 {
-                    if *current_queue_index.read() == 0 {
+                    if current_idx == 0 {
                         div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
                     }
-                    for i in 0..*current_queue_index.read() {
+                    for (list_pos, (queue_idx, track)) in back_items.iter().enumerate() {
                         {
-                            let track = queue.read()[i].clone();
+                            let queue_idx = *queue_idx;
+                            let track_idx = list_pos;
                             let cover_url = get_track_cover(&track);
                             rsx! {
                                 div {
-                                    key: "{i}",
+                                    key: "{queue_idx}",
                                     class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
                                     style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                                    ondoubleclick: move |_| play_song_at_index(i),
+                                    ondoubleclick: move |_| play_song_at_index(track_idx),
                                     div {
                                         class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
                                         style: "width: 40px; height: 40px;",
@@ -369,7 +388,7 @@ pub fn Rightbar(
                         }
                     }
                 } else if *active_tab.read() == 1 {
-                    if up_next_items.is_empty() {
+                    if current_idx == q.len() - 1 {
                         div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
                     } else {
                         div {
@@ -380,17 +399,16 @@ pub fn Rightbar(
                     for (list_pos, (queue_idx, track)) in up_next_items.iter().enumerate() {
                         {
                             let queue_idx = *queue_idx;
-                            let track = track.clone();
                             let cover_url = get_track_cover(&track);
-                            let current_idx = *current_queue_index.read();
-                            let can_move_up = !is_shuffle && queue_idx > current_idx + 1;
-                            let can_move_down = !is_shuffle && queue_idx + 1 < queue.read().len();
+                            let track_idx = current_idx + 1 + list_pos;
+                            let can_move_up = track_idx > current_idx + 1;
+                            let can_move_down = track_idx + 1 < q.len();
                             rsx! {
                                 div {
-                                    key: "{list_pos}",
+                                    key: "{queue_idx}",
                                     class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
                                     style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                                    ondoubleclick: move |_| play_song_at_index(queue_idx),
+                                    ondoubleclick: move |_| play_song_at_index(track_idx),
                                     div {
                                         class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
                                         style: "width: 40px; height: 40px;",
@@ -408,14 +426,12 @@ pub fn Rightbar(
                                         div { class: "text-sm text-white truncate font-medium", "{track.title}" }
                                         div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
                                     }
-                                    if !is_shuffle {
-                                        ReorderButtons {
-                                            can_move_up,
-                                            can_move_down,
-                                            class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
-                                            on_move_up: move |_| move_queue_item(queue_idx, queue_idx - 1),
-                                            on_move_down: move |_| move_queue_item(queue_idx, queue_idx + 1),
-                                        }
+                                    ReorderButtons {
+                                        can_move_up,
+                                        can_move_down,
+                                        class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
+                                        on_move_up: move |_| move_queue_item(track_idx, track_idx - 1),
+                                        on_move_down: move |_| move_queue_item(track_idx, track_idx + 1),
                                     }
                                 }
                             }

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1225,6 +1225,12 @@ impl PlayerController {
         let queue_len = self.queue.peek().len();
         let current_idx = *self.current_queue_index.peek();
 
+        if queue_len == 0 {
+            self.shuffle_order.set(Vec::new());
+            self.current_queue_index.set(0);
+            return;
+        }
+
         // Tracks that come after the current position (play these first).
         let mut ahead: Vec<usize> = (current_idx..queue_len).collect();
         ahead.shuffle(&mut rand::thread_rng());
@@ -1336,16 +1342,17 @@ impl PlayerController {
     }
 
     pub fn move_queue_item(&mut self, from: usize, to: usize) {
-        if *self.shuffle.peek() {
-            self.shuffle_order.with_mut(|so| so.swap(from, to));
-        } else {
-            self.move_physical_queue_item(from, to);
-        }
+        self.move_physical_queue_item(from, to);
     }
 
     fn move_physical_queue_item(&mut self, from: usize, to: usize) {
         let len = self.queue.peek().len();
         if from >= len || to >= len || from == to {
+            return;
+        }
+
+        if *self.shuffle.peek() {
+            self.shuffle_order.with_mut(|so| so.swap(from, to));
             return;
         }
 

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1272,7 +1272,7 @@ impl PlayerController {
         if now_on {
             self.rebuild_shuffle_order();
         } else {
-            // reset current queue index to match track index when not in shuffle mode
+            // reset current queue index to match track index when turning off shuffle mode
             let current_idx = *self.current_queue_index.peek();
             self.current_queue_index
                 .set(self.shuffle_order.peek()[current_idx]);

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -1274,8 +1274,13 @@ impl PlayerController {
         } else {
             // reset current queue index to match track index when turning off shuffle mode
             let current_idx = *self.current_queue_index.peek();
-            self.current_queue_index
-                .set(self.shuffle_order.peek()[current_idx]);
+            self.current_queue_index.set(
+                *self
+                    .shuffle_order
+                    .peek()
+                    .get(current_idx)
+                    .unwrap_or(&current_idx),
+            );
         }
     }
 

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -76,6 +76,15 @@ impl PlayerController {
     }
 
     fn current_track(&self, idx: usize) -> Option<Track> {
+        let idx = if *self.shuffle.peek() {
+            *self
+                .shuffle_order
+                .peek()
+                .get(idx)
+                .expect("shuffle order index out of bounds")
+        } else {
+            idx
+        };
         self.queue.peek().get(idx).cloned()
     }
 
@@ -152,7 +161,8 @@ impl PlayerController {
             self.current_song_bitrate.set(track.bitrate);
             self.current_song_duration.set(track.duration);
             self.current_song_progress.set(progress_secs);
-            self.current_song_cover_url.set(self.cover_url_for_track(&track));
+            self.current_song_cover_url
+                .set(self.cover_url_for_track(&track));
         } else {
             self.current_queue_index.set(0);
             self.clear_current_track_metadata();
@@ -299,7 +309,16 @@ impl PlayerController {
                 h.push(current_idx);
             }
         });
-        self.play_track_no_history_without_crossfade(idx);
+
+        if *self.shuffle.peek() {
+            // workaround: shuffle enable/disable needed to play the selected track when shuffle is enabled
+            self.shuffle.set(false);
+            self.play_track_no_history_without_crossfade(idx);
+            self.shuffle.set(true);
+            self.rebuild_shuffle_order();
+        } else {
+            self.play_track_no_history_without_crossfade(idx);
+        }
     }
 
     pub fn play_track_no_history(&mut self, idx: usize) {
@@ -319,11 +338,11 @@ impl PlayerController {
             let (restore_seek_secs, clear_pending_resume_on_success) =
                 self.pending_resume_seek(&track);
             let use_crossfade = allow_crossfade
-                &&
-                self.should_crossfade() && restore_seek_secs.map_or(true, |secs| secs == 0);
+                && self.should_crossfade()
+                && restore_seek_secs.map_or(true, |secs| secs == 0);
             let outgoing_duration_secs = *self.current_song_duration.peek();
-            let outgoing_progress_secs = (*self.current_song_progress.peek())
-                .min(outgoing_duration_secs);
+            let outgoing_progress_secs =
+                (*self.current_song_progress.peek()).min(outgoing_duration_secs);
             if !use_crossfade {
                 self.clear_pending_crossfade_ui();
             }
@@ -344,7 +363,9 @@ impl PlayerController {
                 #[cfg(not(target_arch = "wasm32"))]
                 {
                     let offline_path = {
-                        let raw = self.config.read()
+                        let raw = self
+                            .config
+                            .read()
                             .offline_tracks
                             .get(&id)
                             .map(std::path::PathBuf::from)
@@ -502,7 +523,6 @@ impl PlayerController {
                         }
                     })
                 } {
-
                     if stream_url.is_empty() {
                         self.is_loading.set(false);
                         self.skip_in_progress.set(false);
@@ -605,17 +625,37 @@ impl PlayerController {
                                         let subsonic_now = {
                                             let conf = scrobble_cfg.read();
                                             conf.server.as_ref().and_then(|s| {
-                                                if matches!(s.service, MusicService::Subsonic | MusicService::Custom) {
-                                                    if let (Some(pw), Some(un)) = (&s.access_token, &s.user_id) {
-                                                        Some((s.url.clone(), un.clone(), pw.clone()))
-                                                    } else { None }
-                                                } else { None }
+                                                if matches!(
+                                                    s.service,
+                                                    MusicService::Subsonic | MusicService::Custom
+                                                ) {
+                                                    if let (Some(pw), Some(un)) =
+                                                        (&s.access_token, &s.user_id)
+                                                    {
+                                                        Some((
+                                                            s.url.clone(),
+                                                            un.clone(),
+                                                            pw.clone(),
+                                                        ))
+                                                    } else {
+                                                        None
+                                                    }
+                                                } else {
+                                                    None
+                                                }
                                             })
                                         };
                                         if let Some((url, username, password)) = subsonic_now {
-                                            let client = ::server::subsonic::SubsonicClient::new(&url, &username, &password);
-                                            if let Err(e) = client.scrobble_now_playing(&scrobble_id).await {
-                                                tracing::warn!("Subsonic now-playing failed: {}", e);
+                                            let client = ::server::subsonic::SubsonicClient::new(
+                                                &url, &username, &password,
+                                            );
+                                            if let Err(e) =
+                                                client.scrobble_now_playing(&scrobble_id).await
+                                            {
+                                                tracing::warn!(
+                                                    "Subsonic now-playing failed: {}",
+                                                    e
+                                                );
                                             }
                                         }
                                     }
@@ -641,10 +681,7 @@ impl PlayerController {
                                         )
                                         .await
                                         {
-                                            tracing::warn!(
-                                                "failed to submit playing_now: {}",
-                                                e
-                                            );
+                                            tracing::warn!("failed to submit playing_now: {}", e);
                                         }
                                     }
 
@@ -661,22 +698,40 @@ impl PlayerController {
                                         let subsonic_scrobble = {
                                             let conf = scrobble_cfg.read();
                                             conf.server.as_ref().and_then(|s| {
-                                                if matches!(s.service, MusicService::Subsonic | MusicService::Custom) {
-                                                    if let (Some(pw), Some(un)) = (&s.access_token, &s.user_id) {
-                                                        Some((s.url.clone(), un.clone(), pw.clone()))
-                                                    } else { None }
-                                                } else { None }
+                                                if matches!(
+                                                    s.service,
+                                                    MusicService::Subsonic | MusicService::Custom
+                                                ) {
+                                                    if let (Some(pw), Some(un)) =
+                                                        (&s.access_token, &s.user_id)
+                                                    {
+                                                        Some((
+                                                            s.url.clone(),
+                                                            un.clone(),
+                                                            pw.clone(),
+                                                        ))
+                                                    } else {
+                                                        None
+                                                    }
+                                                } else {
+                                                    None
+                                                }
                                             })
                                         };
                                         if let Some((url, username, password)) = subsonic_scrobble {
-                                            let client = ::server::subsonic::SubsonicClient::new(&url, &username, &password);
+                                            let client = ::server::subsonic::SubsonicClient::new(
+                                                &url, &username, &password,
+                                            );
                                             match client.scrobble(&scrobble_id).await {
                                                 Ok(_) => tracing::info!(
                                                     "Subsonic scrobbled: {} - {}",
                                                     scrobble_track.artist,
                                                     scrobble_track.title
                                                 ),
-                                                Err(e) => tracing::warn!("Subsonic scrobble failed: {}", e),
+                                                Err(e) => tracing::warn!(
+                                                    "Subsonic scrobble failed: {}",
+                                                    e
+                                                ),
                                             }
                                         }
                                     }
@@ -790,24 +845,33 @@ impl PlayerController {
                                 let scrobble_cfg = cfg_signal;
                                 let scrobble_id = id.clone();
                                 let duration_secs = scrobble_track.duration;
-                                let threshold_secs =
-                                    std::cmp::min(240, (duration_secs / 2) as u64);
+                                let threshold_secs = std::cmp::min(240, (duration_secs / 2) as u64);
 
                                 spawn(async move {
                                     {
                                         let conf = scrobble_cfg.read();
                                         if let Some(server) = conf.server.as_ref() {
-                                            if matches!(server.service, MusicService::Subsonic | MusicService::Custom) {
+                                            if matches!(
+                                                server.service,
+                                                MusicService::Subsonic | MusicService::Custom
+                                            ) {
                                                 if let (Some(password), Some(username)) =
                                                     (&server.access_token, &server.user_id)
                                                 {
-                                                    let client = ::server::subsonic::SubsonicClient::new(
-                                                        &server.url,
-                                                        username,
-                                                        password,
-                                                    );
-                                                    if let Err(e) = client.scrobble_now_playing(&scrobble_id).await {
-                                                        tracing::warn!("Subsonic now-playing failed: {}", e);
+                                                    let client =
+                                                        ::server::subsonic::SubsonicClient::new(
+                                                            &server.url,
+                                                            username,
+                                                            password,
+                                                        );
+                                                    if let Err(e) = client
+                                                        .scrobble_now_playing(&scrobble_id)
+                                                        .await
+                                                    {
+                                                        tracing::warn!(
+                                                            "Subsonic now-playing failed: {}",
+                                                            e
+                                                        );
                                                     }
                                                 }
                                             }
@@ -835,10 +899,7 @@ impl PlayerController {
                                         )
                                         .await
                                         {
-                                            tracing::warn!(
-                                                "failed to submit playing_now: {}",
-                                                e
-                                            );
+                                            tracing::warn!("failed to submit playing_now: {}", e);
                                         }
                                     }
 
@@ -853,22 +914,40 @@ impl PlayerController {
                                         let subsonic_scrobble = {
                                             let conf = scrobble_cfg.read();
                                             conf.server.as_ref().and_then(|s| {
-                                                if matches!(s.service, MusicService::Subsonic | MusicService::Custom) {
-                                                    if let (Some(pw), Some(un)) = (&s.access_token, &s.user_id) {
-                                                        Some((s.url.clone(), un.clone(), pw.clone()))
-                                                    } else { None }
-                                                } else { None }
+                                                if matches!(
+                                                    s.service,
+                                                    MusicService::Subsonic | MusicService::Custom
+                                                ) {
+                                                    if let (Some(pw), Some(un)) =
+                                                        (&s.access_token, &s.user_id)
+                                                    {
+                                                        Some((
+                                                            s.url.clone(),
+                                                            un.clone(),
+                                                            pw.clone(),
+                                                        ))
+                                                    } else {
+                                                        None
+                                                    }
+                                                } else {
+                                                    None
+                                                }
                                             })
                                         };
                                         if let Some((url, username, password)) = subsonic_scrobble {
-                                            let client = ::server::subsonic::SubsonicClient::new(&url, &username, &password);
+                                            let client = ::server::subsonic::SubsonicClient::new(
+                                                &url, &username, &password,
+                                            );
                                             match client.scrobble(&scrobble_id).await {
                                                 Ok(_) => tracing::info!(
                                                     "Subsonic scrobbled: {} - {}",
                                                     scrobble_track.artist,
                                                     scrobble_track.title
                                                 ),
-                                                Err(e) => tracing::warn!("Subsonic scrobble failed: {}", e),
+                                                Err(e) => tracing::warn!(
+                                                    "Subsonic scrobble failed: {}",
+                                                    e
+                                                ),
                                             }
                                         }
                                     }
@@ -1084,52 +1163,20 @@ impl PlayerController {
         }
 
         let loop_mode = *self.loop_mode.peek();
-        let shuffle = *self.shuffle.peek();
 
         match loop_mode {
             LoopMode::Track => {
                 self.play_track_with_history(idx, allow_crossfade);
             }
             _ => {
-                if shuffle && queue_len > 1 {
-                    let is_empty = self.shuffle_order.peek().is_empty();
-
-                    // When the shuffled list is exhausted in queue-loop mode,
-                    // rebuild it so playback continues in a new random order
-                    // starting from the next track after the current one.
-                    if is_empty && loop_mode == LoopMode::Queue {
-                        self.rebuild_shuffle_order();
-                    }
-
-                    let next_idx = self.shuffle_order.with_mut(|order| {
-                        if !order.is_empty() {
-                            Some(order.remove(0))
-                        } else {
-                            None
-                        }
-                    });
-
-                    match next_idx {
-                        Some(i) => {
-                            self.play_track_with_history(i, allow_crossfade);
-                        }
-                        None => {
-                            self.skip_in_progress.set(false);
-                            self.player.write().pause();
-                            self.is_playing.set(false);
-                        }
-                    }
-                } else if shuffle && queue_len == 1 {
-                    self.play_track_with_history(0, allow_crossfade);
-                } else if idx + 1 < queue_len {
-                    self.play_track_with_history(idx + 1, allow_crossfade);
-                } else if loop_mode == LoopMode::Queue {
-                    self.play_track_with_history(0, allow_crossfade);
-                } else {
+                if idx > queue_len - 1 && loop_mode == LoopMode::None {
                     self.skip_in_progress.set(false);
                     self.player.write().pause();
                     self.is_playing.set(false);
+                    return;
                 }
+                let next_idx = if idx + 1 < queue_len { idx + 1 } else { 0 };
+                self.play_track_with_history(next_idx, allow_crossfade);
             }
         }
     }
@@ -1141,12 +1188,7 @@ impl PlayerController {
                 h.push(current_idx);
             }
         });
-
-        if allow_crossfade {
-            self.play_track_no_history_with_transition(track_idx, true);
-        } else {
-            self.play_track_no_history_without_crossfade(track_idx);
-        }
+        self.play_track_no_history_with_transition(track_idx, allow_crossfade);
     }
 
     pub fn play_prev(&mut self) {
@@ -1184,14 +1226,23 @@ impl PlayerController {
         let current_idx = *self.current_queue_index.peek();
 
         // Tracks that come after the current position (play these first).
-        let mut ahead: Vec<usize> = (current_idx + 1..queue_len).collect();
+        let mut ahead: Vec<usize> = (current_idx..queue_len).collect();
         ahead.shuffle(&mut rand::thread_rng());
+        // move current played track to the front
+        let pos = ahead
+            .iter()
+            .position(|&i| i == current_idx)
+            .expect("cannot find current index in shuffle order");
+        ahead.swap(pos, 0);
 
         // Tracks that wrap around from the beginning (play after the ahead group).
         let mut wrapped: Vec<usize> = (0..current_idx).collect();
         wrapped.shuffle(&mut rand::thread_rng());
 
         ahead.extend(wrapped);
+        // reset current queue index to match the currently played track (now moved at pos 0)
+        // will be used as a pointer to the retrieve the current track in the shuffled order
+        self.current_queue_index.set(0);
         self.shuffle_order.set(ahead);
     }
 
@@ -1203,11 +1254,8 @@ impl PlayerController {
         }
 
         self.queue.set(tracks);
-        self.shuffle_order.set(Vec::new());
         let start = rand::thread_rng().gen_range(0..queue_len);
-
         self.play_track(start);
-        self.rebuild_shuffle_order();
     }
 
     pub fn play_queue_linear(&mut self, tracks: Vec<Track>) {
@@ -1215,7 +1263,6 @@ impl PlayerController {
             return;
         }
         self.queue.set(tracks);
-        self.shuffle_order.set(Vec::new());
         self.play_track(0);
     }
 
@@ -1224,6 +1271,11 @@ impl PlayerController {
         self.shuffle.set(now_on);
         if now_on {
             self.rebuild_shuffle_order();
+        } else {
+            // reset current queue index to match track index when not in shuffle mode
+            let current_idx = *self.current_queue_index.peek();
+            self.current_queue_index
+                .set(self.shuffle_order.peek()[current_idx]);
         }
     }
 
@@ -1265,20 +1317,24 @@ impl PlayerController {
             return;
         }
 
-        self.queue.with_mut(|queue| {
-            let track = queue.remove(from);
-            queue.insert(to, track);
-        });
+        if *self.shuffle.peek() {
+            self.shuffle_order.with_mut(|o| o.swap(from, to));
+        } else {
+            self.queue.with_mut(|queue| {
+                let track = queue.remove(from);
+                queue.insert(to, track);
+            });
 
-        let current_idx = *self.current_queue_index.peek();
-        self.current_queue_index
-            .set(Self::remap_queue_index(current_idx, from, to));
+            let current_idx = *self.current_queue_index.peek();
+            self.current_queue_index
+                .set(Self::remap_queue_index(current_idx, from, to));
 
-        self.history.with_mut(|history| {
-            for idx in history.iter_mut() {
-                *idx = Self::remap_queue_index(*idx, from, to);
-            }
-        });
+            self.history.with_mut(|history| {
+                for idx in history.iter_mut() {
+                    *idx = Self::remap_queue_index(*idx, from, to);
+                }
+            });
+        }
     }
 
     pub fn restore_queue_state(


### PR DESCRIPTION
The 'back' tab in rightbar and fullscreen component, was not displaying the correct items when in shuffle mode.
Fixed next/previous and reorder actions on shuffle mode using `current_queue_index` as a pointer to retrieve the current track, preserving the queue state. Reordering in shuffle mode should work fine.
Also now when selecting a track (double click) in the library, album, ..., in shuffle mode, that will be the first played in the queue.
By disabling shuffle mode the queue will continue from the currently played track position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shuffle and queue navigation so selecting, advancing, and reordering tracks behave consistently and preserve the correct current track.
  * Corrected empty-state display for "Up next" and "Previous songs".
  * Ensured selecting a track can avoid creating history or triggering crossfades when intended.

* **Refactor**
  * Streamlined queue/shuffle/up-next/back computation and reorder controls for more reliable UI updates.

* **Style**
  * Reformatted lyrics-not-found fallback construction for clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/197)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->