### PR TITLE
fix(album): album skips tracks with the same name

### DIFF
--- a/components/src/album_details.rs
+++ b/components/src/album_details.rs
@@ -22,7 +22,7 @@ pub fn AlbumDetails(
     let mut tracks: Vec<_> = lib
         .tracks
         .iter()
-        .filter(|t| t.album == album_title)
+        .filter(|t| t.album_id == album_id)
         .cloned()
         .collect();
     tracks.sort_by(|a, b| {


### PR DESCRIPTION
before:

<img width="686" height="576" alt="image" src="https://github.com/user-attachments/assets/511a7571-b901-434c-b667-17aaea57d62c" />

after:

<img width="707" height="570" alt="image" src="https://github.com/user-attachments/assets/72289930-8d44-48d4-b056-42058947cf2a" />

fixes #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the album track list display to correctly show only tracks associated with the selected album, improving accuracy when viewing album details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/223?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->