### PR TITLE
feat: Add local artist image handling and improve artwork URL formatting

### DIFF
--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -10,9 +10,9 @@ use components::{
     rightbar::Rightbar, sidebar::Sidebar, titlebar::Titlebar,
 };
 #[cfg(not(target_arch = "wasm32"))]
-use dioxus::desktop::tao::dpi::LogicalSize;
-#[cfg(not(target_arch = "wasm32"))]
 use dioxus::desktop::RequestAsyncResponder;
+#[cfg(not(target_arch = "wasm32"))]
+use dioxus::desktop::tao::dpi::LogicalSize;
 #[cfg(all(not(target_arch = "wasm32"), target_os = "macos"))]
 use dioxus::desktop::tao::platform::macos::WindowBuilderExtMacOS;
 use dioxus::prelude::*;
@@ -45,7 +45,12 @@ fn migrate_legacy_locations() {
     }
 
     let old_cache = dirs.cache_dir().to_path_buf();
-    let files = ["library.json", "playlists.json", "favorites.json", "queue_state.json"];
+    let files = [
+        "library.json",
+        "playlists.json",
+        "favorites.json",
+        "queue_state.json",
+    ];
     for file in files {
         let src = old_cache.join(file);
         let dst = new_config.join(file);
@@ -294,7 +299,6 @@ fn hq_cache_path(file_path: &str) -> std::path::PathBuf {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn make_thumbnail(raw: &[u8], cache_path: &std::path::Path) -> Option<Vec<u8>> {
-    use image::GenericImageView;
     use image::codecs::jpeg::JpegEncoder;
     let img = image::load_from_memory(raw).ok()?;
     const MAX: u32 = 400;
@@ -304,7 +308,8 @@ fn make_thumbnail(raw: &[u8], cache_path: &std::path::Path) -> Option<Vec<u8>> {
         img
     };
     let mut out: Vec<u8> = Vec::new();
-    img.write_with_encoder(JpegEncoder::new_with_quality(&mut out, 75)).ok()?;
+    img.write_with_encoder(JpegEncoder::new_with_quality(&mut out, 75))
+        .ok()?;
     let _ = std::fs::write(cache_path, &out);
     Some(out)
 }
@@ -313,7 +318,6 @@ fn make_thumbnail(raw: &[u8], cache_path: &std::path::Path) -> Option<Vec<u8>> {
 // or None when the original is already small enough to serve as-is.
 #[cfg(not(target_arch = "wasm32"))]
 fn make_hq_image(raw: &[u8], cache_path: &std::path::Path) -> Option<Vec<u8>> {
-    use image::GenericImageView;
     use image::codecs::jpeg::JpegEncoder;
     const SIZE_LIMIT: usize = 2 * 1024 * 1024; // 2 MB
     const MAX_DIM: u32 = 1920;
@@ -329,7 +333,8 @@ fn make_hq_image(raw: &[u8], cache_path: &std::path::Path) -> Option<Vec<u8>> {
         img
     };
     let mut out: Vec<u8> = Vec::new();
-    img.write_with_encoder(JpegEncoder::new_with_quality(&mut out, QUALITY)).ok()?;
+    img.write_with_encoder(JpegEncoder::new_with_quality(&mut out, QUALITY))
+        .ok()?;
     let _ = std::fs::write(cache_path, &out);
     Some(out)
 }
@@ -408,151 +413,191 @@ fn main() {
             )
             .with_data_directory(webview_data_dir)
             .with_window(window)
-            .with_asynchronous_custom_protocol("artwork", |_id, request, responder: RequestAsyncResponder| {
-                let uri = request.uri().clone();
+            .with_asynchronous_custom_protocol(
+                "artwork",
+                |_id, request, responder: RequestAsyncResponder| {
+                    let uri = request.uri().clone();
 
-                tokio::spawn(async move {
-                    let query = uri.query().unwrap_or_default();
-                    let file_path: String = query
-                        .split('&')
-                        .find_map(|kv| kv.strip_prefix("p="))
-                        .map(|encoded| {
-                            percent_encoding::percent_decode_str(encoded)
-                                .decode_utf8_lossy()
-                                .into_owned()
-                        })
-                        .unwrap_or_default();
-                    let high_quality = query.split('&').any(|kv| kv == "hq=1");
+                    tokio::spawn(async move {
+                        let query = uri.query().unwrap_or_default();
+                        let file_path: String = query
+                            .split('&')
+                            .find_map(|kv| kv.strip_prefix("p="))
+                            .map(|encoded| {
+                                percent_encoding::percent_decode_str(encoded)
+                                    .decode_utf8_lossy()
+                                    .into_owned()
+                            })
+                            .unwrap_or_default();
+                        let high_quality = query.split('&').any(|kv| kv == "hq=1");
 
-                    if file_path.is_empty() {
-                        responder.respond(
-                            http::Response::builder()
-                                .status(400)
-                                .body(std::borrow::Cow::from(Vec::new()))
-                                .unwrap(),
-                        );
-                        return;
-                    }
-
-                    #[cfg(target_os = "windows")]
-                    let file_path = file_path.replace('/', "\\");
-
-                    #[cfg(not(target_os = "windows"))]
-                    let file_path = if file_path.starts_with('~') {
-                        if let Ok(home) = std::env::var("HOME") {
-                            file_path.replacen('~', &home, 1)
-                        } else {
-                            file_path
-                        }
-                    } else {
-                        file_path
-                    };
-
-                    if high_quality {
-                        let hq_path = hq_cache_path(&file_path);
-                        if hq_path.exists() {
-                            if let Ok(b) = tokio::fs::read(&hq_path).await {
-                                responder.respond(
-                                    http::Response::builder()
-                                        .header("Content-Type", "image/jpeg")
-                                        .header("Access-Control-Allow-Origin", "*")
-                                        .header("Cache-Control", "public, max-age=31536000")
-                                        .body(std::borrow::Cow::from(b))
-                                        .unwrap(),
-                                );
-                                return;
-                            }
-                        }
-                        match tokio::fs::read(&file_path).await {
-                            Ok(raw) => {
-                                let file_path_clone = file_path.clone();
-                                let result = tokio::task::spawn_blocking(move || {
-                                    make_hq_image(&raw, &hq_path)
-                                        .map(|b| (b, "image/jpeg"))
-                                        .unwrap_or_else(|| {
-                                            let mime = if file_path_clone.ends_with(".png") { "image/png" } else { "image/jpeg" };
-                                            (raw, mime)
-                                        })
-                                }).await;
-                                match result {
-                                    Ok((bytes, mime)) => responder.respond(
-                                        http::Response::builder()
-                                            .header("Content-Type", mime)
-                                            .header("Access-Control-Allow-Origin", "*")
-                                            .header("Cache-Control", "public, max-age=31536000")
-                                            .body(std::borrow::Cow::from(bytes))
-                                            .unwrap(),
-                                    ),
-                                    Err(_) => responder.respond(
-                                        http::Response::builder()
-                                            .status(500)
-                                            .body(std::borrow::Cow::from(Vec::new()))
-                                            .unwrap(),
-                                    ),
-                                }
-                            }
-                            Err(_) => responder.respond(
+                        if file_path.is_empty() {
+                            responder.respond(
                                 http::Response::builder()
-                                    .status(404)
+                                    .status(400)
                                     .body(std::borrow::Cow::from(Vec::new()))
                                     .unwrap(),
-                            ),
+                            );
+                            return;
                         }
-                        return;
-                    }
 
-                    let thumb_path = thumb_cache_path(&file_path);
+                        #[cfg(target_os = "windows")]
+                        let file_path = file_path.replace('/', "\\");
 
-                    let (bytes, mime) = if thumb_path.exists() {
-                        match tokio::fs::read(&thumb_path).await {
-                            Ok(b) => (b, "image/jpeg"),
-                            Err(_) => {
-                                let _ = std::fs::remove_file(&thumb_path);
-                                match tokio::fs::read(&file_path).await {
-                                    Ok(b) => (b, if file_path.ends_with(".png") { "image/png" } else { "image/jpeg" }),
-                                    Err(_) => {
-                                        responder.respond(http::Response::builder().status(404).body(std::borrow::Cow::from(Vec::new())).unwrap());
-                                        return;
+                        #[cfg(not(target_os = "windows"))]
+                        let file_path = if file_path.starts_with('~') {
+                            if let Ok(home) = std::env::var("HOME") {
+                                file_path.replacen('~', &home, 1)
+                            } else {
+                                file_path
+                            }
+                        } else {
+                            file_path
+                        };
+
+                        if high_quality {
+                            let hq_path = hq_cache_path(&file_path);
+                            if hq_path.exists() {
+                                if let Ok(b) = tokio::fs::read(&hq_path).await {
+                                    responder.respond(
+                                        http::Response::builder()
+                                            .header("Content-Type", "image/jpeg")
+                                            .header("Access-Control-Allow-Origin", "*")
+                                            .header("Cache-Control", "public, max-age=31536000")
+                                            .body(std::borrow::Cow::from(b))
+                                            .unwrap(),
+                                    );
+                                    return;
+                                }
+                            }
+                            match tokio::fs::read(&file_path).await {
+                                Ok(raw) => {
+                                    let file_path_clone = file_path.clone();
+                                    let result = tokio::task::spawn_blocking(move || {
+                                        make_hq_image(&raw, &hq_path)
+                                            .map(|b| (b, "image/jpeg"))
+                                            .unwrap_or_else(|| {
+                                                let mime = if file_path_clone.ends_with(".png") {
+                                                    "image/png"
+                                                } else {
+                                                    "image/jpeg"
+                                                };
+                                                (raw, mime)
+                                            })
+                                    })
+                                    .await;
+                                    match result {
+                                        Ok((bytes, mime)) => responder.respond(
+                                            http::Response::builder()
+                                                .header("Content-Type", mime)
+                                                .header("Access-Control-Allow-Origin", "*")
+                                                .header("Cache-Control", "public, max-age=31536000")
+                                                .body(std::borrow::Cow::from(bytes))
+                                                .unwrap(),
+                                        ),
+                                        Err(_) => responder.respond(
+                                            http::Response::builder()
+                                                .status(500)
+                                                .body(std::borrow::Cow::from(Vec::new()))
+                                                .unwrap(),
+                                        ),
+                                    }
+                                }
+                                Err(_) => responder.respond(
+                                    http::Response::builder()
+                                        .status(404)
+                                        .body(std::borrow::Cow::from(Vec::new()))
+                                        .unwrap(),
+                                ),
+                            }
+                            return;
+                        }
+
+                        let thumb_path = thumb_cache_path(&file_path);
+
+                        let (bytes, mime) = if thumb_path.exists() {
+                            match tokio::fs::read(&thumb_path).await {
+                                Ok(b) => (b, "image/jpeg"),
+                                Err(_) => {
+                                    let _ = std::fs::remove_file(&thumb_path);
+                                    match tokio::fs::read(&file_path).await {
+                                        Ok(b) => (
+                                            b,
+                                            if file_path.ends_with(".png") {
+                                                "image/png"
+                                            } else {
+                                                "image/jpeg"
+                                            },
+                                        ),
+                                        Err(_) => {
+                                            responder.respond(
+                                                http::Response::builder()
+                                                    .status(404)
+                                                    .body(std::borrow::Cow::from(Vec::new()))
+                                                    .unwrap(),
+                                            );
+                                            return;
+                                        }
                                     }
                                 }
                             }
-                        }
-                    } else {
-                        match tokio::fs::read(&file_path).await {
-                            Ok(raw) => {
-                                let thumb_path_clone = thumb_path.clone();
-                                match tokio::task::spawn_blocking(move || {
-                                    match make_thumbnail(&raw, &thumb_path_clone) {
+                        } else {
+                            match tokio::fs::read(&file_path).await {
+                                Ok(raw) => {
+                                    let thumb_path_clone = thumb_path.clone();
+                                    match tokio::task::spawn_blocking(move || match make_thumbnail(
+                                        &raw,
+                                        &thumb_path_clone,
+                                    ) {
                                         Some(b) => Ok(b),
                                         None => Err(raw),
-                                    }
-                                }).await {
-                                    Ok(Ok(b)) => (b, "image/jpeg"),
-                                    Ok(Err(raw)) => (raw, if file_path.ends_with(".png") { "image/png" } else { "image/jpeg" }),
-                                    Err(_) => {
-                                        responder.respond(http::Response::builder().status(500).body(std::borrow::Cow::from(Vec::new())).unwrap());
-                                        return;
+                                    })
+                                    .await
+                                    {
+                                        Ok(Ok(b)) => (b, "image/jpeg"),
+                                        Ok(Err(raw)) => (
+                                            raw,
+                                            if file_path.ends_with(".png") {
+                                                "image/png"
+                                            } else {
+                                                "image/jpeg"
+                                            },
+                                        ),
+                                        Err(_) => {
+                                            responder.respond(
+                                                http::Response::builder()
+                                                    .status(500)
+                                                    .body(std::borrow::Cow::from(Vec::new()))
+                                                    .unwrap(),
+                                            );
+                                            return;
+                                        }
                                     }
                                 }
+                                Err(e) => {
+                                    tracing::warn!("[artwork] not found {}: {}", file_path, e);
+                                    responder.respond(
+                                        http::Response::builder()
+                                            .status(404)
+                                            .body(std::borrow::Cow::from(Vec::new()))
+                                            .unwrap(),
+                                    );
+                                    return;
+                                }
                             }
-                            Err(e) => {
-                                tracing::warn!("[artwork] not found {}: {}", file_path, e);
-                                responder.respond(http::Response::builder().status(404).body(std::borrow::Cow::from(Vec::new())).unwrap());
-                                return;
-                            }
-                        }
-                    };
+                        };
 
-                    responder.respond(
-                        http::Response::builder()
-                            .header("Content-Type", mime)
-                            .header("Access-Control-Allow-Origin", "*")
-                            .header("Cache-Control", "public, max-age=31536000")
-                            .body(std::borrow::Cow::from(bytes))
-                            .unwrap(),
-                    );
-                });
-            });
+                        responder.respond(
+                            http::Response::builder()
+                                .header("Content-Type", mime)
+                                .header("Access-Control-Allow-Origin", "*")
+                                .header("Cache-Control", "public, max-age=31536000")
+                                .body(std::borrow::Cow::from(bytes))
+                                .unwrap(),
+                        );
+                    });
+                },
+            );
 
         dioxus::LaunchBuilder::desktop()
             .with_cfg(config)
@@ -664,7 +709,7 @@ fn App() -> Element {
                 var loaded=0;
                 function onLoad(){if(++loaded>=links.length)show();}
                 links.forEach(function(l){if(l.sheet){onLoad();}else{l.addEventListener('load',onLoad);l.addEventListener('error',onLoad);}});
-            })();"#
+            })();"#,
         );
     });
 
@@ -1178,6 +1223,7 @@ fn App() -> Element {
             }
 
             if !configured_dirs.is_empty() {
+                current_lib.local_artist_images.clear();
                 scan_current_file.set(Some(String::new()));
 
                 let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -7,6 +7,10 @@ use reader::{Library, PlaylistStore};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
+fn normalize_artist_key(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
 #[component]
 pub fn LocalArtist(
     library: Signal<Library>,
@@ -42,11 +46,12 @@ pub fn LocalArtist(
     let local_artists = use_memo(move || {
         let lib = library.read();
         let use_artist_photo = config.read().artist_photo_source == ArtistPhotoSource::ArtistPhoto;
-        let mut artist_map: HashMap<String, Option<std::path::PathBuf>> = HashMap::new();
+        let mut artist_map: HashMap<String, (String, Option<std::path::PathBuf>)> =
+            HashMap::new();
         for album in &lib.albums {
             artist_map
-                .entry(album.artist.clone())
-                .or_insert_with(|| album.cover_path.clone());
+                .entry(normalize_artist_key(&album.artist))
+                .or_insert_with(|| (album.artist.clone(), album.cover_path.clone()));
         }
         for track in &lib.tracks {
             let cover = lib
@@ -56,16 +61,21 @@ pub fn LocalArtist(
                 .and_then(|a| a.cover_path.clone());
             for artist in &track.artists {
                 artist_map
-                    .entry(artist.clone())
-                    .or_insert_with(|| cover.clone());
+                    .entry(normalize_artist_key(artist))
+                    .or_insert_with(|| (artist.clone(), cover.clone()));
             }
         }
         if use_artist_photo {
             for (artist, image_path) in &lib.local_artist_images {
-                artist_map.insert(artist.clone(), Some(image_path.clone()));
+                let normalized = normalize_artist_key(artist);
+                let display_name = artist_map
+                    .get(&normalized)
+                    .map(|(display_name, _)| display_name.clone())
+                    .unwrap_or_else(|| artist.clone());
+                artist_map.insert(normalized, (display_name, Some(image_path.clone())));
             }
         }
-        let mut artists: Vec<_> = artist_map.into_iter().collect();
+        let mut artists: Vec<_> = artist_map.into_values().collect();
         artists.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
         artists
     });

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -1,7 +1,7 @@
 use components::dots_menu::{DotsMenu, MenuAction};
 use components::playlist_modal::PlaylistModal;
 use components::selection_bar::SelectionBar;
-use config::{AppConfig, ArtistViewOrder};
+use config::{AppConfig, ArtistPhotoSource, ArtistViewOrder};
 use dioxus::prelude::*;
 use reader::{Library, PlaylistStore};
 use std::collections::{HashMap, HashSet};
@@ -41,6 +41,7 @@ pub fn LocalArtist(
 
     let local_artists = use_memo(move || {
         let lib = library.read();
+        let use_artist_photo = config.read().artist_photo_source == ArtistPhotoSource::ArtistPhoto;
         let mut artist_map: HashMap<String, Option<std::path::PathBuf>> = HashMap::new();
         for album in &lib.albums {
             artist_map
@@ -57,6 +58,11 @@ pub fn LocalArtist(
                 artist_map
                     .entry(artist.clone())
                     .or_insert_with(|| cover.clone());
+            }
+        }
+        if use_artist_photo {
+            for (artist, image_path) in &lib.local_artist_images {
+                artist_map.insert(artist.clone(), Some(image_path.clone()));
             }
         }
         let mut artists: Vec<_> = artist_map.into_iter().collect();
@@ -89,15 +95,30 @@ pub fn LocalArtist(
 
     let artist_cover = use_memo(move || {
         let lib = library.read();
+        let use_artist_photo = config.read().artist_photo_source == ArtistPhotoSource::ArtistPhoto;
         let artist = artist_name.read();
         if artist.is_empty() {
             return None;
         }
         let artist_lc = artist.to_lowercase();
-        lib.albums
-            .iter()
-            .find(|a| a.artist.to_lowercase() == artist_lc)
-            .and_then(|album| utils::format_artwork_url(album.cover_path.as_ref()))
+        if use_artist_photo {
+            lib.local_artist_images
+                .iter()
+                .find(|(name, _)| name.to_lowercase() == artist_lc)
+                .map(|(_, path)| path)
+                .and_then(|path| utils::format_artwork_url(Some(path)))
+                .or_else(|| {
+                    lib.albums
+                        .iter()
+                        .find(|a| a.artist.to_lowercase() == artist_lc)
+                        .and_then(|album| utils::format_artwork_url(album.cover_path.as_ref()))
+                })
+        } else {
+            lib.albums
+                .iter()
+                .find(|a| a.artist.to_lowercase() == artist_lc)
+                .and_then(|album| utils::format_artwork_url(album.cover_path.as_ref()))
+        }
     });
 
     let artist_albums = use_memo(move || {
@@ -170,7 +191,7 @@ pub fn LocalArtist(
                 div { class: "grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-8",
                     for (artist , cover_path) in local_artists() {
                         {
-                            let cover_url = utils::format_artwork_url(cover_path.as_ref());
+                            let cover_url = utils::format_artwork_thumb_url(cover_path.as_ref(), 320);
                             let art = artist.clone();
                             rsx! {
                                 div {
@@ -247,7 +268,7 @@ pub fn LocalArtist(
                                     .filter(|t| selected.contains(&t.path))
                                     .cloned()
                                     .collect();
-                                
+
                                 if !tracks.is_empty() {
                                     ctrl.add_to_queue(tracks);
                                 }
@@ -531,10 +552,8 @@ pub fn LocalArtist(
 fn SortOrderToggle(mut sort_order: Signal<ArtistViewOrder>) -> Element {
     let is_tracks = *sort_order.read() == ArtistViewOrder::Tracks;
 
-    let btn_active =
-        "inline-flex items-center justify-center h-7 px-3 text-xs rounded-md bg-white/10 text-white font-medium transition-all";
-    let btn_inactive =
-        "inline-flex items-center justify-center h-7 px-3 text-xs rounded-md text-white/40 hover:text-white/80 transition-all";
+    let btn_active = "inline-flex items-center justify-center h-7 px-3 text-xs rounded-md bg-white/10 text-white font-medium transition-all";
+    let btn_inactive = "inline-flex items-center justify-center h-7 px-3 text-xs rounded-md text-white/40 hover:text-white/80 transition-all";
 
     rsx! {
         div { class: "inline-flex items-center h-9 p-1 space-x-1 bg-white/5 border border-white/5 rounded-full",

--- a/pages/src/local/home.rs
+++ b/pages/src/local/home.rs
@@ -6,6 +6,10 @@ use reader::{Album, FavoritesStore, Library, PlaylistStore, Track};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+fn normalize_artist_key(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
 fn section_label(key: &str) -> String {
     let i18n_key = match key {
         "hero" => "home_section_hero",
@@ -93,13 +97,19 @@ pub fn LocalHome(
     let artists = use_memo(move || {
         let lib = library.read();
         let use_artist_photo = config.read().artist_photo_source == ArtistPhotoSource::ArtistPhoto;
+        let normalized_local_artist_images: HashMap<String, PathBuf> = lib
+            .local_artist_images
+            .iter()
+            .map(|(artist, path)| (normalize_artist_key(artist), path.clone()))
+            .collect();
         let mut unique_artists = std::collections::HashSet::new();
         let mut artist_list = Vec::new();
         for album in &lib.albums {
-            if unique_artists.insert(album.artist.clone()) {
+            let normalized_artist = normalize_artist_key(&album.artist);
+            if unique_artists.insert(normalized_artist.clone()) {
                 let cover = if use_artist_photo {
-                    lib.local_artist_images
-                        .get(&album.artist)
+                    normalized_local_artist_images
+                        .get(&normalized_artist)
                         .cloned()
                         .or_else(|| album.cover_path.clone())
                 } else {
@@ -113,7 +123,7 @@ pub fn LocalHome(
         }
         if use_artist_photo {
             for (artist, image_path) in &lib.local_artist_images {
-                if unique_artists.insert(artist.clone()) {
+                if unique_artists.insert(normalize_artist_key(artist)) {
                     artist_list.push((artist.clone(), Some(image_path.clone())));
                 }
                 if artist_list.len() >= 10 {

--- a/pages/src/local/home.rs
+++ b/pages/src/local/home.rs
@@ -1,4 +1,4 @@
-use config::{AppConfig, ListenNowStyle, UiStyle};
+use config::{AppConfig, ArtistPhotoSource, ListenNowStyle, UiStyle};
 use dioxus::prelude::*;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
@@ -92,15 +92,33 @@ pub fn LocalHome(
 
     let artists = use_memo(move || {
         let lib = library.read();
+        let use_artist_photo = config.read().artist_photo_source == ArtistPhotoSource::ArtistPhoto;
         let mut unique_artists = std::collections::HashSet::new();
         let mut artist_list = Vec::new();
         for album in &lib.albums {
             if unique_artists.insert(album.artist.clone()) {
-                let cover = album.cover_path.clone();
+                let cover = if use_artist_photo {
+                    lib.local_artist_images
+                        .get(&album.artist)
+                        .cloned()
+                        .or_else(|| album.cover_path.clone())
+                } else {
+                    album.cover_path.clone()
+                };
                 artist_list.push((album.artist.clone(), cover));
             }
             if artist_list.len() >= 10 {
-                break;
+                return artist_list;
+            }
+        }
+        if use_artist_photo {
+            for (artist, image_path) in &lib.local_artist_images {
+                if unique_artists.insert(artist.clone()) {
+                    artist_list.push((artist.clone(), Some(image_path.clone())));
+                }
+                if artist_list.len() >= 10 {
+                    break;
+                }
             }
         }
         artist_list
@@ -383,7 +401,13 @@ fn render_local_section(
             on_play_album,
             scroll_container,
         ),
-        "listen_now" => render_listen_now(is_modern, listen_now_style, local_shuffled, on_select_album, on_play_album),
+        "listen_now" => render_listen_now(
+            is_modern,
+            listen_now_style,
+            local_shuffled,
+            on_select_album,
+            on_play_album,
+        ),
         "top_artists" => render_top_artists(is_modern, artists, on_search_artist, scroll_container),
         "new_releases" => render_albums_row(
             "albums-scroll",
@@ -800,7 +824,7 @@ fn render_top_artists(
                         },
                         div { class: "aspect-square rounded-full bg-stone-800/80 mb-4 overflow-hidden transition-all duration-300 relative mx-auto gpu-hover",
                             if let Some(path) = cover_path {
-                                if let Some(url) = utils::format_artwork_url(Some(&path)) {
+                                if let Some(url) = utils::format_artwork_thumb_url(Some(&path), 320) {
                                     img { src: "{url.as_ref()}", class: "w-full h-full object-cover group-hover:scale-110 transition-transform duration-700", decoding: "async", loading: "lazy" }
                                 }
                             } else {

--- a/pages/src/server/album.rs
+++ b/pages/src/server/album.rs
@@ -35,7 +35,6 @@ pub fn JellyfinAlbum(
                 .cmp(&b.title.trim().to_lowercase())
         });
 
-
         let mut unique_albums = Vec::new();
         let mut seen_titles = std::collections::HashSet::new();
 
@@ -337,7 +336,10 @@ pub fn JellyfinAlbumDetails(
         let q_idx = *ctrl.current_queue_index.read();
         let tracks: Vec<_> = album_tracks().into_iter().map(|(t, _)| t).collect();
         if queue.len() == tracks.len()
-            && queue.iter().zip(tracks.iter()).all(|(q, t)| q.path == t.path)
+            && queue
+                .iter()
+                .zip(tracks.iter())
+                .all(|(q, t)| q.path == t.path)
         {
             Some(q_idx)
         } else {

--- a/pages/src/server/artist.rs
+++ b/pages/src/server/artist.rs
@@ -60,9 +60,15 @@ pub fn JellyfinArtist(
 
         let snapshot = {
             let conf = config.read();
-            let Some(server) = &conf.server else { return; };
-            let Some(token) = &server.access_token else { return; };
-            let Some(user_id) = &server.user_id else { return; };
+            let Some(server) = &conf.server else {
+                return;
+            };
+            let Some(token) = &server.access_token else {
+                return;
+            };
+            let Some(user_id) = &server.user_id else {
+                return;
+            };
             let service = server.service;
             let url = server.url.clone();
             let tok = token.clone();
@@ -79,7 +85,8 @@ pub fn JellyfinArtist(
 
             match service {
                 config::MusicService::Jellyfin => {
-                    let client = JellyfinClient::new(&url, Some(&token), &device_id, Some(&user_id));
+                    let client =
+                        JellyfinClient::new(&url, Some(&token), &device_id, Some(&user_id));
                     match client.get_artists().await {
                         Ok(artists) => {
                             for artist in artists {
@@ -109,7 +116,9 @@ pub fn JellyfinArtist(
                         Ok(artists) => {
                             for artist in artists {
                                 if let Some(cover_art_id) = &artist.cover_art {
-                                    if let Ok(img_url) = client.cover_art_url(cover_art_id, Some(512)) {
+                                    if let Ok(img_url) =
+                                        client.cover_art_url(cover_art_id, Some(512))
+                                    {
                                         images.insert(artist.name.clone(), img_url);
                                     }
                                 }
@@ -899,10 +908,8 @@ pub fn JellyfinArtist(
 fn SortOrderToggle(mut sort_order: Signal<ArtistViewOrder>) -> Element {
     let is_tracks = *sort_order.read() == ArtistViewOrder::Tracks;
 
-    let btn_active =
-        "inline-flex items-center justify-center h-7 px-3 text-xs rounded-md bg-white/10 text-white font-medium transition-all";
-    let btn_inactive =
-        "inline-flex items-center justify-center h-7 px-3 text-xs rounded-md text-white/40 hover:text-white/80 transition-all";
+    let btn_active = "inline-flex items-center justify-center h-7 px-3 text-xs rounded-md bg-white/10 text-white font-medium transition-all";
+    let btn_inactive = "inline-flex items-center justify-center h-7 px-3 text-xs rounded-md text-white/40 hover:text-white/80 transition-all";
 
     rsx! {
         div { class: "inline-flex items-center h-9 p-1 space-x-1 bg-white/5 border border-white/5 rounded-full",

--- a/pages/src/server/home.rs
+++ b/pages/src/server/home.rs
@@ -181,7 +181,12 @@ pub fn JellyfinHome(
             .into_iter()
             .map(|album| {
                 let cover = album_cover_url(&conf, &album);
-                (album.id.clone(), album.title.clone(), album.artist.clone(), cover)
+                (
+                    album.id.clone(),
+                    album.title.clone(),
+                    album.artist.clone(),
+                    cover,
+                )
             })
             .collect()
     });
@@ -203,7 +208,12 @@ pub fn JellyfinHome(
             .into_iter()
             .map(|album| {
                 let cover = album_cover_url(&conf, &album);
-                (album.id.clone(), album.title.clone(), album.artist.clone(), cover)
+                (
+                    album.id.clone(),
+                    album.title.clone(),
+                    album.artist.clone(),
+                    cover,
+                )
             })
             .collect()
     });
@@ -283,7 +293,12 @@ pub fn JellyfinHome(
             .into_iter()
             .map(|album| {
                 let cover = album_cover_url(&conf, &album);
-                (album.id.clone(), album.title.clone(), album.artist.clone(), cover)
+                (
+                    album.id.clone(),
+                    album.title.clone(),
+                    album.artist.clone(),
+                    cover,
+                )
             })
             .collect();
         (top_genre, cards)

--- a/reader/Cargo.toml
+++ b/reader/Cargo.toml
@@ -10,4 +10,4 @@ serde_json = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 lofty = { workspace = true }
 async-recursion = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }

--- a/reader/src/models.rs
+++ b/reader/src/models.rs
@@ -50,6 +50,8 @@ pub struct Library {
     pub jellyfin_genres: Vec<(String, String)>,
     #[serde(default)]
     pub server_artist_images: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub local_artist_images: std::collections::HashMap<String, PathBuf>,
 }
 
 fn deserialize_root_paths<'de, D>(deserializer: D) -> Result<Vec<PathBuf>, D::Error>

--- a/reader/src/scanner.rs
+++ b/reader/src/scanner.rs
@@ -7,12 +7,25 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
 
+fn normalize_artist_key(value: &str) -> Option<String> {
+    let normalized = value.trim().to_lowercase();
+    if normalized.is_empty() {
+        None
+    } else {
+        Some(normalized)
+    }
+}
+
 pub async fn scan_directory(
     dir: PathBuf,
     cover_cache: PathBuf,
     library: &mut Library,
     on_progress: Arc<dyn Fn(String) + Send + Sync>,
 ) -> std::io::Result<()> {
+    library
+        .local_artist_images
+        .retain(|_, image_path| !image_path.starts_with(&dir));
+
     let existing_paths: HashSet<PathBuf> = library.tracks.iter().map(|t| t.path.clone()).collect();
     let existing_artists_by_dir = build_existing_artist_index(&library.tracks);
     scan_directory_internal(
@@ -68,11 +81,11 @@ async fn scan_directory_internal(
                     progress(name.to_string_lossy().into_owned());
                 }
                 if let Some(track) = read(&path, &cover_cache_clone, &mut lib) {
-                    if !track.artist.trim().is_empty() {
-                        scanned_artists.insert(track.artist);
+                    if let Some(artist) = normalize_artist_key(&track.artist) {
+                        scanned_artists.insert(artist);
                     }
                     for artist in track.artists {
-                        if !artist.trim().is_empty() {
+                        if let Some(artist) = normalize_artist_key(&artist) {
                             scanned_artists.insert(artist);
                         }
                     }
@@ -141,13 +154,13 @@ fn build_existing_artist_index(
 fn collect_track_artists(track: &super::models::Track) -> HashSet<String> {
     let mut artists = HashSet::new();
 
-    if !track.artist.trim().is_empty() {
-        artists.insert(track.artist.clone());
+    if let Some(artist) = normalize_artist_key(&track.artist) {
+        artists.insert(artist);
     }
 
     for artist in &track.artists {
-        if !artist.trim().is_empty() {
-            artists.insert(artist.clone());
+        if let Some(artist) = normalize_artist_key(artist) {
+            artists.insert(artist);
         }
     }
 

--- a/reader/src/scanner.rs
+++ b/reader/src/scanner.rs
@@ -36,17 +36,14 @@ async fn scan_directory_internal(
     existing_artists_by_dir: &HashMap<PathBuf, HashSet<String>>,
     on_progress: Arc<dyn Fn(String) + Send + Sync>,
 ) -> std::io::Result<HashSet<String>> {
-    let mut entries = match fs::read_dir(&dir).await {
-        Ok(e) => e,
-        Err(_) => return Ok(HashSet::new()),
-    };
+    let mut entries = fs::read_dir(&dir).await?;
 
     let mut audio_files = Vec::new();
     let mut sub_dirs = Vec::new();
     let mut artist_image = None;
     let mut artists_in_subtree = existing_artists_by_dir.get(&dir).cloned().unwrap_or_default();
 
-    while let Ok(Some(entry)) = entries.next_entry().await {
+    while let Some(entry) = entries.next_entry().await? {
         let path = entry.path();
         if path.is_dir() {
             sub_dirs.push(path);
@@ -99,20 +96,19 @@ async fn scan_directory_internal(
             existing_artists_by_dir,
             on_progress.clone(),
         )
-        .await;
+        .await?;
 
-        if let Ok(child_artists) = child_artists {
-            artists_in_subtree.extend(child_artists);
-        }
+        artists_in_subtree.extend(child_artists);
     }
 
-    if let Some(artist_image_path) = artist_image {
-        for artist in &artists_in_subtree {
-            library
-                .local_artist_images
-                .entry(artist.clone())
-                .or_insert_with(|| artist_image_path.clone());
-        }
+    if let Some(artist_image_path) = artist_image
+        && artists_in_subtree.len() == 1
+        && let Some(artist) = artists_in_subtree.iter().next()
+    {
+        library
+            .local_artist_images
+            .entry(artist.clone())
+            .or_insert_with(|| artist_image_path);
     }
 
     Ok(artists_in_subtree)

--- a/reader/src/scanner.rs
+++ b/reader/src/scanner.rs
@@ -1,7 +1,8 @@
 use super::metadata::read;
 use super::models::Library;
+use super::utils::is_artist_image_file;
 use async_recursion::async_recursion;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs;
@@ -13,7 +14,17 @@ pub async fn scan_directory(
     on_progress: Arc<dyn Fn(String) + Send + Sync>,
 ) -> std::io::Result<()> {
     let existing_paths: HashSet<PathBuf> = library.tracks.iter().map(|t| t.path.clone()).collect();
-    scan_directory_internal(dir, cover_cache, library, &existing_paths, on_progress).await
+    let existing_artists_by_dir = build_existing_artist_index(&library.tracks);
+    scan_directory_internal(
+        dir,
+        cover_cache,
+        library,
+        &existing_paths,
+        &existing_artists_by_dir,
+        on_progress,
+    )
+        .await
+        .map(|_| ())
 }
 
 #[async_recursion]
@@ -22,15 +33,18 @@ async fn scan_directory_internal(
     cover_cache: PathBuf,
     library: &mut Library,
     existing_paths: &HashSet<PathBuf>,
+    existing_artists_by_dir: &HashMap<PathBuf, HashSet<String>>,
     on_progress: Arc<dyn Fn(String) + Send + Sync>,
-) -> std::io::Result<()> {
+) -> std::io::Result<HashSet<String>> {
     let mut entries = match fs::read_dir(&dir).await {
         Ok(e) => e,
-        Err(_) => return Ok(()),
+        Err(_) => return Ok(HashSet::new()),
     };
 
     let mut audio_files = Vec::new();
     let mut sub_dirs = Vec::new();
+    let mut artist_image = None;
+    let mut artists_in_subtree = existing_artists_by_dir.get(&dir).cloned().unwrap_or_default();
 
     while let Ok(Some(entry)) = entries.next_entry().await {
         let path = entry.path();
@@ -40,6 +54,8 @@ async fn scan_directory_internal(
             if !existing_paths.contains(&path) {
                 audio_files.push(path);
             }
+        } else if artist_image.is_none() && is_artist_image_file(&path) {
+            artist_image = Some(path);
         }
     }
 
@@ -48,33 +64,98 @@ async fn scan_directory_internal(
         let cover_cache_clone = cover_cache.clone();
         let progress = on_progress.clone();
 
-        lib = tokio::task::spawn_blocking(move || {
+        let (updated_lib, scanned_artists) = tokio::task::spawn_blocking(move || {
+            let mut scanned_artists = HashSet::new();
             for path in audio_files {
                 if let Some(name) = path.file_name() {
                     progress(name.to_string_lossy().into_owned());
                 }
-                read(&path, &cover_cache_clone, &mut lib);
+                if let Some(track) = read(&path, &cover_cache_clone, &mut lib) {
+                    if !track.artist.trim().is_empty() {
+                        scanned_artists.insert(track.artist);
+                    }
+                    for artist in track.artists {
+                        if !artist.trim().is_empty() {
+                            scanned_artists.insert(artist);
+                        }
+                    }
+                }
             }
-            lib
+            (lib, scanned_artists)
         })
         .await
         .unwrap();
 
-        *library = lib;
+        *library = updated_lib;
+        artists_in_subtree.extend(scanned_artists);
     }
 
     for sub_dir in sub_dirs {
-        let _ = scan_directory_internal(
+        let child_artists = scan_directory_internal(
             sub_dir,
             cover_cache.clone(),
             library,
             existing_paths,
+            existing_artists_by_dir,
             on_progress.clone(),
         )
         .await;
+
+        if let Ok(child_artists) = child_artists {
+            artists_in_subtree.extend(child_artists);
+        }
     }
 
-    Ok(())
+    if let Some(artist_image_path) = artist_image {
+        for artist in &artists_in_subtree {
+            library
+                .local_artist_images
+                .entry(artist.clone())
+                .or_insert_with(|| artist_image_path.clone());
+        }
+    }
+
+    Ok(artists_in_subtree)
+}
+
+fn build_existing_artist_index(
+    tracks: &[super::models::Track],
+) -> HashMap<PathBuf, HashSet<String>> {
+    let mut artists_by_dir = HashMap::new();
+
+    for track in tracks {
+        let artists = collect_track_artists(track);
+        if artists.is_empty() {
+            continue;
+        }
+
+        let mut current = track.path.parent();
+        while let Some(dir) = current {
+            artists_by_dir
+                .entry(dir.to_path_buf())
+                .or_insert_with(HashSet::new)
+                .extend(artists.iter().cloned());
+            current = dir.parent();
+        }
+    }
+
+    artists_by_dir
+}
+
+fn collect_track_artists(track: &super::models::Track) -> HashSet<String> {
+    let mut artists = HashSet::new();
+
+    if !track.artist.trim().is_empty() {
+        artists.insert(track.artist.clone());
+    }
+
+    for artist in &track.artists {
+        if !artist.trim().is_empty() {
+            artists.insert(artist.clone());
+        }
+    }
+
+    artists
 }
 
 pub fn is_audio_file(path: &Path) -> bool {

--- a/reader/src/utils.rs
+++ b/reader/src/utils.rs
@@ -38,6 +38,18 @@ pub fn find_folder_cover(dir: &Path) -> Option<PathBuf> {
     None
 }
 
+pub fn is_artist_image_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| {
+            matches!(
+                name.to_ascii_lowercase().as_str(),
+                "artist.jpg" | "artist.jpeg" | "artist.png" | "artist.webp"
+            )
+        })
+        .unwrap_or(false)
+}
+
 pub fn save_cover(
     album_id: &str,
     data: &[u8],

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -30,7 +30,7 @@ pub async fn sleep(duration: std::time::Duration) {
     }
 }
 
-pub fn format_artwork_url(path: Option<&impl AsRef<Path>>) -> Option<CoverUrl> {
+fn format_artwork_url_impl(path: Option<&impl AsRef<Path>>, size: Option<u32>) -> Option<CoverUrl> {
     path.and_then(|p| {
         let p = p.as_ref();
         let p_str = p.to_string_lossy();
@@ -68,15 +68,34 @@ pub fn format_artwork_url(path: Option<&impl AsRef<Path>>) -> Option<CoverUrl> {
             .add(b':');
 
         if cfg!(target_os = "windows") {
-            Some(cover_url_from_string(format!(
+            let mut url = format!(
                 "http://artwork.dioxus.localhost/local?p={}",
                 percent_encoding::utf8_percent_encode(&abs_str, QUERY_VAL)
-            )))
+            );
+            if let Some(size) = size {
+                url.push_str(&format!("&s={size}"));
+            }
+            Some(cover_url_from_string(url))
         } else {
-            Some(cover_url_from_string(format!(
+            let mut url = format!(
                 "artwork://local?p={}",
                 percent_encoding::utf8_percent_encode(&abs_str, QUERY_VAL)
-            )))
+            );
+            if let Some(size) = size {
+                url.push_str(&format!("&s={size}"));
+            }
+            Some(cover_url_from_string(url))
         }
     })
+}
+
+pub fn format_artwork_url(path: Option<&impl AsRef<Path>>) -> Option<CoverUrl> {
+    format_artwork_url_impl(path, None)
+}
+
+pub fn format_artwork_thumb_url(
+    path: Option<&impl AsRef<Path>>,
+    size: u32,
+) -> Option<CoverUrl> {
+    format_artwork_url_impl(path, Some(size))
 }


### PR DESCRIPTION


This pull request introduces support for configurable artist images by integrating a new `ArtistPhotoSource` setting and updating how artist images are selected and displayed throughout the application. It also includes several formatting improvements and minor code cleanups for clarity and maintainability.

Implemented for #208  

**Configurable Artist Images:**

* Added `ArtistPhotoSource` to configuration and updated logic in `LocalArtist` and `LocalHome` components to use local artist images when this setting is enabled, falling back to album covers as needed. This affects artist list rendering and artist detail views, ensuring artist images are shown according to user preference. [[1]](diffhunk://#diff-1c4cf7fb67b72a53effd2d83432b0ba4d47b9f92ff0333b9a5ab2e27a1b9a70dL4-R4) [[2]](diffhunk://#diff-1ccf9313a9973bc40f004e64e9aec3794fec282b11597a1cc2100d769cddcbaeL1-R1) [[3]](diffhunk://#diff-1c4cf7fb67b72a53effd2d83432b0ba4d47b9f92ff0333b9a5ab2e27a1b9a70dR44) [[4]](diffhunk://#diff-1c4cf7fb67b72a53effd2d83432b0ba4d47b9f92ff0333b9a5ab2e27a1b9a70dR63-R67) [[5]](diffhunk://#diff-1c4cf7fb67b72a53effd2d83432b0ba4d47b9f92ff0333b9a5ab2e27a1b9a70dR98-R121) [[6]](diffhunk://#diff-1ccf9313a9973bc40f004e64e9aec3794fec282b11597a1cc2100d769cddcbaeR95-R123)
* Updated functions to use `format_artwork_thumb_url` for artist thumbnails, ensuring consistent image sizing and improved performance. [[1]](diffhunk://#diff-1c4cf7fb67b72a53effd2d83432b0ba4d47b9f92ff0333b9a5ab2e27a1b9a70dL173-R194) [[2]](diffhunk://#diff-1ccf9313a9973bc40f004e64e9aec3794fec282b11597a1cc2100d769cddcbaeL803-R827)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Use local artist image files as a dedicated source for artist cover photos
  * Added thumbnail artwork URL support to request resized cover images

* **Improvements**
  * Artist grid and top-artist thumbnails now use resized (320px) images for better performance
  * Library rescans detect common artist image filenames and refresh local artist images
  * Local artist images are cleared when configured library roots change

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/209)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->