### PR TITLE
Add js_runtimes option to YtdlpOptions and update command builder

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -46,6 +46,8 @@ pub struct YtdlpOptions {
     pub rate_limit: String,
     #[serde(default)]
     pub cookies_from_browser: String,
+    #[serde(default)]
+    pub js_runtimes: String,
     #[serde(default = "default_audio_quality")]
     pub audio_quality: u8,
 }
@@ -74,6 +76,7 @@ impl Default for YtdlpOptions {
             no_mtime: false,
             rate_limit: String::new(),
             cookies_from_browser: String::new(),
+            js_runtimes: String::new(),
             audio_quality: 0,
         }
     }

--- a/locales/ar.ftl
+++ b/locales/ar.ftl
@@ -290,6 +290,7 @@ ytdlp_write_xattrs = xattrs كتابة
 ytdlp_no_mtime = mtime لا تقم بتعيين ملف
 ytdlp_unlimited = غير محدود
 ytdlp_none = لا شيء
+ytdlp_js_runtimes_tooltip = إذا فشل YouTube بسبب أخطاء JavaScript أو تحديات captcha، فعيّن هنا بيئة تشغيل JavaScript مثل deno أو node.
 ytdlp_format_best_audio = أفضل صوت
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/de.ftl
+++ b/locales/de.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = xattrs schreiben
 ytdlp_no_mtime = Datei-mtime nicht setzen
 ytdlp_unlimited = unbegrenzt
 ytdlp_none = Keine
+ytdlp_js_runtimes_tooltip = Wenn YouTube mit JS- oder Captcha-Fehlern fehlschlägt, lege hier eine JS-Laufzeit fest, z. B. deno oder node.
 ytdlp_format_best_audio = Bestes Audio
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -88,6 +88,7 @@ ytdlp_write_xattrs = Write xattrs
 ytdlp_no_mtime = Don't set file mtime
 ytdlp_unlimited = unlimited
 ytdlp_none = None
+ytdlp_js_runtimes_tooltip = If YouTube fails with JS or captcha challenge errors, set a JS runtime here, e.g. deno or node.
 ytdlp_format_best_audio = Best Audio
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/es.ftl
+++ b/locales/es.ftl
@@ -285,6 +285,7 @@ ytdlp_write_xattrs = Escribir xattrs
 ytdlp_no_mtime = No establecer mtime del archivo
 ytdlp_unlimited = ilimitado
 ytdlp_none = Ninguno
+ytdlp_js_runtimes_tooltip = Si YouTube falla con errores de JS o de desafío captcha, configura aquí un runtime de JS, por ejemplo deno o node.
 ytdlp_format_best_audio = Mejor Audio
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/fr.ftl
+++ b/locales/fr.ftl
@@ -259,6 +259,7 @@ ytdlp_write_xattrs = Écrire les xattrs
 ytdlp_no_mtime = Ne pas définir le mtime du fichier
 ytdlp_unlimited = illimité
 ytdlp_none = Aucun
+ytdlp_js_runtimes_tooltip = Si YouTube échoue avec des erreurs JS ou de défi captcha, définissez ici un runtime JavaScript, par exemple deno ou node.
 ytdlp_format_best_audio = Meilleur Audio
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/gr.ftl
+++ b/locales/gr.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = Αποθήκευση xattrs
 ytdlp_no_mtime = Να μην οριστεί το mtime του αρχείου
 ytdlp_unlimited = απεριόριστο
 ytdlp_none = Κανένα
+ytdlp_js_runtimes_tooltip = Αν το YouTube αποτυγχάνει με σφάλματα JS ή προκλήσεις captcha, ορίστε εδώ ένα runtime JS, π.χ. deno ή node.
 ytdlp_format_best_audio = Καλύτερος Ήχος
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/he.ftl
+++ b/locales/he.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = כתוב xattrs
 ytdlp_no_mtime = אל תגדיר mtime לקובץ
 ytdlp_unlimited = ללא הגבלה
 ytdlp_none = ללא
+ytdlp_js_runtimes_tooltip = אם YouTube נכשל עם שגיאות JS או אתגרי captcha, הגדר כאן סביבת ריצה של JS, למשל deno או node.
 ytdlp_format_best_audio = אודיו מיטבי
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/hu.ftl
+++ b/locales/hu.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = xattrs mentése
 ytdlp_no_mtime = Ne módosítsa a fájl idejét (mtime)
 ytdlp_unlimited = korlátlan
 ytdlp_none = Nincs
+ytdlp_js_runtimes_tooltip = Ha a YouTube JS- vagy captcha-hiba miatt nem működik, állíts be itt egy JS futtatókörnyezetet, például deno-t vagy node-ot.
 ytdlp_format_best_audio = Legjobb hang
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/id.ftl
+++ b/locales/id.ftl
@@ -80,6 +80,7 @@ ytdlp_write_xattrs = Tulis xattrs
 ytdlp_no_mtime = Jangan set mtime
 ytdlp_unlimited = tak terbatas
 ytdlp_none = Nonaktif
+ytdlp_js_runtimes_tooltip = Jika YouTube gagal karena error JS atau tantangan captcha, atur runtime JS di sini, misalnya deno atau node.
 ytdlp_format_best_audio = Audio Terbaik
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/ja.ftl
+++ b/locales/ja.ftl
@@ -290,6 +290,7 @@ ytdlp_write_xattrs = xattrs を出力
 ytdlp_no_mtime = ファイルの変更時間を設定しない
 ytdlp_unlimited = 無制限
 ytdlp_none = なし
+ytdlp_js_runtimes_tooltip = YouTube が JS エラーや captcha チャレンジ エラーで失敗する場合は、ここで deno や node などの JS ランタイムを設定してください。
 ytdlp_format_best_audio = 最高音質
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/ko.ftl
+++ b/locales/ko.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = xattrs 저장
 ytdlp_no_mtime = 파일 mtime 설정 해제
 ytdlp_unlimited = 무제한
 ytdlp_none = 없음
+ytdlp_js_runtimes_tooltip = YouTube가 JS 오류나 captcha 챌린지 오류로 실패하면 여기에서 deno 또는 node 같은 JS 런타임을 설정하세요.
 ytdlp_format_best_audio = 최고 음질
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/pl.ftl
+++ b/locales/pl.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = Zapisz xattrs
 ytdlp_no_mtime = Nie ustawiaj mtime pliku
 ytdlp_unlimited = bez limitu
 ytdlp_none = Brak
+ytdlp_js_runtimes_tooltip = Jeśli YouTube kończy się błędami JS lub captcha, ustaw tutaj środowisko uruchomieniowe JS, np. deno lub node.
 ytdlp_format_best_audio = Najlepsze Audio
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/pt-BR.ftl
+++ b/locales/pt-BR.ftl
@@ -80,6 +80,7 @@ ytdlp_write_xattrs = Gravar atributos estendidos
 ytdlp_no_mtime = Não definir mtime do arquivo
 ytdlp_unlimited = ilimitado
 ytdlp_none = Nenhum
+ytdlp_js_runtimes_tooltip = Se o YouTube falhar com erros de JS ou desafios de captcha, defina aqui um runtime de JS, por exemplo deno ou node.
 ytdlp_format_best_audio = Melhor áudio
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/ro.ftl
+++ b/locales/ro.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = Scrie xattrs
 ytdlp_no_mtime = Nu seta mtime din fișier
 ytdlp_unlimited = nelimitat
 ytdlp_none = Niciunul
+ytdlp_js_runtimes_tooltip = Dacă YouTube eșuează cu erori JS sau provocări captcha, setează aici un runtime JS, de exemplu deno sau node.
 ytdlp_format_best_audio = Cel mai bun Audio
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/ru.ftl
+++ b/locales/ru.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = Записывать xattrs
 ytdlp_no_mtime = Не изменять время файла (mtime)
 ytdlp_unlimited = без ограничений
 ytdlp_none = Нет
+ytdlp_js_runtimes_tooltip = Если YouTube завершается с ошибками JS или captcha, укажите здесь JS-рантайм, например deno или node.
 ytdlp_format_best_audio = Лучшее аудио
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/tok-SP.ftl
+++ b/locales/tok-SP.ftl
@@ -259,6 +259,7 @@ ytdlp_write_xattrs = 󱥎 󱥫 󱤉 xattrs
 ytdlp_no_mtime = 󱥎 󱥔 󱤂 󱤉 mtime
 ytdlp_unlimited = 󱥯 󱤄
 ytdlp_none = 󱤂
+ytdlp_js_runtimes_tooltip = sina lon e pakala JS anu pakala captcha lon YouTube la, o pana e ilo JS lon ni, sama deno anu node.
 ytdlp_format_best_audio = 󱤖 󱥟 󱥅
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/tok.ftl
+++ b/locales/tok.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = o sitelen e xattrs
 ytdlp_no_mtime = o pali ala e mtime
 ytdlp_unlimited = suli ale
 ytdlp_none = ala
+ytdlp_js_runtimes_tooltip = sina lon e pakala JS anu pakala captcha lon YouTube la, o pana e ilo JS lon ni, sama deno anu node.
 ytdlp_format_best_audio = kalama pona mute
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/tr.ftl
+++ b/locales/tr.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = xattrs yaz
 ytdlp_no_mtime = Dosya mtime (değiştirilme zamanı) ayarlama
 ytdlp_unlimited = sınırsız
 ytdlp_none = Yok
+ytdlp_js_runtimes_tooltip = YouTube JS veya captcha doğrulama hatalarıyla başarısız olursa, buraya deno ya da node gibi bir JS çalışma zamanı girin.
 ytdlp_format_best_audio = En İyi Ses
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/uk.ftl
+++ b/locales/uk.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = Зберігати xattrs
 ytdlp_no_mtime = Не змінювати mtime файлу
 ytdlp_unlimited = необмежений
 ytdlp_none = Немає
+ytdlp_js_runtimes_tooltip = Якщо YouTube завершується з помилками JS або captcha, вкажіть тут JS-рантайм, наприклад deno або node.
 ytdlp_format_best_audio = Найкраще аудіо
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/locales/zh-CN.ftl
+++ b/locales/zh-CN.ftl
@@ -284,6 +284,7 @@ ytdlp_write_xattrs = 写入扩展属性
 ytdlp_no_mtime = 不设置文件 mtime
 ytdlp_unlimited = 无限制
 ytdlp_none = 无
+ytdlp_js_runtimes_tooltip = 如果 YouTube 因 JS 错误或 captcha 挑战而失败，请在这里设置 JS 运行时，例如 deno 或 node。
 ytdlp_format_best_audio = 最佳音频
 ytdlp_format_mp3 = MP3
 ytdlp_format_flac = FLAC

--- a/pages/src/ytdlp.rs
+++ b/pages/src/ytdlp.rs
@@ -308,6 +308,9 @@ fn build_command(
         cmd.arg("--cookies-from-browser")
             .arg(&opts.cookies_from_browser);
     }
+    if !opts.js_runtimes.trim().is_empty() {
+        cmd.arg("--js-runtimes").arg(opts.js_runtimes.trim());
+    }
 
     cmd.arg(url)
         .stdout(std::process::Stdio::piped())
@@ -905,6 +908,17 @@ fn OptionsPanel(config: Signal<AppConfig>) -> Element {
                             option { value: "safari",   selected: opts().cookies_from_browser == "safari",   "Safari" }
                             option { value: "brave",    selected: opts().cookies_from_browser == "brave",    "Brave" }
                             option { value: "vivaldi",  selected: opts().cookies_from_browser == "vivaldi",  "Vivaldi" }
+                        }
+                    }
+                    div {
+                        label { class: "text-xs text-slate-500 mb-1 block",
+                            "--js-runtimes"
+                        }
+                        input {
+                            class: "w-full bg-black/30 border border-white/10 rounded-lg px-3 py-1.5 text-white text-sm placeholder-slate-700 focus:outline-none focus:border-white/30 transition-colors",
+                            placeholder: "deno, node, bun or quickjs[:/path]",
+                            value: "{opts().js_runtimes}",
+                            oninput: move |e| config.write().ytdlp_options.js_runtimes = e.value(),
                         }
                     }
                 }

--- a/pages/src/ytdlp.rs
+++ b/pages/src/ytdlp.rs
@@ -911,8 +911,12 @@ fn OptionsPanel(config: Signal<AppConfig>) -> Element {
                         }
                     }
                     div {
-                        label { class: "text-xs text-slate-500 mb-1 block",
-                            "--js-runtimes"
+                        label { class: "text-xs text-slate-500 mb-1 flex items-center gap-1.5",
+                            span { "--js-runtimes" }
+                            i {
+                                class: "fa-solid fa-circle-info text-[11px] text-slate-400 cursor-help",
+                                title: "{i18n::t(\"ytdlp_js_runtimes_tooltip\")}"
+                            }
                         }
                         input {
                             class: "w-full bg-black/30 border border-white/10 rounded-lg px-3 py-1.5 text-white text-sm placeholder-slate-700 focus:outline-none focus:border-white/30 transition-colors",


### PR DESCRIPTION
Adds an optional yt-dlp JS runtime setting to Kopuz’s downloader configuration. This lets users pass --js-runtimes directly from the UI for cases where YouTube extraction requires an external runtime such as deno, node, bun, or quickjs, especially on Windows or non-bundled yt-dlp setups. The setting is persisted in config and only applied when non-empty.

Fix for #178 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration option for JavaScript runtimes in yt-dlp settings.
  * Added UI control in options panel to easily configure JavaScript runtime preferences.

* **Localization**
  * Added tooltip translations for the new JavaScript runtimes option across multiple languages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/211)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->