### PR TITLE
feat(queue): add add-to-queue in Selection

### DIFF
--- a/components/src/selection_bar.rs
+++ b/components/src/selection_bar.rs
@@ -3,6 +3,7 @@ use dioxus::prelude::*;
 #[component]
 pub fn SelectionBar(
     count: usize,
+    on_add_to_queue: EventHandler<()>,
     on_add_to_playlist: EventHandler<()>,
     on_delete: EventHandler<()>,
     on_cancel: EventHandler<()>,
@@ -13,6 +14,7 @@ pub fn SelectionBar(
     }
 
     let delete_text = i18n::t("delete").to_string();
+    let add_to_queue_text = i18n::t("add_to_queue").to_string();
     let add_to_playlist_text = i18n::t("add_to_playlist").to_string();
 
     rsx! {
@@ -24,6 +26,12 @@ pub fn SelectionBar(
             div { class: "w-px h-5 bg-white/20" }
 
             div { class: "flex items-center gap-4",
+                button {
+                    class: "hover:opacity-80 transition-opacity flex items-center gap-2 font-medium whitespace-nowrap",
+                    onclick: move |_| on_add_to_queue.call(()),
+                    i { class: "fa-solid fa-list-ul text-sm" }
+                    span { class: "hidden sm:inline", "{add_to_queue_text}" }
+                }
                 button {
                     class: "hover:opacity-80 transition-opacity flex items-center gap-2 font-medium whitespace-nowrap",
                     onclick: move |_| on_add_to_playlist.call(()),

--- a/components/src/track_list_view.rs
+++ b/components/src/track_list_view.rs
@@ -161,8 +161,13 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
                         if selected.is_empty() {
                             return;
                         }
-                        for track in tracks_sel_queue.iter().filter(|t| selected.contains(&t.path)) {
-                            ctrl.add_to_queue(vec![track.clone()]);
+                        let tracks: Vec<_> = tracks_sel_queue
+                            .iter()
+                            .filter(|t| selected.contains(&t.path))
+                            .cloned()
+                            .collect();
+                        if !tracks.is_empty() {
+                            ctrl.add_to_queue(tracks);
                         }
                         selected_tracks.write().clear();
                         is_selection_mode.set(false);

--- a/components/src/track_list_view.rs
+++ b/components/src/track_list_view.rs
@@ -52,6 +52,7 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
     let tracks_queue = props.tracks.clone();
     let tracks_menu = props.tracks.clone();
     let tracks_sel_delete = props.tracks.clone();
+    let tracks_sel_queue = props.tracks.clone();
 
     rsx! {
         div { class: "w-full max-w-[1600px] mx-auto select-none",
@@ -155,6 +156,17 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
                 crate::selection_bar::SelectionBar {
                     count: selected_tracks.read().len(),
                     show_delete: props.show_delete_in_selection,
+                    on_add_to_queue: move |_| {
+                        let selected = selected_tracks.read().clone();
+                        if selected.is_empty() {
+                            return;
+                        }
+                        for track in tracks_sel_queue.iter().filter(|t| selected.contains(&t.path)) {
+                            ctrl.add_to_queue(vec![track.clone()]);
+                        }
+                        selected_tracks.write().clear();
+                        is_selection_mode.set(false);
+                    },
                     on_add_to_playlist: move |_| show_playlist_modal.set(true),
                     on_delete: move |_| {
                         let paths: Vec<PathBuf> = tracks_sel_delete.iter()

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -242,9 +242,14 @@ pub fn LocalArtist(
                                 if selected.is_empty() {
                                     return;
                                 }
-                                let tracks = artist_tracks();
-                                for track in tracks.iter().filter(|t| selected.contains(&t.path)) {
-                                    ctrl.add_to_queue(vec![track.clone()]);
+                                let tracks: Vec<_> = artist_tracks()
+                                    .iter()
+                                    .filter(|t| selected.contains(&t.path))
+                                    .cloned()
+                                    .collect();
+                                
+                                if !tracks.is_empty() {
+                                    ctrl.add_to_queue(tracks);
                                 }
                                 clear_selection(&mut is_selection_mode, &mut selected_tracks);
                             },

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -237,6 +237,17 @@ pub fn LocalArtist(
                     if is_selection_mode() {
                         SelectionBar {
                             count: selected_tracks.read().len(),
+                            on_add_to_queue: move |_| {
+                                let selected = selected_tracks.read().clone();
+                                if selected.is_empty() {
+                                    return;
+                                }
+                                let tracks = artist_tracks();
+                                for track in tracks.iter().filter(|t| selected.contains(&t.path)) {
+                                    ctrl.add_to_queue(vec![track.clone()]);
+                                }
+                                clear_selection(&mut is_selection_mode, &mut selected_tracks);
+                            },
                             on_add_to_playlist: move |_| show_playlist_modal.set(true),
                             on_delete: move |_| {
                                 let paths: Vec<_> = selected_tracks.read().iter().cloned().collect();

--- a/pages/src/local/favorites.rs
+++ b/pages/src/local/favorites.rs
@@ -194,8 +194,13 @@ pub fn LocalFavorites(
                         if selected.is_empty() {
                             return;
                         }
-                        for track in queue_tracks_for_selection.iter().filter(|t| selected.contains(&t.path)) {
-                            ctrl.add_to_queue(vec![track.clone()]);
+                        let tracks: Vec<_> = queue_tracks_for_selection
+                            .iter()
+                            .filter(|t| selected.contains(&t.path))
+                            .cloned()
+                            .collect();
+                        if !tracks.is_empty() {
+                            ctrl.add_to_queue(tracks);
                         }
                         selected_tracks.write().clear();
                         is_selection_mode.set(false);

--- a/pages/src/local/favorites.rs
+++ b/pages/src/local/favorites.rs
@@ -52,6 +52,7 @@ pub fn LocalFavorites(
 
     let queue_tracks: Vec<reader::models::Track> =
         displayed_tracks.iter().map(|(t, _)| t.clone()).collect();
+    let queue_tracks_for_selection = queue_tracks.clone();
 
     let is_empty = displayed_tracks.is_empty();
 
@@ -188,6 +189,17 @@ pub fn LocalFavorites(
             if is_selection_mode() {
                 SelectionBar {
                     count: selected_tracks.read().len(),
+                    on_add_to_queue: move |_| {
+                        let selected = selected_tracks.read().clone();
+                        if selected.is_empty() {
+                            return;
+                        }
+                        for track in queue_tracks_for_selection.iter().filter(|t| selected.contains(&t.path)) {
+                            ctrl.add_to_queue(vec![track.clone()]);
+                        }
+                        selected_tracks.write().clear();
+                        is_selection_mode.set(false);
+                    },
                     on_add_to_playlist: move |_| {
                         show_playlist_modal.set(true);
                     },

--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -242,9 +242,13 @@ div {
                         if selected.is_empty() {
                             return;
                         }
-                        let tracks = displayed_tracks.read();
-                        for track in tracks.iter().filter(|t| selected.contains(&t.path)) {
-                            ctrl.add_to_queue(vec![track.clone()]);
+                        let tracks: Vec<_> = displayed_tracks.read()
+                            .iter()
+                            .filter(|t| selected.contains(&t.path))
+                            .cloned()
+                            .collect();
+                        if !tracks.is_empty() {
+                            ctrl.add_to_queue(tracks);
                         }
                         selected_tracks.write().clear();
                         is_selection_mode.set(false);

--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -237,6 +237,18 @@ div {
             if is_selection_mode() {
                 SelectionBar {
                     count: selected_tracks.read().len(),
+                    on_add_to_queue: move |_| {
+                        let selected = selected_tracks.read().clone();
+                        if selected.is_empty() {
+                            return;
+                        }
+                        let tracks = displayed_tracks.read();
+                        for track in tracks.iter().filter(|t| selected.contains(&t.path)) {
+                            ctrl.add_to_queue(vec![track.clone()]);
+                        }
+                        selected_tracks.write().clear();
+                        is_selection_mode.set(false);
+                    },
                     on_add_to_playlist: move |_| {
                         show_playlist_modal.set(true);
                     },

--- a/pages/src/server/album.rs
+++ b/pages/src/server/album.rs
@@ -466,9 +466,13 @@ pub fn JellyfinAlbumDetails(
                         if selected.is_empty() {
                             return;
                         }
-                        let tracks = album_tracks();
-                        for (track, _) in tracks.iter().filter(|(t, _)| selected.contains(&t.path)) {
-                            ctrl.add_to_queue(vec![track.clone()]);
+                        let tracks: Vec<_> = album_tracks()
+                            .iter()
+                            .filter(|(t, _)| selected.contains(&t.path))
+                            .map(|(track, _)| track.clone())
+                            .collect();
+                        if !album_tracks.is_empty() {
+                            ctrl.add_to_queue(tracks);
                         }
                         is_selection_mode.set(false);
                         selected_tracks.write().clear();

--- a/pages/src/server/album.rs
+++ b/pages/src/server/album.rs
@@ -461,6 +461,18 @@ pub fn JellyfinAlbumDetails(
                 SelectionBar {
                     count: selected_tracks.read().len(),
                     show_delete: false,
+                    on_add_to_queue: move |_| {
+                        let selected = selected_tracks.read().clone();
+                        if selected.is_empty() {
+                            return;
+                        }
+                        let tracks = album_tracks();
+                        for (track, _) in tracks.iter().filter(|(t, _)| selected.contains(&t.path)) {
+                            ctrl.add_to_queue(vec![track.clone()]);
+                        }
+                        is_selection_mode.set(false);
+                        selected_tracks.write().clear();
+                    },
                     on_add_to_playlist: move |_| {
                         show_playlist_modal.set(true);
                     },

--- a/pages/src/server/artist.rs
+++ b/pages/src/server/artist.rs
@@ -379,9 +379,13 @@ pub fn JellyfinArtist(
                                 if selected.is_empty() {
                                     return;
                                 }
-                                let tracks = artist_tracks();
-                                for track in tracks.iter().filter(|t| selected.contains(&t.path)) {
-                                    ctrl.add_to_queue(vec![track.clone()]);
+                                let tracks: Vec<_> = artist_tracks()
+                                    .iter()
+                                    .filter(|t| selected.contains(&t.path))
+                                    .cloned()
+                                    .collect();
+                                if !tracks.is_empty() {
+                                ctrl.add_to_queue(tracks);
                                 }
                                 is_selection_mode.set(false);
                                 selected_tracks.write().clear();

--- a/pages/src/server/artist.rs
+++ b/pages/src/server/artist.rs
@@ -374,6 +374,18 @@ pub fn JellyfinArtist(
                         SelectionBar {
                             count: selected_tracks.read().len(),
                             show_delete: false,
+                            on_add_to_queue: move |_| {
+                                let selected = selected_tracks.read().clone();
+                                if selected.is_empty() {
+                                    return;
+                                }
+                                let tracks = artist_tracks();
+                                for track in tracks.iter().filter(|t| selected.contains(&t.path)) {
+                                    ctrl.add_to_queue(vec![track.clone()]);
+                                }
+                                is_selection_mode.set(false);
+                                selected_tracks.write().clear();
+                            },
                             on_add_to_playlist: move |_| {
                                 show_playlist_modal.set(true);
                             },

--- a/pages/src/server/favorites.rs
+++ b/pages/src/server/favorites.rs
@@ -343,8 +343,13 @@ pub fn JellyfinFavorites(
                         if selected.is_empty() {
                             return;
                         }
-                        for (track, _) in displayed_tracks_for_selection.iter().filter(|(t, _)| selected.contains(&t.path)) {
-                            ctrl.add_to_queue(vec![track.clone()]);
+                        let tracks: Vec<_> = displayed_tracks_for_selection
+                            .iter()
+                            .filter(|(t, _)| selected.contains(&t.path))
+                            .map(|(track, _)| track.clone())
+                            .collect();
+                        if !tracks.is_empty() {
+                            ctrl.add_to_queue(tracks);
                         }
                         is_selection_mode.set(false);
                         selected_tracks.write().clear();

--- a/pages/src/server/favorites.rs
+++ b/pages/src/server/favorites.rs
@@ -127,6 +127,7 @@ pub fn JellyfinFavorites(
     let queue_tracks: Vec<reader::models::Track> =
         displayed_tracks.iter().map(|(t, _)| t.clone()).collect();
 
+    let displayed_tracks_for_selection = displayed_tracks.clone();
     let is_empty = displayed_tracks.is_empty();
 
     let tracks_nodes = displayed_tracks
@@ -337,6 +338,17 @@ pub fn JellyfinFavorites(
                 SelectionBar {
                     count: selected_tracks.read().len(),
                     show_delete: false,
+                    on_add_to_queue: move |_| {
+                        let selected = selected_tracks.read().clone();
+                        if selected.is_empty() {
+                            return;
+                        }
+                        for (track, _) in displayed_tracks_for_selection.iter().filter(|(t, _)| selected.contains(&t.path)) {
+                            ctrl.add_to_queue(vec![track.clone()]);
+                        }
+                        is_selection_mode.set(false);
+                        selected_tracks.write().clear();
+                    },
                     on_add_to_playlist: move |_| {
                         show_playlist_modal.set(true);
                     },

--- a/pages/src/server/library.rs
+++ b/pages/src/server/library.rs
@@ -415,9 +415,13 @@ pub fn JellyfinLibrary(
                         if selected.is_empty() {
                             return;
                         }
-                        let tracks = displayed_tracks.read();
-                        for (track, _) in tracks.iter().filter(|(t, _)| selected.contains(&t.path)) {
-                            ctrl.add_to_queue(vec![track.clone()]);
+                        let tracks: Vec<_> = displayed_tracks.read()
+                            .iter()
+                            .filter(|(t, _)| selected.contains(&t.path))
+                            .map(|(track, _)| track.clone())
+                            .collect();
+                        if !tracks.is_empty() {
+                            ctrl.add_to_queue(tracks);
                         }
                         is_selection_mode.set(false);
                         selected_tracks.write().clear();

--- a/pages/src/server/library.rs
+++ b/pages/src/server/library.rs
@@ -410,6 +410,18 @@ pub fn JellyfinLibrary(
                 SelectionBar {
                     count: selected_tracks.read().len(),
                     show_delete: false,
+                    on_add_to_queue: move |_| {
+                        let selected = selected_tracks.read().clone();
+                        if selected.is_empty() {
+                            return;
+                        }
+                        let tracks = displayed_tracks.read();
+                        for (track, _) in tracks.iter().filter(|(t, _)| selected.contains(&t.path)) {
+                            ctrl.add_to_queue(vec![track.clone()]);
+                        }
+                        is_selection_mode.set(false);
+                        selected_tracks.write().clear();
+                    },
                     on_add_to_playlist: move |_| {
                         show_playlist_modal.set(true);
                     },


### PR DESCRIPTION
small follow up from yesterday, this PR adds "Add to Queue" button to Selection bar

* https://github.com/Kopuz-org/kopuz/pull/176



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Add to Queue" action to multi-selection mode. Users can select multiple tracks and enqueue them from library, artist, album and favorites views (local and server).
  * The action appears alongside existing selection controls and clears the selection/exit selection mode after enqueuing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/199)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->