### PR TITLE
improve performance for rightbar component

### DIFF
--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -25,14 +25,6 @@ pub fn Rightbar(
 
     let mut active_tab = use_signal(|| 1usize);
     let mut ctrl = use_context::<PlayerController>();
-    let mut exact_progress = use_signal(|| 0.0_f64);
-
-    use_future(move || async move {
-        loop {
-            utils::sleep(std::time::Duration::from_millis(50)).await;
-            exact_progress.set(ctrl.displayed_progress_secs_f64());
-        }
-    });
 
     let config = use_context::<Signal<AppConfig>>();
 
@@ -79,13 +71,9 @@ pub fn Rightbar(
             return;
         }
 
-        if let Some(cached) = utils::lyrics::cached_lyrics(
-            &artist,
-            &title,
-            &album,
-            duration,
-            &track_path,
-        ) {
+        if let Some(cached) =
+            utils::lyrics::cached_lyrics(&artist, &title, &album, duration, &track_path)
+        {
             let display = cached.or_else(|| {
                 Some(utils::lyrics::Lyrics::Plain(
                     i18n::t("lyrics_not_found").to_string(),
@@ -120,32 +108,55 @@ pub fn Rightbar(
         });
     });
 
-    let active_lyric_index = use_memo(move || {
-        if *active_tab.read() == 2 {
-            if let Some(Some(utils::lyrics::Lyrics::Synced(lines))) = &*lyrics.read() {
-                let current_time = *exact_progress.read();
-                return lines
-                    .iter()
-                    .rposition(|l| l.start_time <= current_time)
-                    .unwrap_or(0);
-            }
-        }
-        0
-    });
+    let _update_func = eval(
+        r#"
+        let currEl;
 
-    use_effect(move || {
-        let _idx = active_lyric_index();
-        if *active_tab.read() == 2 {
-            let _ = eval(
-                r#"
-                setTimeout(() => {
-                    let el = document.getElementById('rightbar-active-lyric');
-                    if (el) {
-                        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        window.rightbar_updateLyrics = (nextIndex) => {
+            let nextEl = document.getElementById(`rightbar-lyrics-${nextIndex}`)
+            if (currEl != nextEl) {
+                if (currEl) {
+                    currEl.classList = 'text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer';
+                }
+
+                if (nextEl) {
+                    nextEl.classList = 'text-white text-lg font-bold transition-all duration-300';
+                    nextEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    currEl = nextEl;
+                }
+            }
+        }"#,
+    );
+
+    use_resource(move || {
+        let lyrics = lyrics.read().clone();
+
+        async move {
+            if let Some(Some(utils::lyrics::Lyrics::Synced(lines))) = lyrics {
+                let mut sleep_duration_ms = 50;
+
+                loop {
+                    if *active_tab.peek() == 2 {
+                        let current_time = ctrl.player.peek().get_position().as_secs_f64();
+                        if let Some(next_index) =
+                            lines.iter().rposition(|l| l.start_time <= current_time)
+                        {
+                            let _ = eval(&format!("window.rightbar_updateLyrics({next_index})"));
+
+                            sleep_duration_ms = lines
+                                .get(next_index.saturating_add(1))
+                                .map(|line| {
+                                    ((line.start_time - current_time) * 1000.0)
+                                        .max(16.0)
+                                        .min(50.0) as u64
+                                })
+                                .unwrap_or(50);
+                        }
                     }
-                }, 50);
-                "#,
-            );
+
+                    utils::sleep(std::time::Duration::from_millis(sleep_duration_ms)).await;
+                }
+            }
         }
     });
 
@@ -245,31 +256,22 @@ pub fn Rightbar(
     let q = queue.read();
     let current_idx = *current_queue_index.read();
     let is_shuffle = *ctrl.shuffle.read();
-
-    let (back_items, up_next_items): (Vec<_>, Vec<_>) = if is_shuffle {
-        let order = ctrl.shuffle_order.read();
-        let back = order
-            .get(..current_idx)
-            .unwrap_or_default()
+    let items: Vec<_> = if is_shuffle {
+        ctrl.shuffle_order
+            .read()
             .iter()
             .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
-            .collect();
-        let next = order
-            .get(current_idx + 1..)
-            .unwrap_or_default()
-            .iter()
-            .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
-            .collect();
-        (back, next)
+            .collect()
     } else {
-        let back = (0..current_idx)
+        (0..q.len())
             .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
-            .collect();
-        let next = (current_idx + 1..q.len())
-            .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
-            .collect();
-        (back, next)
+            .collect()
     };
+
+    let (back_items, up_next_items) = (
+        items.get(..current_idx).unwrap_or_default(),
+        items.get(current_idx + 1..).unwrap_or_default(),
+    );
 
     let up_next_count = up_next_items.len();
     let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
@@ -281,6 +283,8 @@ pub fn Rightbar(
         ),
         format_queue_duration(up_next_duration)
     );
+
+    let active_tab_val = *active_tab.read();
 
     rsx! {
         div {
@@ -301,7 +305,7 @@ pub fn Rightbar(
                 div {
                     class: "flex items-center gap-1",
                     button {
-                        class: if *active_tab.read() == 0 {
+                        class: if active_tab_val == 0 {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white border-b-2 border-white"
                         } else {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white/40 hover:text-white/70 transition-colors"
@@ -310,7 +314,7 @@ pub fn Rightbar(
                         "{back_text}"
                     }
                     button {
-                        class: if *active_tab.read() == 1 {
+                        class: if active_tab_val == 1 {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white border-b-2 border-white"
                         } else {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white/40 hover:text-white/70 transition-colors"
@@ -319,7 +323,7 @@ pub fn Rightbar(
                         "{up_next_text}"
                     }
                     button {
-                        class: if *active_tab.read() == 2 {
+                        class: if active_tab_val == 2 {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white border-b-2 border-white"
                         } else {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white/40 hover:text-white/70 transition-colors"
@@ -338,22 +342,17 @@ pub fn Rightbar(
             div {
                 class: "flex-1 overflow-y-auto px-2 py-2 space-y-1 relative",
 
-                if *active_tab.read() == 2 {
+                if active_tab_val == 2 {
                     div {
                         class: "text-white/70 text-center py-4 px-4 leading-relaxed font-medium text-sm flex flex-col gap-4",
                         match &*lyrics.read() {
                             Some(Some(utils::lyrics::Lyrics::Synced(lines))) => {
-                                let active_idx = active_lyric_index();
                                 rsx! {
                                     for (i, line) in lines.iter().enumerate() {
                                         div {
                                             key: "{i}",
-                                            id: if i == active_idx { "rightbar-active-lyric" } else { "" },
-                                            class: if i == active_idx {
-                                                "text-white text-lg font-bold transition-all duration-300"
-                                            } else {
-                                                "text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer"
-                                            },
+                                            id: "rightbar-lyrics-{i}",
+                                            class:  "text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer",
                                             onclick: {
                                                 let st = line.start_time;
                                                 move |_| {
@@ -373,7 +372,7 @@ pub fn Rightbar(
                             None => rsx! { "{i18n::t(\"loading_lyrics\")}" },
                         }
                     }
-                } else if *active_tab.read() == 0 {
+                } else if active_tab_val == 0 {
                     if back_items.is_empty() {
                         div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
                     } else {
@@ -411,7 +410,7 @@ pub fn Rightbar(
                             }
                         }
 
-                } else if *active_tab.read() == 1 {
+                } else if active_tab_val == 1 {
                     if up_next_items.is_empty() {
                         div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
                     } else {

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -56,7 +56,7 @@ pub fn LyricsPanel(
                 let mut sleep_duration_ms = 50;
 
                 loop {
-                    let current_time = ctrl.player.peek().get_position().as_secs_f64();
+                    let current_time = ctrl.displayed_progress_secs_f64();
                     if let Some(next_index) =
                         lines.iter().rposition(|l| l.start_time <= current_time)
                     {
@@ -317,6 +317,15 @@ pub fn Rightbar(
     let mut fetch_gen: Signal<u32> = use_signal(|| 0);
     let mut last_key: Signal<String> = use_signal(String::new);
 
+    let js_scroll_to_top = || {
+        let _scroll_to_top = eval(
+            r#"
+                const el = document.getElementById('rightbar-content');
+                if (el) { el.scrollTo({top: 0, left: 0, behavior: 'auto'}); }
+            "#,
+        );
+    };
+
     use_effect(move || {
         let title = current_song_title.read().clone();
         let track_path = {
@@ -391,6 +400,14 @@ pub fn Rightbar(
                 lyrics.set(Some(display));
             }
         });
+
+        js_scroll_to_top();
+    });
+
+    // reset scroll position on tab change
+    use_effect(move || {
+        let _tab = active_tab.read();
+        js_scroll_to_top();
     });
 
     let mut is_resizing = use_signal(|| false);
@@ -503,6 +520,7 @@ pub fn Rightbar(
             }
 
             div {
+                id: "rightbar-content",
                 class: "flex-1 overflow-y-auto px-2 py-2 space-y-1 relative",
 
                 if active_tab_val == Tabs::Lyrics {

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -203,7 +203,7 @@ pub fn QueuePanel(
             if back_items.is_empty() {
                 div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
             } else {
-            for (list_pos, (queue_idx, track)) in back_items.iter().take(30).enumerate().rev() {
+            for (list_pos, (queue_idx, track)) in back_items.iter().rev().take(30).enumerate() {
                 {
                     let queue_idx = *queue_idx;
                     let track_idx = list_pos;

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -31,11 +31,11 @@ pub fn LyricsPanel(
                         let nextEl = document.getElementById(`rightbar-lyrics-${nextIndex}`)
                         if (currEl != nextEl) {
                             if (currEl) {
-                                currEl.classList = 'text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer';
+                                currEl.className = 'text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer';
                             }
 
                             if (nextEl) {
-                                nextEl.classList = 'text-white text-lg font-bold transition-all duration-300';
+                                nextEl.className = 'text-white text-lg font-bold transition-all duration-300';
                                 nextEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
                                 currEl = nextEl;
                             }

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -1,10 +1,294 @@
 use crate::reorder_buttons::ReorderButtons;
 use config::AppConfig;
+use dioxus::core::use_hook_with_cleanup;
 use dioxus::document::eval;
 use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
 use reader::Library;
 use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Tabs {
+    Back,
+    Next,
+    Lyrics,
+}
+
+#[component]
+pub fn LyricsPanel(
+    lyrics: Signal<Option<Option<utils::lyrics::Lyrics>>>,
+    current_song_progress: Signal<u64>,
+) -> Element {
+    let mut ctrl = use_context::<PlayerController>();
+
+    use_hook_with_cleanup(
+        move || {
+            let _update_func = eval(
+                r#"
+                    let currEl;
+
+                    window.rightbar_updateLyrics = (nextIndex) => {
+                        let nextEl = document.getElementById(`rightbar-lyrics-${nextIndex}`)
+                        if (currEl != nextEl) {
+                            if (currEl) {
+                                currEl.classList = 'text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer';
+                            }
+
+                            if (nextEl) {
+                                nextEl.classList = 'text-white text-lg font-bold transition-all duration-300';
+                                nextEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                                currEl = nextEl;
+                            }
+                        }
+                    }"#,
+            );
+        },
+        move |_| {
+            let _cleanup = eval("window.rightbar_updateLyrics = undefined;");
+        },
+    );
+
+    use_resource(move || {
+        let lyrics = lyrics.read().clone();
+
+        async move {
+            if let Some(Some(utils::lyrics::Lyrics::Synced(lines))) = lyrics {
+                let mut sleep_duration_ms = 50;
+
+                loop {
+                    let current_time = ctrl.player.peek().get_position().as_secs_f64();
+                    if let Some(next_index) =
+                        lines.iter().rposition(|l| l.start_time <= current_time)
+                    {
+                        let _ = eval(&format!("window.rightbar_updateLyrics({next_index})"));
+
+                        sleep_duration_ms = lines
+                            .get(next_index.saturating_add(1))
+                            .map(|line| {
+                                ((line.start_time - current_time) * 1000.0)
+                                    .max(16.0)
+                                    .min(50.0) as u64
+                            })
+                            .unwrap_or(50);
+                    }
+
+                    utils::sleep(std::time::Duration::from_millis(sleep_duration_ms)).await;
+                }
+            }
+        }
+    });
+
+    rsx! {
+        div {
+            class: "text-white/70 text-center py-4 px-4 leading-relaxed font-medium text-sm flex flex-col gap-4",
+            match &*lyrics.read() {
+                Some(Some(utils::lyrics::Lyrics::Synced(lines))) => {
+                    rsx! {
+                        for (i, line) in lines.iter().enumerate() {
+                            div {
+                                key: "{i}",
+                                id: "rightbar-lyrics-{i}",
+                                class:  "text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer",
+                                onclick: {
+                                    let st = line.start_time;
+                                    move |_| {
+                                        ctrl.player.write().seek(std::time::Duration::from_secs_f64(st));
+                                        current_song_progress.set(st as u64);
+                                    }
+                                },
+                                "{line.text}"
+                            }
+                        }
+                    }
+                }
+                Some(Some(utils::lyrics::Lyrics::Plain(text))) => rsx! {
+                    div { class: "whitespace-pre-wrap", "{text}" }
+                },
+                Some(None) => rsx! { "" },
+                None => rsx! { "{i18n::t(\"loading_lyrics\")}" },
+            }
+        }
+    }
+}
+
+#[component]
+pub fn QueuePanel(
+    items: Vec<(usize, reader::Track)>,
+    library: Signal<Library>,
+    config: Signal<AppConfig>,
+    current_queue_index: Signal<usize>,
+    active_tab: Tabs,
+) -> Element {
+    let mut ctrl = use_context::<PlayerController>();
+
+    let get_track_cover = |track: &reader::Track| -> Option<utils::CoverUrl> {
+        let lib = library.read();
+        let conf = config.read();
+
+        let is_server_track = conf.active_source == config::MusicSource::Server;
+
+        if is_server_track {
+            if let Some(server) = &conf.server {
+                let path_str = track.path.to_string_lossy();
+                let url = match server.service {
+                    config::MusicService::Jellyfin => {
+                        utils::jellyfin_image::jellyfin_image_url_from_path(
+                            &path_str,
+                            &server.url,
+                            server.access_token.as_deref(),
+                            80,
+                            80,
+                        )
+                    }
+                    config::MusicService::Subsonic | config::MusicService::Custom => {
+                        utils::subsonic_image::subsonic_image_url_from_path(
+                            &path_str,
+                            &server.url,
+                            server.access_token.as_deref(),
+                            80,
+                            80,
+                        )
+                    }
+                };
+                return utils::map_cover_url(url);
+            }
+            None
+        } else {
+            lib.albums
+                .iter()
+                .find(|a| a.id == track.album_id)
+                .and_then(|album| utils::format_artwork_url(album.cover_path.as_ref()))
+        }
+    };
+
+    let mut play_song_at_index = move |index: usize| {
+        ctrl.play_track_no_history(index);
+    };
+
+    let mut move_queue_item = move |from: usize, to: usize| {
+        ctrl.move_queue_item(from, to);
+    };
+
+    let format_queue_duration = |seconds: u64| {
+        let hours = seconds / 3600;
+        let minutes = (seconds % 3600) / 60;
+        let secs = seconds % 60;
+        if hours > 0 {
+            format!("{hours}:{minutes:02}:{secs:02}")
+        } else {
+            format!("{minutes}:{secs:02}")
+        }
+    };
+
+    let current_idx = *current_queue_index.read();
+    let (back_items, up_next_items) = (
+        items.get(..current_idx).unwrap_or_default(),
+        items.get(current_idx + 1..).unwrap_or_default(),
+    );
+
+    let up_next_count = up_next_items.len();
+    let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
+    let up_next_summary = format!(
+        "{} • {}",
+        i18n::t_with(
+            "showcase_song_count",
+            &[("count", up_next_count.to_string())]
+        ),
+        format_queue_duration(up_next_duration)
+    );
+
+    rsx! {
+        if active_tab == Tabs::Back {
+            if back_items.is_empty() {
+                div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
+            } else {
+            for (list_pos, (queue_idx, track)) in back_items.iter().take(30).enumerate().rev() {
+                {
+                    let queue_idx = *queue_idx;
+                    let track_idx = list_pos;
+                    let cover_url = get_track_cover(&track);
+                    rsx! {
+                        div {
+                            key: "{queue_idx}",
+                            class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
+                            style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
+                            ondoubleclick: move |_| play_song_at_index(track_idx),
+                            div {
+                                class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
+                                style: "width: 40px; height: 40px;",
+                                if let Some(ref url) = cover_url {
+                                    img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
+                                } else {
+                                            div {
+                                                class: "w-full h-full flex items-center justify-center",
+                                                i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
+                                            }
+                                        }
+                                    }
+                                    div {
+                                        class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
+                                        div { class: "text-sm text-white truncate font-medium", "{track.title}" }
+                                        div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+        } else if active_tab == Tabs::Next {
+        if up_next_items.is_empty() {
+            div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
+        } else {
+            div {
+                class: "px-2 pt-1 pb-2 text-[11px] uppercase tracking-[0.18em] text-slate-500",
+                "{up_next_summary}"
+            }
+            for (list_pos, (queue_idx, track)) in up_next_items.iter().take(30).enumerate() {
+                {
+                    let queue_idx = *queue_idx;
+                    let cover_url = get_track_cover(&track);
+                    let track_idx = current_idx + 1 + list_pos;
+                    let can_move_up = track_idx > current_idx + 1;
+                    let can_move_down = track_idx + 1 < items.len();
+                    rsx! {
+                        div {
+                            key: "{queue_idx}",
+                            class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
+                            style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
+                            ondoubleclick: move |_| play_song_at_index(track_idx),
+                            div {
+                                class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
+                                style: "width: 40px; height: 40px;",
+                                if let Some(ref url) = cover_url {
+                                    img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
+                        } else {
+                            div {
+                                class: "w-full h-full flex items-center justify-center",
+                                i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
+                            }
+                        }
+                            }
+                            div {
+                                class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
+                                div { class: "text-sm text-white truncate font-medium", "{track.title}" }
+                                div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
+                            }
+                            ReorderButtons {
+                                can_move_up,
+                                can_move_down,
+                                class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
+                                on_move_up: move |_| move_queue_item(track_idx, track_idx - 1),
+                                on_move_down: move |_| move_queue_item(track_idx, track_idx + 1),
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        }
+    }
+}
 
 #[component]
 pub fn Rightbar(
@@ -23,8 +307,8 @@ pub fn Rightbar(
         return rsx! { div {} };
     }
 
-    let mut active_tab = use_signal(|| 1usize);
-    let mut ctrl = use_context::<PlayerController>();
+    let mut active_tab = use_signal(|| Tabs::Next);
+    let ctrl = use_context::<PlayerController>();
 
     let config = use_context::<Signal<AppConfig>>();
 
@@ -108,107 +392,6 @@ pub fn Rightbar(
         });
     });
 
-    use_effect(move || {
-        let _update_func = eval(
-            r#"
-            let currEl;
-
-            window.rightbar_updateLyrics = (nextIndex) => {
-                let nextEl = document.getElementById(`rightbar-lyrics-${nextIndex}`)
-                if (currEl != nextEl) {
-                    if (currEl) {
-                        currEl.classList = 'text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer';
-                    }
-
-                    if (nextEl) {
-                        nextEl.classList = 'text-white text-lg font-bold transition-all duration-300';
-                        nextEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                        currEl = nextEl;
-                    }
-                }
-            }"#,
-        );
-    });
-
-    use_resource(move || {
-        let lyrics = lyrics.read().clone();
-
-        async move {
-            if let Some(Some(utils::lyrics::Lyrics::Synced(lines))) = lyrics {
-                let mut sleep_duration_ms = 50;
-
-                loop {
-                    if *active_tab.peek() == 2 {
-                        let current_time = ctrl.player.peek().get_position().as_secs_f64();
-                        if let Some(next_index) =
-                            lines.iter().rposition(|l| l.start_time <= current_time)
-                        {
-                            let _ = eval(&format!("window.rightbar_updateLyrics({next_index})"));
-
-                            sleep_duration_ms = lines
-                                .get(next_index.saturating_add(1))
-                                .map(|line| {
-                                    ((line.start_time - current_time) * 1000.0)
-                                        .max(16.0)
-                                        .min(50.0) as u64
-                                })
-                                .unwrap_or(50);
-                        }
-                    }
-
-                    utils::sleep(std::time::Duration::from_millis(sleep_duration_ms)).await;
-                }
-            }
-        }
-    });
-
-    let get_track_cover = |track: &reader::Track| -> Option<utils::CoverUrl> {
-        let lib = library.read();
-        let conf = config.read();
-
-        let is_server_track = conf.active_source == config::MusicSource::Server;
-
-        if is_server_track {
-            if let Some(server) = &conf.server {
-                let path_str = track.path.to_string_lossy();
-                let url = match server.service {
-                    config::MusicService::Jellyfin => {
-                        utils::jellyfin_image::jellyfin_image_url_from_path(
-                            &path_str,
-                            &server.url,
-                            server.access_token.as_deref(),
-                            80,
-                            80,
-                        )
-                    }
-                    config::MusicService::Subsonic | config::MusicService::Custom => {
-                        utils::subsonic_image::subsonic_image_url_from_path(
-                            &path_str,
-                            &server.url,
-                            server.access_token.as_deref(),
-                            80,
-                            80,
-                        )
-                    }
-                };
-                return utils::map_cover_url(url);
-            }
-            None
-        } else {
-            lib.albums
-                .iter()
-                .find(|a| a.id == track.album_id)
-                .and_then(|album| utils::format_artwork_url(album.cover_path.as_ref()))
-        }
-    };
-
-    let mut play_song_at_index = move |index: usize| {
-        ctrl.play_track_no_history(index);
-    };
-    let mut move_queue_item = move |from: usize, to: usize| {
-        ctrl.move_queue_item(from, to);
-    };
-
     let mut is_resizing = use_signal(|| false);
 
     use_effect(move || {
@@ -245,18 +428,10 @@ pub fn Rightbar(
     let back_text = i18n::t("back").to_string().to_uppercase();
     let up_next_text = i18n::t("up_next").to_string();
     let lyrics_text = i18n::t("lyrics").to_string();
-    let format_queue_duration = |seconds: u64| {
-        let hours = seconds / 3600;
-        let minutes = (seconds % 3600) / 60;
-        let secs = seconds % 60;
-        if hours > 0 {
-            format!("{hours}:{minutes:02}:{secs:02}")
-        } else {
-            format!("{minutes}:{secs:02}")
-        }
-    };
+
+    let active_tab_val = *active_tab.read();
+
     let q = queue.read();
-    let current_idx = *current_queue_index.read();
     let is_shuffle = *ctrl.shuffle.read();
     let items: Vec<_> = if is_shuffle {
         ctrl.shuffle_order
@@ -269,24 +444,6 @@ pub fn Rightbar(
             .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
             .collect()
     };
-
-    let (back_items, up_next_items) = (
-        items.get(..current_idx).unwrap_or_default(),
-        items.get(current_idx + 1..).unwrap_or_default(),
-    );
-
-    let up_next_count = up_next_items.len();
-    let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
-    let up_next_summary = format!(
-        "{} • {}",
-        i18n::t_with(
-            "showcase_song_count",
-            &[("count", up_next_count.to_string())]
-        ),
-        format_queue_duration(up_next_duration)
-    );
-
-    let active_tab_val = *active_tab.read();
 
     rsx! {
         div {
@@ -307,30 +464,30 @@ pub fn Rightbar(
                 div {
                     class: "flex items-center gap-1",
                     button {
-                        class: if active_tab_val == 0 {
+                        class: if active_tab_val == Tabs::Back {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white border-b-2 border-white"
                         } else {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white/40 hover:text-white/70 transition-colors"
                         },
-                        onclick: move |_| active_tab.set(0),
+                        onclick: move |_| active_tab.set(Tabs::Back),
                         "{back_text}"
                     }
                     button {
-                        class: if active_tab_val == 1 {
+                        class: if active_tab_val == Tabs::Next {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white border-b-2 border-white"
                         } else {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white/40 hover:text-white/70 transition-colors"
                         },
-                        onclick: move |_| active_tab.set(1),
+                        onclick: move |_| active_tab.set(Tabs::Next),
                         "{up_next_text}"
                     }
                     button {
-                        class: if active_tab_val == 2 {
+                        class: if active_tab_val == Tabs::Lyrics {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white border-b-2 border-white"
                         } else {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white/40 hover:text-white/70 transition-colors"
                         },
-                        onclick: move |_| active_tab.set(2),
+                        onclick: move |_| active_tab.set(Tabs::Lyrics),
                         "{lyrics_text}"
                     }
                 }
@@ -344,124 +501,19 @@ pub fn Rightbar(
             div {
                 class: "flex-1 overflow-y-auto px-2 py-2 space-y-1 relative",
 
-                if active_tab_val == 2 {
-                    div {
-                        class: "text-white/70 text-center py-4 px-4 leading-relaxed font-medium text-sm flex flex-col gap-4",
-                        match &*lyrics.read() {
-                            Some(Some(utils::lyrics::Lyrics::Synced(lines))) => {
-                                rsx! {
-                                    for (i, line) in lines.iter().enumerate() {
-                                        div {
-                                            key: "{i}",
-                                            id: "rightbar-lyrics-{i}",
-                                            class:  "text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer",
-                                            onclick: {
-                                                let st = line.start_time;
-                                                move |_| {
-                                                    ctrl.player.write().seek(std::time::Duration::from_secs_f64(st));
-                                                    current_song_progress.set(st as u64);
-                                                }
-                                            },
-                                            "{line.text}"
-                                        }
-                                    }
-                                }
-                            }
-                            Some(Some(utils::lyrics::Lyrics::Plain(text))) => rsx! {
-                                div { class: "whitespace-pre-wrap", "{text}" }
-                            },
-                            Some(None) => rsx! { "" },
-                            None => rsx! { "{i18n::t(\"loading_lyrics\")}" },
-                        }
+                if active_tab_val == Tabs::Lyrics {
+                    LyricsPanel{
+                        lyrics: lyrics,
+                        current_song_progress: current_song_progress
                     }
-                } else if active_tab_val == 0 {
-                    if back_items.is_empty() {
-                        div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
-                    } else {
-                    for (list_pos, (queue_idx, track)) in back_items.iter().enumerate() {
-                        {
-                            let queue_idx = *queue_idx;
-                            let track_idx = list_pos;
-                            let cover_url = get_track_cover(&track);
-                            rsx! {
-                                div {
-                                    key: "{queue_idx}",
-                                    class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
-                                    style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                                    ondoubleclick: move |_| play_song_at_index(track_idx),
-                                    div {
-                                        class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
-                                        style: "width: 40px; height: 40px;",
-                                        if let Some(ref url) = cover_url {
-                                            img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
-                                        } else {
-                                                    div {
-                                                        class: "w-full h-full flex items-center justify-center",
-                                                        i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
-                                                    }
-                                                }
-                                            }
-                                            div {
-                                                class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
-                                                div { class: "text-sm text-white truncate font-medium", "{track.title}" }
-                                                div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                } else if active_tab_val == 1 {
-                    if up_next_items.is_empty() {
-                        div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
-                    } else {
-                        div {
-                            class: "px-2 pt-1 pb-2 text-[11px] uppercase tracking-[0.18em] text-slate-500",
-                            "{up_next_summary}"
-                        }
-                        for (list_pos, (queue_idx, track)) in up_next_items.iter().enumerate() {
-                            {
-                                let queue_idx = *queue_idx;
-                                let cover_url = get_track_cover(&track);
-                                let track_idx = current_idx + 1 + list_pos;
-                                let can_move_up = track_idx > current_idx + 1;
-                                let can_move_down = track_idx + 1 < q.len();
-                                rsx! {
-                                    div {
-                                        key: "{queue_idx}",
-                                        class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
-                                        style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                                        ondoubleclick: move |_| play_song_at_index(track_idx),
-                                        div {
-                                            class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
-                                            style: "width: 40px; height: 40px;",
-                                            if let Some(ref url) = cover_url {
-                                                img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
-                                    } else {
-                                        div {
-                                            class: "w-full h-full flex items-center justify-center",
-                                            i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
-                                        }
-                                    }
-                                        }
-                                        div {
-                                            class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
-                                            div { class: "text-sm text-white truncate font-medium", "{track.title}" }
-                                            div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
-                                        }
-                                        ReorderButtons {
-                                            can_move_up,
-                                            can_move_down,
-                                            class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
-                                            on_move_up: move |_| move_queue_item(track_idx, track_idx - 1),
-                                            on_move_down: move |_| move_queue_item(track_idx, track_idx + 1),
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                } else {
+                    QueuePanel{
+                        items: items,
+                        library: library,
+                        config: config,
+                        current_queue_index: current_queue_index,
+                        active_tab: active_tab_val
+                   }
                 }
             }
         }

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -7,6 +7,15 @@ use hooks::use_player_controller::PlayerController;
 use reader::Library;
 use serde_json::Value;
 
+fn js_scroll_to_top() {
+    let _scroll_to_top = eval(
+        r#"
+            const el = document.getElementById('rightbar-content');
+            if (el) { el.scrollTo({top: 0, left: 0, behavior: 'auto'}); }
+        "#,
+    );
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Tabs {
     Back,
@@ -165,6 +174,7 @@ pub fn QueuePanel(
 
     let mut play_song_at_index = move |index: usize| {
         ctrl.play_track_no_history(index);
+        js_scroll_to_top();
     };
 
     let mut move_queue_item = move |from: usize, to: usize| {
@@ -319,15 +329,6 @@ pub fn Rightbar(
     let mut fetch_gen: Signal<u32> = use_signal(|| 0);
     let mut last_key: Signal<String> = use_signal(String::new);
 
-    let js_scroll_to_top = || {
-        let _scroll_to_top = eval(
-            r#"
-                const el = document.getElementById('rightbar-content');
-                if (el) { el.scrollTo({top: 0, left: 0, behavior: 'auto'}); }
-            "#,
-        );
-    };
-
     use_effect(move || {
         let title = current_song_title.read().clone();
         let track_path = {
@@ -402,8 +403,6 @@ pub fn Rightbar(
                 lyrics.set(Some(display));
             }
         });
-
-        js_scroll_to_top();
     });
 
     // reset scroll position on tab change

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -108,25 +108,27 @@ pub fn Rightbar(
         });
     });
 
-    let _update_func = eval(
-        r#"
-        let currEl;
+    use_effect(move || {
+        let _update_func = eval(
+            r#"
+            let currEl;
 
-        window.rightbar_updateLyrics = (nextIndex) => {
-            let nextEl = document.getElementById(`rightbar-lyrics-${nextIndex}`)
-            if (currEl != nextEl) {
-                if (currEl) {
-                    currEl.classList = 'text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer';
-                }
+            window.rightbar_updateLyrics = (nextIndex) => {
+                let nextEl = document.getElementById(`rightbar-lyrics-${nextIndex}`)
+                if (currEl != nextEl) {
+                    if (currEl) {
+                        currEl.classList = 'text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer';
+                    }
 
-                if (nextEl) {
-                    nextEl.classList = 'text-white text-lg font-bold transition-all duration-300';
-                    nextEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                    currEl = nextEl;
+                    if (nextEl) {
+                        nextEl.classList = 'text-white text-lg font-bold transition-all duration-300';
+                        nextEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                        currEl = nextEl;
+                    }
                 }
-            }
-        }"#,
-    );
+            }"#,
+        );
+    });
 
     use_resource(move || {
         let lyrics = lyrics.read().clone();

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -113,7 +113,7 @@ pub fn LyricsPanel(
 
 #[component]
 pub fn QueuePanel(
-    items: Vec<(usize, reader::Track)>,
+    items: Memo<Vec<(usize, reader::Track)>>,
     library: Signal<Library>,
     config: Signal<AppConfig>,
     current_queue_index: Signal<usize>,
@@ -180,6 +180,7 @@ pub fn QueuePanel(
         }
     };
 
+    let items = items.read();
     let current_idx = *current_queue_index.read();
     let (back_items, up_next_items) = (
         items.get(..current_idx).unwrap_or_default(),
@@ -431,19 +432,22 @@ pub fn Rightbar(
 
     let active_tab_val = *active_tab.read();
 
-    let q = queue.read();
-    let is_shuffle = *ctrl.shuffle.read();
-    let items: Vec<_> = if is_shuffle {
-        ctrl.shuffle_order
-            .read()
-            .iter()
-            .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
-            .collect()
-    } else {
-        (0..q.len())
-            .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
-            .collect()
-    };
+    let items = use_memo(move || {
+        let q = queue.read();
+        let is_shuffle = *ctrl.shuffle.read();
+
+        if is_shuffle {
+            ctrl.shuffle_order
+                .read()
+                .iter()
+                .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
+                .collect::<Vec<_>>()
+        } else {
+            (0..q.len())
+                .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
+                .collect::<Vec<_>>()
+        }
+    });
 
     rsx! {
         div {

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -70,6 +70,8 @@ pub fn LyricsPanel(
                                     .min(50.0) as u64
                             })
                             .unwrap_or(50);
+                    } else {
+                        let _ = eval("window.rightbar_updateLyrics(-1)");
                     }
 
                     utils::sleep(std::time::Duration::from_millis(sleep_duration_ms)).await;
@@ -203,7 +205,7 @@ pub fn QueuePanel(
             if back_items.is_empty() {
                 div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
             } else {
-            for (list_pos, (queue_idx, track)) in back_items.iter().rev().take(30).enumerate() {
+            for (list_pos, (queue_idx, track)) in back_items.iter().enumerate().rev() {
                 {
                     let queue_idx = *queue_idx;
                     let track_idx = list_pos;
@@ -245,7 +247,7 @@ pub fn QueuePanel(
                 class: "px-2 pt-1 pb-2 text-[11px] uppercase tracking-[0.18em] text-slate-500",
                 "{up_next_summary}"
             }
-            for (list_pos, (queue_idx, track)) in up_next_items.iter().take(30).enumerate() {
+            for (list_pos, (queue_idx, track)) in up_next_items.iter().enumerate() {
                 {
                     let queue_idx = *queue_idx;
                     let cover_url = get_track_cover(&track);

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -33,12 +33,11 @@ pub fn LyricsPanel(
                             if (currEl) {
                                 currEl.className = 'text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer';
                             }
-
                             if (nextEl) {
                                 nextEl.className = 'text-white text-lg font-bold transition-all duration-300';
                                 nextEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                                currEl = nextEl;
                             }
+                            currEl = nextEl;
                         }
                     }"#,
             );
@@ -53,7 +52,7 @@ pub fn LyricsPanel(
 
         async move {
             if let Some(Some(utils::lyrics::Lyrics::Synced(lines))) = lyrics {
-                let mut sleep_duration_ms = 50;
+                let mut sleep_duration_ms: u64;
 
                 loop {
                     let current_time = ctrl.displayed_progress_secs_f64();
@@ -72,6 +71,7 @@ pub fn LyricsPanel(
                             .unwrap_or(50);
                     } else {
                         let _ = eval("window.rightbar_updateLyrics(-1)");
+                        sleep_duration_ms = 50;
                     }
 
                     utils::sleep(std::time::Duration::from_millis(sleep_duration_ms)).await;


### PR DESCRIPTION
Some performance improvements:

Avoid full redraw of lyrics each time the current line changes by managing it with javascript.
The queue items are now updated only when the queue itself changes, not when the current played track change or tab changes. achieved by splitting into components.
Added a max number of items to be displayed (30, just a placeholder for now).

fixes:

Scroll to top when the active tab changes.
The back items are now reverted so the latest played tracks are displayed on top

These changes may also apply to the fullscreen component. 
One way might be by sharing components, so the behavior can be easily reproduced in both but I'm not sure how to deal with the css differences in an ideal way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Right-side panel split into separate Lyrics and Queue panes for clearer UI separation.
  * Lyrics pane now syncs with playback, auto-highlights and scrolls the active line, and uses a dedicated lyrics updater.
  * Queue pane shows previous/up-next lists, preserves reorder and double-click playback, and supports shuffle via a precomputed item list.
  * Tab switching now scrolls content to the top for a smoother experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->