### PR TITLE
refactor(workspace): centralize package versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "components"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "config",
  "dioxus",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "directories",
  "serde",
@@ -1688,7 +1688,7 @@ dependencies = [
 
 [[package]]
 name = "discord-presence"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "discord-rich-presence",
  "reader",
@@ -2713,7 +2713,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hooks"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "config",
  "dioxus",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "kopuz_route"
-version = "0.3.6"
+version = "0.5.5"
 
 [[package]]
 name = "kuchikiki"
@@ -4411,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "pages"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "components",
  "config",
@@ -4677,7 +4677,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "player"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "block2",
  "config",
@@ -4991,7 +4991,7 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radio"
-version = "0.1.0"
+version = "0.5.5"
 dependencies = [
  "futures-util",
  "reqwest 0.12.28",
@@ -5202,7 +5202,7 @@ checksum = "56cf8381505b60ae18a4097f1d0be093287ca3bf4fbb23d36ac5ad3bba335daa"
 
 [[package]]
 name = "reader"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "lofty",
  "serde",
@@ -5511,7 +5511,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scrobble"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "config",
  "dioxus",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "config",
  "jellyfin-sdk-rust",
@@ -7013,7 +7013,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utils"
-version = "0.3.6"
+version = "0.5.5"
 dependencies = [
  "color-thief",
  "gloo-timers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ members = [
 ]
 resolver = "3"
 
+[workspace.package]
+version = "0.5.5"
+
 [workspace.dependencies]
 dioxus = { version = "0.7.5", features = [] }
 getrandom = { version = "0.2", features = ["js"] }
@@ -73,4 +76,3 @@ inherits = "dev"
 
 [profile.android-dev]
 inherits = "dev"
-

--- a/components/Cargo.toml
+++ b/components/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "components"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "config"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/discord-presence/Cargo.toml
+++ b/discord-presence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "discord-presence"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/discord-presence/src/cover_art.rs
+++ b/discord-presence/src/cover_art.rs
@@ -3,7 +3,11 @@ use serde::Deserialize;
 const MUSICBRAINZ_API: &str = "https://musicbrainz.org/ws/2";
 const COVER_ART_ARCHIVE: &str = "https://coverartarchive.org";
 const ITUNES: &str = "https://itunes.apple.com/search";
-const USER_AGENT: &str = "Kopuz/0.5.5 (https://github.com/temidaradev/kopuz)";
+pub const USER_AGENT: &str = concat!(
+    "Kopuz/",
+    env!("CARGO_PKG_VERSION"),
+    " (https://github.com/temidaradev/kopuz)"
+);
 
 fn build_client() -> Result<reqwest::Client, reqwest::Error> {
     reqwest::Client::builder().user_agent(USER_AGENT).build()

--- a/hooks/Cargo.toml
+++ b/hooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hooks"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/kopuz/Cargo.toml
+++ b/kopuz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kopuz"
-version = "0.5.5"
+version.workspace = true
 edition = "2024"
 
 [package.metadata.bundle]

--- a/kopuz_route/Cargo.toml
+++ b/kopuz_route/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kopuz_route"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/pages/Cargo.toml
+++ b/pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pages"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "player"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/radio/Cargo.toml
+++ b/radio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "radio"
-version = "0.1.0"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/radio/src/doujinstyle.rs
+++ b/radio/src/doujinstyle.rs
@@ -31,7 +31,7 @@ impl RadioMetadataProvider for DoujinstyleProvider {
 
         tokio::spawn(async move {
             let client = reqwest::Client::builder()
-                .user_agent("Kopuz/0.5.5")
+                .user_agent(concat!("Kopuz/", env!("CARGO_PKG_VERSION")))
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new());
 

--- a/radio/src/j1.rs
+++ b/radio/src/j1.rs
@@ -27,7 +27,7 @@ impl RadioMetadataProvider for J1Provider {
 
         tokio::spawn(async move {
             let client = reqwest::Client::builder()
-                .user_agent("Kopuz/0.5.5")
+                .user_agent(concat!("Kopuz/", env!("CARGO_PKG_VERSION")))
                 .timeout(std::time::Duration::from_secs(10))
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new());

--- a/radio/src/vocaloid.rs
+++ b/radio/src/vocaloid.rs
@@ -28,7 +28,7 @@ impl RadioMetadataProvider for VocaloidProvider {
         let (tx, rx) = mpsc::unbounded_channel();
         tokio::spawn(async move {
             let client = reqwest::Client::builder()
-                .user_agent("Kopuz/0.5.5")
+                .user_agent(concat!("Kopuz/", env!("CARGO_PKG_VERSION")))
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new());
 

--- a/reader/Cargo.toml
+++ b/reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reader"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/scrobble/Cargo.toml
+++ b/scrobble/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scrobble"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/server/src/jellyfin.rs
+++ b/server/src/jellyfin.rs
@@ -2,7 +2,7 @@ use jellyfin_sdk_rust::JellyfinSDK;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-const APP_VERSION: &str = "0.5.5";
+const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Serialize)]
 struct PlaybackProgressRequest<'a> {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils"
-version = "0.3.6"
+version.workspace = true
 edition = "2024"
 
 [dependencies]

--- a/utils/src/lyrics.rs
+++ b/utils/src/lyrics.rs
@@ -583,7 +583,7 @@ async fn fetch_from_lrclib(artist: &str, title: &str, album: &str, duration: u64
     let client = reqwest::Client::new();
     let res = client
         .get(&url)
-        .header("User-Agent", "kopuz/0.5.5")
+        .header("User-Agent", concat!("Kopuz/", env!("CARGO_PKG_VERSION")))
         .send()
         .await
         .ok()?;
@@ -603,7 +603,7 @@ async fn fetch_from_lrclib(artist: &str, title: &str, album: &str, duration: u64
     );
     let search_res = client
         .get(&search_url)
-        .header("User-Agent", "kopuz/0.5.5")
+        .header("User-Agent", concat!("Kopuz/", env!("CARGO_PKG_VERSION")))
         .send()
         .await
         .ok()?;

--- a/utils/src/stream_buffer.rs
+++ b/utils/src/stream_buffer.rs
@@ -42,7 +42,7 @@ impl StreamBuffer {
         handle.spawn(async move {
             let client = reqwest::Client::builder()
                 .tcp_nodelay(true)
-                .user_agent("Kopuz/0.5.5")
+                .user_agent(concat!("Kopuz/", env!("CARGO_PKG_VERSION")))
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new());
 


### PR DESCRIPTION
# Description

This PR centralizes version management across all workspace packages by using the workspace version as the shared source of truth.

All version usage in the codebase now use env!("CARGO_PKG_VERSION") consistently, reducing duplicated version definitions and making releases easier to manage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized version management by establishing workspace-level version configuration, ensuring all components consistently report version 0.5.5 in their HTTP client User-Agent headers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->