### PR TITLE
refactor: streamline lyrics fetching and improve track metadata handling

### DIFF
--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -87,7 +87,12 @@ pub fn Fullscreen(
         let current_track = {
             let q = queue.read();
             let idx = *current_queue_index.read();
-            q.get(idx).cloned()
+            let queue_idx = if *ctrl.shuffle.read() {
+                ctrl.shuffle_order.read().get(idx).copied()
+            } else {
+                Some(idx)
+            };
+            queue_idx.and_then(|queue_idx| q.get(queue_idx).cloned())
         };
 
         let (title, artist, album, duration, track_path) = if let Some(track) = current_track {

--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -84,23 +84,35 @@ pub fn Fullscreen(
     let mut last_key: Signal<String> = use_signal(String::new);
 
     use_effect(move || {
-        let title = current_song_title.read().clone();
-        let track_path = {
+        let current_track = {
             let q = queue.read();
             let idx = *current_queue_index.read();
-            q.get(idx)
-                .map(|t| t.path.to_string_lossy().into_owned())
-                .unwrap_or_default()
+            q.get(idx).cloned()
         };
-        let new_key = format!("{}|{}", title, track_path);
+
+        let (title, artist, album, duration, track_path) = if let Some(track) = current_track {
+            (
+                track.title,
+                track.artist,
+                track.album,
+                track.duration,
+                track.path.to_string_lossy().into_owned(),
+            )
+        } else {
+            (
+                current_song_title.read().clone(),
+                current_song_artist.read().clone(),
+                current_song_album.read().clone(),
+                *current_song_duration.read(),
+                String::new(),
+            )
+        };
+
+        let new_key = format!("{title}|{track_path}");
         if *last_key.peek() == new_key {
             return;
         }
         last_key.set(new_key);
-
-        let artist = current_song_artist.peek().clone();
-        let album = current_song_album.peek().clone();
-        let duration = *current_song_duration.peek();
         let (server_url, server_token, server_user_id) = {
             let conf = config.peek();
             if let Some(server) = &conf.server {

--- a/components/src/fullscreen.rs
+++ b/components/src/fullscreen.rs
@@ -84,16 +84,7 @@ pub fn Fullscreen(
     let mut last_key: Signal<String> = use_signal(String::new);
 
     use_effect(move || {
-        let current_track = {
-            let q = queue.read();
-            let idx = *current_queue_index.read();
-            let queue_idx = if *ctrl.shuffle.read() {
-                ctrl.shuffle_order.read().get(idx).copied()
-            } else {
-                Some(idx)
-            };
-            queue_idx.and_then(|queue_idx| q.get(queue_idx).cloned())
-        };
+        let current_track = ctrl.current_track_snapshot.read().clone();
 
         let (title, artist, album, duration, track_path) = if let Some(track) = current_track {
             (

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -39,18 +39,10 @@ pub fn Rightbar(
     let mut lyrics: Signal<Option<Option<utils::lyrics::Lyrics>>> = use_signal(|| None);
     let mut fetch_gen: Signal<u32> = use_signal(|| 0);
     let mut last_key: Signal<String> = use_signal(String::new);
+    let mut last_scrolled_lyric_index: Signal<Option<usize>> = use_signal(|| None);
 
     use_effect(move || {
-        let current_track = {
-            let q = queue.read();
-            let idx = *current_queue_index.read();
-            let queue_idx = if *ctrl.shuffle.read() {
-                ctrl.shuffle_order.read().get(idx).copied()
-            } else {
-                Some(idx)
-            };
-            queue_idx.and_then(|queue_idx| q.get(queue_idx).cloned())
-        };
+        let current_track = ctrl.current_track_snapshot.read().clone();
 
         let (title, artist, album, duration, track_path) = if let Some(track) = current_track {
             (
@@ -151,19 +143,39 @@ pub fn Rightbar(
     });
 
     use_effect(move || {
-        let _idx = active_lyric_index();
-        if *active_tab.read() == 2 {
+        let idx = active_lyric_index();
+        if *active_tab.read() != 2 {
+            last_scrolled_lyric_index.set(None);
             let _ = eval(
                 r#"
-                setTimeout(() => {
-                    let el = document.getElementById('rightbar-active-lyric');
-                    if (el) {
-                        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                    }
-                }, 50);
+                if (window.__kopuzRightbarLyricScrollTimeout) {
+                    clearTimeout(window.__kopuzRightbarLyricScrollTimeout);
+                    window.__kopuzRightbarLyricScrollTimeout = null;
+                }
                 "#,
             );
+            return;
         }
+
+        if *last_scrolled_lyric_index.peek() == Some(idx) {
+            return;
+        }
+
+        last_scrolled_lyric_index.set(Some(idx));
+        let _ = eval(
+            r#"
+            if (window.__kopuzRightbarLyricScrollTimeout) {
+                clearTimeout(window.__kopuzRightbarLyricScrollTimeout);
+            }
+            window.__kopuzRightbarLyricScrollTimeout = setTimeout(() => {
+                let el = document.getElementById('rightbar-active-lyric');
+                if (el) {
+                    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                }
+                window.__kopuzRightbarLyricScrollTimeout = null;
+            }, 50);
+            "#,
+        );
     });
 
     let get_track_cover = |track: &reader::Track| -> Option<utils::CoverUrl> {
@@ -394,17 +406,16 @@ pub fn Rightbar(
                     if back_items.is_empty() {
                         div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
                     } else {
-                    for (list_pos, (queue_idx, track)) in back_items.iter().enumerate() {
+                    for (queue_idx, track) in back_items.iter() {
                         {
                             let queue_idx = *queue_idx;
-                            let track_idx = list_pos;
                             let cover_url = get_track_cover(&track);
                             rsx! {
                                 div {
                                     key: "{queue_idx}",
                                     class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
                                     style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                                    ondoubleclick: move |_| play_song_at_index(track_idx),
+                                    ondoubleclick: move |_| play_song_at_index(queue_idx),
                                     div {
                                         class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
                                         style: "width: 40px; height: 40px;",
@@ -436,19 +447,18 @@ pub fn Rightbar(
                             class: "px-2 pt-1 pb-2 text-[11px] uppercase tracking-[0.18em] text-slate-500",
                             "{up_next_summary}"
                         }
-                        for (list_pos, (queue_idx, track)) in up_next_items.iter().enumerate() {
+                        for (queue_idx, track) in up_next_items.iter() {
                             {
                                 let queue_idx = *queue_idx;
                                 let cover_url = get_track_cover(&track);
-                                let track_idx = current_idx + 1 + list_pos;
-                                let can_move_up = track_idx > current_idx + 1;
-                                let can_move_down = track_idx + 1 < q.len();
+                                let can_move_up = queue_idx > 0;
+                                let can_move_down = queue_idx + 1 < q.len();
                                 rsx! {
                                     div {
                                         key: "{queue_idx}",
                                         class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
                                         style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                                        ondoubleclick: move |_| play_song_at_index(track_idx),
+                                        ondoubleclick: move |_| play_song_at_index(queue_idx),
                                         div {
                                             class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
                                             style: "width: 40px; height: 40px;",
@@ -470,8 +480,8 @@ pub fn Rightbar(
                                             can_move_up,
                                             can_move_down,
                                             class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
-                                            on_move_up: move |_| move_queue_item(track_idx, track_idx - 1),
-                                            on_move_down: move |_| move_queue_item(track_idx, track_idx + 1),
+                                            on_move_up: move |_| move_queue_item(queue_idx, queue_idx - 1),
+                                            on_move_down: move |_| move_queue_item(queue_idx, queue_idx + 1),
                                         }
                                     }
                                 }

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -1,307 +1,10 @@
 use crate::reorder_buttons::ReorderButtons;
 use config::AppConfig;
-use dioxus::core::use_hook_with_cleanup;
 use dioxus::document::eval;
 use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
 use reader::Library;
 use serde_json::Value;
-
-fn js_scroll_to_top() {
-    let _scroll_to_top = eval(
-        r#"
-            const el = document.getElementById('rightbar-content');
-            if (el) { el.scrollTo({top: 0, left: 0, behavior: 'auto'}); }
-        "#,
-    );
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Tabs {
-    Back,
-    Next,
-    Lyrics,
-}
-
-#[component]
-pub fn LyricsPanel(
-    lyrics: Signal<Option<Option<utils::lyrics::Lyrics>>>,
-    current_song_progress: Signal<u64>,
-) -> Element {
-    let mut ctrl = use_context::<PlayerController>();
-
-    use_hook_with_cleanup(
-        move || {
-            let _update_func = eval(
-                r#"
-                    let currEl;
-
-                    window.rightbar_updateLyrics = (nextIndex) => {
-                        let nextEl = document.getElementById(`rightbar-lyrics-${nextIndex}`)
-                        if (currEl != nextEl) {
-                            if (currEl) {
-                                currEl.className = 'text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer';
-                            }
-                            if (nextEl) {
-                                nextEl.className = 'text-white text-lg font-bold transition-all duration-300';
-                                nextEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                            }
-                            currEl = nextEl;
-                        }
-                    }"#,
-            );
-        },
-        move |_| {
-            let _cleanup = eval("window.rightbar_updateLyrics = undefined;");
-        },
-    );
-
-    use_resource(move || {
-        let lyrics = lyrics.read().clone();
-
-        async move {
-            if let Some(Some(utils::lyrics::Lyrics::Synced(lines))) = lyrics {
-                let mut sleep_duration_ms: u64;
-
-                loop {
-                    let current_time = ctrl.displayed_progress_secs_f64();
-                    if let Some(next_index) =
-                        lines.iter().rposition(|l| l.start_time <= current_time)
-                    {
-                        let _ = eval(&format!("window.rightbar_updateLyrics({next_index})"));
-
-                        sleep_duration_ms = lines
-                            .get(next_index.saturating_add(1))
-                            .map(|line| {
-                                ((line.start_time - current_time) * 1000.0)
-                                    .max(16.0)
-                                    .min(50.0) as u64
-                            })
-                            .unwrap_or(50);
-                    } else {
-                        let _ = eval("window.rightbar_updateLyrics(-1)");
-                        sleep_duration_ms = 50;
-                    }
-
-                    utils::sleep(std::time::Duration::from_millis(sleep_duration_ms)).await;
-                }
-            }
-        }
-    });
-
-    rsx! {
-        div {
-            class: "text-white/70 text-center py-4 px-4 leading-relaxed font-medium text-sm flex flex-col gap-4",
-            match &*lyrics.read() {
-                Some(Some(utils::lyrics::Lyrics::Synced(lines))) => {
-                    rsx! {
-                        for (i, line) in lines.iter().enumerate() {
-                            div {
-                                key: "{i}",
-                                id: "rightbar-lyrics-{i}",
-                                class:  "text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer",
-                                onclick: {
-                                    let st = line.start_time;
-                                    move |_| {
-                                        ctrl.player.write().seek(std::time::Duration::from_secs_f64(st));
-                                        current_song_progress.set(st as u64);
-                                    }
-                                },
-                                "{line.text}"
-                            }
-                        }
-                    }
-                }
-                Some(Some(utils::lyrics::Lyrics::Plain(text))) => rsx! {
-                    div { class: "whitespace-pre-wrap", "{text}" }
-                },
-                Some(None) => rsx! { "" },
-                None => rsx! { "{i18n::t(\"loading_lyrics\")}" },
-            }
-        }
-    }
-}
-
-#[component]
-pub fn QueuePanel(
-    items: Memo<Vec<(usize, reader::Track)>>,
-    library: Signal<Library>,
-    config: Signal<AppConfig>,
-    current_queue_index: Signal<usize>,
-    active_tab: Tabs,
-) -> Element {
-    let mut ctrl = use_context::<PlayerController>();
-
-    let get_track_cover = |track: &reader::Track| -> Option<utils::CoverUrl> {
-        let lib = library.read();
-        let conf = config.read();
-
-        let is_server_track = conf.active_source == config::MusicSource::Server;
-
-        if is_server_track {
-            if let Some(server) = &conf.server {
-                let path_str = track.path.to_string_lossy();
-                let url = match server.service {
-                    config::MusicService::Jellyfin => {
-                        utils::jellyfin_image::jellyfin_image_url_from_path(
-                            &path_str,
-                            &server.url,
-                            server.access_token.as_deref(),
-                            80,
-                            80,
-                        )
-                    }
-                    config::MusicService::Subsonic | config::MusicService::Custom => {
-                        utils::subsonic_image::subsonic_image_url_from_path(
-                            &path_str,
-                            &server.url,
-                            server.access_token.as_deref(),
-                            80,
-                            80,
-                        )
-                    }
-                };
-                return utils::map_cover_url(url);
-            }
-            None
-        } else {
-            lib.albums
-                .iter()
-                .find(|a| a.id == track.album_id)
-                .and_then(|album| utils::format_artwork_url(album.cover_path.as_ref()))
-        }
-    };
-
-    let mut play_song_at_index = move |index: usize| {
-        ctrl.play_track_no_history(index);
-        js_scroll_to_top();
-    };
-
-    let mut move_queue_item = move |from: usize, to: usize| {
-        ctrl.move_queue_item(from, to);
-    };
-
-    let format_queue_duration = |seconds: u64| {
-        let hours = seconds / 3600;
-        let minutes = (seconds % 3600) / 60;
-        let secs = seconds % 60;
-        if hours > 0 {
-            format!("{hours}:{minutes:02}:{secs:02}")
-        } else {
-            format!("{minutes}:{secs:02}")
-        }
-    };
-
-    let items = items.read();
-    let current_idx = *current_queue_index.read();
-    let (back_items, up_next_items) = (
-        items.get(..current_idx).unwrap_or_default(),
-        items.get(current_idx + 1..).unwrap_or_default(),
-    );
-
-    let up_next_count = up_next_items.len();
-    let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
-    let up_next_summary = format!(
-        "{} • {}",
-        i18n::t_with(
-            "showcase_song_count",
-            &[("count", up_next_count.to_string())]
-        ),
-        format_queue_duration(up_next_duration)
-    );
-
-    rsx! {
-        if active_tab == Tabs::Back {
-            if back_items.is_empty() {
-                div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
-            } else {
-            for (list_pos, (queue_idx, track)) in back_items.iter().enumerate().rev() {
-                {
-                    let queue_idx = *queue_idx;
-                    let track_idx = list_pos;
-                    let cover_url = get_track_cover(&track);
-                    rsx! {
-                        div {
-                            key: "{queue_idx}",
-                            class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
-                            style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                            ondoubleclick: move |_| play_song_at_index(track_idx),
-                            div {
-                                class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
-                                style: "width: 40px; height: 40px;",
-                                if let Some(ref url) = cover_url {
-                                    img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
-                                } else {
-                                            div {
-                                                class: "w-full h-full flex items-center justify-center",
-                                                i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
-                                            }
-                                        }
-                                    }
-                                    div {
-                                        class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
-                                        div { class: "text-sm text-white truncate font-medium", "{track.title}" }
-                                        div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-        } else if active_tab == Tabs::Next {
-        if up_next_items.is_empty() {
-            div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
-        } else {
-            div {
-                class: "px-2 pt-1 pb-2 text-[11px] uppercase tracking-[0.18em] text-slate-500",
-                "{up_next_summary}"
-            }
-            for (list_pos, (queue_idx, track)) in up_next_items.iter().enumerate() {
-                {
-                    let queue_idx = *queue_idx;
-                    let cover_url = get_track_cover(&track);
-                    let track_idx = current_idx + 1 + list_pos;
-                    let can_move_up = track_idx > current_idx + 1;
-                    let can_move_down = track_idx + 1 < items.len();
-                    rsx! {
-                        div {
-                            key: "{queue_idx}",
-                            class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
-                            style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
-                            ondoubleclick: move |_| play_song_at_index(track_idx),
-                            div {
-                                class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
-                                style: "width: 40px; height: 40px;",
-                                if let Some(ref url) = cover_url {
-                                    img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
-                        } else {
-                            div {
-                                class: "w-full h-full flex items-center justify-center",
-                                i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
-                            }
-                        }
-                            }
-                            div {
-                                class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
-                                div { class: "text-sm text-white truncate font-medium", "{track.title}" }
-                                div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
-                            }
-                            ReorderButtons {
-                                can_move_up,
-                                can_move_down,
-                                class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
-                                on_move_up: move |_| move_queue_item(track_idx, track_idx - 1),
-                                on_move_down: move |_| move_queue_item(track_idx, track_idx + 1),
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        }
-    }
-}
 
 #[component]
 pub fn Rightbar(
@@ -320,8 +23,16 @@ pub fn Rightbar(
         return rsx! { div {} };
     }
 
-    let mut active_tab = use_signal(|| Tabs::Next);
-    let ctrl = use_context::<PlayerController>();
+    let mut active_tab = use_signal(|| 1usize);
+    let mut ctrl = use_context::<PlayerController>();
+    let mut exact_progress = use_signal(|| 0.0_f64);
+
+    use_future(move || async move {
+        loop {
+            utils::sleep(std::time::Duration::from_millis(50)).await;
+            exact_progress.set(ctrl.displayed_progress_secs_f64());
+        }
+    });
 
     let config = use_context::<Signal<AppConfig>>();
 
@@ -368,9 +79,13 @@ pub fn Rightbar(
             return;
         }
 
-        if let Some(cached) =
-            utils::lyrics::cached_lyrics(&artist, &title, &album, duration, &track_path)
-        {
+        if let Some(cached) = utils::lyrics::cached_lyrics(
+            &artist,
+            &title,
+            &album,
+            duration,
+            &track_path,
+        ) {
             let display = cached.or_else(|| {
                 Some(utils::lyrics::Lyrics::Plain(
                     i18n::t("lyrics_not_found").to_string(),
@@ -405,11 +120,81 @@ pub fn Rightbar(
         });
     });
 
-    // reset scroll position on tab change
-    use_effect(move || {
-        let _tab = active_tab.read();
-        js_scroll_to_top();
+    let active_lyric_index = use_memo(move || {
+        if *active_tab.read() == 2 {
+            if let Some(Some(utils::lyrics::Lyrics::Synced(lines))) = &*lyrics.read() {
+                let current_time = *exact_progress.read();
+                return lines
+                    .iter()
+                    .rposition(|l| l.start_time <= current_time)
+                    .unwrap_or(0);
+            }
+        }
+        0
     });
+
+    use_effect(move || {
+        let _idx = active_lyric_index();
+        if *active_tab.read() == 2 {
+            let _ = eval(
+                r#"
+                setTimeout(() => {
+                    let el = document.getElementById('rightbar-active-lyric');
+                    if (el) {
+                        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    }
+                }, 50);
+                "#,
+            );
+        }
+    });
+
+    let get_track_cover = |track: &reader::Track| -> Option<utils::CoverUrl> {
+        let lib = library.read();
+        let conf = config.read();
+
+        let is_server_track = conf.active_source == config::MusicSource::Server;
+
+        if is_server_track {
+            if let Some(server) = &conf.server {
+                let path_str = track.path.to_string_lossy();
+                let url = match server.service {
+                    config::MusicService::Jellyfin => {
+                        utils::jellyfin_image::jellyfin_image_url_from_path(
+                            &path_str,
+                            &server.url,
+                            server.access_token.as_deref(),
+                            80,
+                            80,
+                        )
+                    }
+                    config::MusicService::Subsonic | config::MusicService::Custom => {
+                        utils::subsonic_image::subsonic_image_url_from_path(
+                            &path_str,
+                            &server.url,
+                            server.access_token.as_deref(),
+                            80,
+                            80,
+                        )
+                    }
+                };
+                return utils::map_cover_url(url);
+            }
+            None
+        } else {
+            lib.albums
+                .iter()
+                .find(|a| a.id == track.album_id)
+                .and_then(|album| utils::format_artwork_url(album.cover_path.as_ref()))
+        }
+    };
+
+    let mut play_song_at_index = move |index: usize| {
+        ctrl.play_track_no_history(index);
+    };
+    let mut move_queue_item = move |from: usize, to: usize| {
+        ctrl.move_queue_item(from, to);
+    };
 
     let mut is_resizing = use_signal(|| false);
 
@@ -447,25 +232,55 @@ pub fn Rightbar(
     let back_text = i18n::t("back").to_string().to_uppercase();
     let up_next_text = i18n::t("up_next").to_string();
     let lyrics_text = i18n::t("lyrics").to_string();
-
-    let active_tab_val = *active_tab.read();
-
-    let items = use_memo(move || {
-        let q = queue.read();
-        let is_shuffle = *ctrl.shuffle.read();
-
-        if is_shuffle {
-            ctrl.shuffle_order
-                .read()
-                .iter()
-                .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
-                .collect::<Vec<_>>()
+    let format_queue_duration = |seconds: u64| {
+        let hours = seconds / 3600;
+        let minutes = (seconds % 3600) / 60;
+        let secs = seconds % 60;
+        if hours > 0 {
+            format!("{hours}:{minutes:02}:{secs:02}")
         } else {
-            (0..q.len())
-                .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
-                .collect::<Vec<_>>()
+            format!("{minutes}:{secs:02}")
         }
-    });
+    };
+    let q = queue.read();
+    let current_idx = *current_queue_index.read();
+    let is_shuffle = *ctrl.shuffle.read();
+
+    let (back_items, up_next_items): (Vec<_>, Vec<_>) = if is_shuffle {
+        let order = ctrl.shuffle_order.read();
+        let back = order
+            .get(..current_idx)
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        let next = order
+            .get(current_idx + 1..)
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|&qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        (back, next)
+    } else {
+        let back = (0..current_idx)
+            .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        let next = (current_idx + 1..q.len())
+            .filter_map(|qi| q.get(qi).cloned().map(|t| (qi, t)))
+            .collect();
+        (back, next)
+    };
+
+    let up_next_count = up_next_items.len();
+    let up_next_duration: u64 = up_next_items.iter().map(|(_, t)| t.duration).sum();
+    let up_next_summary = format!(
+        "{} • {}",
+        i18n::t_with(
+            "showcase_song_count",
+            &[("count", up_next_count.to_string())]
+        ),
+        format_queue_duration(up_next_duration)
+    );
 
     rsx! {
         div {
@@ -486,30 +301,30 @@ pub fn Rightbar(
                 div {
                     class: "flex items-center gap-1",
                     button {
-                        class: if active_tab_val == Tabs::Back {
+                        class: if *active_tab.read() == 0 {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white border-b-2 border-white"
                         } else {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white/40 hover:text-white/70 transition-colors"
                         },
-                        onclick: move |_| active_tab.set(Tabs::Back),
+                        onclick: move |_| active_tab.set(0),
                         "{back_text}"
                     }
                     button {
-                        class: if active_tab_val == Tabs::Next {
+                        class: if *active_tab.read() == 1 {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white border-b-2 border-white"
                         } else {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white/40 hover:text-white/70 transition-colors"
                         },
-                        onclick: move |_| active_tab.set(Tabs::Next),
+                        onclick: move |_| active_tab.set(1),
                         "{up_next_text}"
                     }
                     button {
-                        class: if active_tab_val == Tabs::Lyrics {
+                        class: if *active_tab.read() == 2 {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white border-b-2 border-white"
                         } else {
                             "px-2 py-1 text-[10px] font-medium tracking-wider text-white/40 hover:text-white/70 transition-colors"
                         },
-                        onclick: move |_| active_tab.set(Tabs::Lyrics),
+                        onclick: move |_| active_tab.set(2),
                         "{lyrics_text}"
                     }
                 }
@@ -521,22 +336,131 @@ pub fn Rightbar(
             }
 
             div {
-                id: "rightbar-content",
                 class: "flex-1 overflow-y-auto px-2 py-2 space-y-1 relative",
 
-                if active_tab_val == Tabs::Lyrics {
-                    LyricsPanel{
-                        lyrics: lyrics,
-                        current_song_progress: current_song_progress
+                if *active_tab.read() == 2 {
+                    div {
+                        class: "text-white/70 text-center py-4 px-4 leading-relaxed font-medium text-sm flex flex-col gap-4",
+                        match &*lyrics.read() {
+                            Some(Some(utils::lyrics::Lyrics::Synced(lines))) => {
+                                let active_idx = active_lyric_index();
+                                rsx! {
+                                    for (i, line) in lines.iter().enumerate() {
+                                        div {
+                                            key: "{i}",
+                                            id: if i == active_idx { "rightbar-active-lyric" } else { "" },
+                                            class: if i == active_idx {
+                                                "text-white text-lg font-bold transition-all duration-300"
+                                            } else {
+                                                "text-white/40 transition-all duration-300 hover:text-white/60 cursor-pointer"
+                                            },
+                                            onclick: {
+                                                let st = line.start_time;
+                                                move |_| {
+                                                    ctrl.player.write().seek(std::time::Duration::from_secs_f64(st));
+                                                    current_song_progress.set(st as u64);
+                                                }
+                                            },
+                                            "{line.text}"
+                                        }
+                                    }
+                                }
+                            }
+                            Some(Some(utils::lyrics::Lyrics::Plain(text))) => rsx! {
+                                div { class: "whitespace-pre-wrap", "{text}" }
+                            },
+                            Some(None) => rsx! { "" },
+                            None => rsx! { "{i18n::t(\"loading_lyrics\")}" },
+                        }
                     }
-                } else {
-                    QueuePanel{
-                        items: items,
-                        library: library,
-                        config: config,
-                        current_queue_index: current_queue_index,
-                        active_tab: active_tab_val
-                   }
+                } else if *active_tab.read() == 0 {
+                    if back_items.is_empty() {
+                        div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_previous_songs\")}" }
+                    } else {
+                    for (list_pos, (queue_idx, track)) in back_items.iter().enumerate() {
+                        {
+                            let queue_idx = *queue_idx;
+                            let track_idx = list_pos;
+                            let cover_url = get_track_cover(&track);
+                            rsx! {
+                                div {
+                                    key: "{queue_idx}",
+                                    class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
+                                    style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
+                                    ondoubleclick: move |_| play_song_at_index(track_idx),
+                                    div {
+                                        class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
+                                        style: "width: 40px; height: 40px;",
+                                        if let Some(ref url) = cover_url {
+                                            img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
+                                        } else {
+                                                    div {
+                                                        class: "w-full h-full flex items-center justify-center",
+                                                        i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
+                                                    }
+                                                }
+                                            }
+                                            div {
+                                                class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
+                                                div { class: "text-sm text-white truncate font-medium", "{track.title}" }
+                                                div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                } else if *active_tab.read() == 1 {
+                    if up_next_items.is_empty() {
+                        div { class: "text-white/30 text-center py-10 text-sm", "{i18n::t(\"no_more_songs\")}" }
+                    } else {
+                        div {
+                            class: "px-2 pt-1 pb-2 text-[11px] uppercase tracking-[0.18em] text-slate-500",
+                            "{up_next_summary}"
+                        }
+                        for (list_pos, (queue_idx, track)) in up_next_items.iter().enumerate() {
+                            {
+                                let queue_idx = *queue_idx;
+                                let cover_url = get_track_cover(&track);
+                                let track_idx = current_idx + 1 + list_pos;
+                                let can_move_up = track_idx > current_idx + 1;
+                                let can_move_down = track_idx + 1 < q.len();
+                                rsx! {
+                                    div {
+                                        key: "{queue_idx}",
+                                        class: "flex items-center gap-3 px-2 py-2 hover:bg-white/5 cursor-pointer rounded-lg transition-colors group",
+                                        style: "content-visibility: auto; contain-intrinsic-size: 0 56px;",
+                                        ondoubleclick: move |_| play_song_at_index(track_idx),
+                                        div {
+                                            class: "rounded-md overflow-hidden bg-black/30 flex-shrink-0 shadow-sm",
+                                            style: "width: 40px; height: 40px;",
+                                            if let Some(ref url) = cover_url {
+                                                img { src: "{url.as_ref()}", class: "w-full h-full object-cover" }
+                                    } else {
+                                        div {
+                                            class: "w-full h-full flex items-center justify-center",
+                                            i { class: "fa-solid fa-music text-white/20", style: "font-size: 12px;" }
+                                        }
+                                    }
+                                        }
+                                        div {
+                                            class: "flex-1 min-w-0 flex flex-col justify-center gap-0.5",
+                                            div { class: "text-sm text-white truncate font-medium", "{track.title}" }
+                                            div { class: "text-xs text-white/50 truncate group-hover:text-white/70", "{track.artist}" }
+                                        }
+                                        ReorderButtons {
+                                            can_move_up,
+                                            can_move_down,
+                                            class: "flex flex-col pr-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity".to_string(),
+                                            on_move_up: move |_| move_queue_item(track_idx, track_idx - 1),
+                                            on_move_down: move |_| move_queue_item(track_idx, track_idx + 1),
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/components/src/rightbar.rs
+++ b/components/src/rightbar.rs
@@ -41,23 +41,40 @@ pub fn Rightbar(
     let mut last_key: Signal<String> = use_signal(String::new);
 
     use_effect(move || {
-        let title = current_song_title.read().clone();
-        let track_path = {
+        let current_track = {
             let q = queue.read();
             let idx = *current_queue_index.read();
-            q.get(idx)
-                .map(|t| t.path.to_string_lossy().into_owned())
-                .unwrap_or_default()
+            let queue_idx = if *ctrl.shuffle.read() {
+                ctrl.shuffle_order.read().get(idx).copied()
+            } else {
+                Some(idx)
+            };
+            queue_idx.and_then(|queue_idx| q.get(queue_idx).cloned())
         };
-        let new_key = format!("{}|{}", title, track_path);
+
+        let (title, artist, album, duration, track_path) = if let Some(track) = current_track {
+            (
+                track.title,
+                track.artist,
+                track.album,
+                track.duration,
+                track.path.to_string_lossy().into_owned(),
+            )
+        } else {
+            (
+                current_song_title.read().clone(),
+                current_song_artist.read().clone(),
+                current_song_album.read().clone(),
+                *current_song_duration.read(),
+                String::new(),
+            )
+        };
+
+        let new_key = format!("{title}|{track_path}");
         if *last_key.peek() == new_key {
             return;
         }
         last_key.set(new_key);
-
-        let artist = current_song_artist.peek().clone();
-        let album = current_song_album.peek().clone();
-        let duration = *current_song_duration.peek();
         let (server_url, server_token, server_user_id) = {
             let conf = config.peek();
             if let Some(server) = &conf.server {

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -48,6 +48,7 @@ pub struct PlayerController {
     pub current_song_duration: Signal<u64>,
     pub current_song_progress: Signal<u64>,
     pub current_song_cover_url: Signal<String>,
+    pub current_track_snapshot: Signal<Option<Track>>,
     pub volume: Signal<f32>,
     pub library: Signal<Library>,
     pub config: Signal<AppConfig>,
@@ -149,6 +150,7 @@ impl PlayerController {
         self.current_song_duration.set(0);
         self.current_song_progress.set(0);
         self.current_song_cover_url.set(String::new());
+        self.current_track_snapshot.set(None);
     }
 
     fn hydrate_current_track_metadata(&mut self, idx: usize, progress_secs: u64) {
@@ -164,6 +166,7 @@ impl PlayerController {
             self.current_song_progress.set(progress_secs);
             self.current_song_cover_url
                 .set(self.cover_url_for_track(&track));
+            self.current_track_snapshot.set(Some(track));
         } else {
             self.current_queue_index.set(0);
             self.clear_current_track_metadata();
@@ -1761,6 +1764,7 @@ pub fn use_player_controller(
     current_song_duration: Signal<u64>,
     current_song_progress: Signal<u64>,
     current_song_cover_url: Signal<String>,
+    current_track_snapshot: Signal<Option<Track>>,
     volume: Signal<f32>,
     library: Signal<Library>,
     config: Signal<AppConfig>,
@@ -1795,6 +1799,7 @@ pub fn use_player_controller(
         current_song_duration,
         current_song_progress,
         current_song_cover_url,
+        current_track_snapshot,
         volume,
         library,
         config,

--- a/hooks/src/use_player_controller.rs
+++ b/hooks/src/use_player_controller.rs
@@ -151,42 +151,6 @@ impl PlayerController {
         self.current_song_cover_url.set(String::new());
     }
 
-    fn prefetch_lyrics_for_track(&self, track: &Track) {
-        let track_path = track.path.to_string_lossy();
-        if track.title.trim().is_empty() || track_path.starts_with("radio:") {
-            return;
-        }
-
-        let track = track.clone();
-        let (server_url, server_token, server_user_id) = {
-            let conf = self.config.read();
-            if let Some(server) = &conf.server {
-                (
-                    Some(server.url.clone()),
-                    server.access_token.clone(),
-                    server.user_id.clone(),
-                )
-            } else {
-                (None, None, None)
-            }
-        };
-
-        spawn(async move {
-            let track_path = track.path.to_string_lossy().into_owned();
-            let _ = utils::lyrics::fetch_lyrics(
-                &track.artist,
-                &track.title,
-                &track.album,
-                track.duration,
-                &track_path,
-                server_url.as_deref(),
-                server_token.as_deref(),
-                server_user_id.as_deref(),
-            )
-            .await;
-        });
-    }
-
     fn hydrate_current_track_metadata(&mut self, idx: usize, progress_secs: u64) {
         if let Some(track) = self.current_track(idx) {
             let progress_secs = progress_secs.min(track.duration);
@@ -200,7 +164,6 @@ impl PlayerController {
             self.current_song_progress.set(progress_secs);
             self.current_song_cover_url
                 .set(self.cover_url_for_track(&track));
-            self.prefetch_lyrics_for_track(&track);
         } else {
             self.current_queue_index.set(0);
             self.clear_current_track_metadata();

--- a/hooks/src/use_player_task.rs
+++ b/hooks/src/use_player_task.rs
@@ -254,23 +254,20 @@ pub fn use_player_task(ctrl: PlayerController) {
                     let current_idx = *ctrl.current_queue_index.read();
                     if *ctrl.shuffle.read() {
                         let order = ctrl.shuffle_order.read();
-                        let current = order.get(current_idx).and_then(|&idx| q.get(idx)).cloned();
                         let next = order
                             .get(current_idx + 1)
                             .and_then(|&idx| q.get(idx))
                             .cloned();
-                        (current, next)
+                        next
                     } else {
-                        let current = q.get(current_idx).cloned();
-                        let next = q.get(current_idx + 1).cloned();
-                        (current, next)
+                        q.get(current_idx + 1).cloned()
                     }
                 };
 
-                if let (Some(current_track), next_track) = lyrics_prefetch {
-                    let current_track_key = current_track.path.to_string_lossy().to_string();
-                    if last_lyrics_prefetch_track.as_ref() != Some(&current_track_key) {
-                        last_lyrics_prefetch_track = Some(current_track_key);
+                if let Some(next_track) = lyrics_prefetch {
+                    let next_track_key = next_track.path.to_string_lossy().to_string();
+                    if last_lyrics_prefetch_track.as_ref() != Some(&next_track_key) {
+                        last_lyrics_prefetch_track = Some(next_track_key);
                         let (server_url, server_token, server_user_id) = {
                             let conf = config.read();
                             if let Some(server) = &conf.server {
@@ -285,33 +282,18 @@ pub fn use_player_task(ctrl: PlayerController) {
                         };
 
                         spawn(async move {
-                            let current_track_path = current_track.path.to_string_lossy().into_owned();
+                            let next_track_path = next_track.path.to_string_lossy().into_owned();
                             let _ = utils::lyrics::fetch_lyrics(
-                                &current_track.artist,
-                                &current_track.title,
-                                &current_track.album,
-                                current_track.duration,
-                                &current_track_path,
+                                &next_track.artist,
+                                &next_track.title,
+                                &next_track.album,
+                                next_track.duration,
+                                &next_track_path,
                                 server_url.as_deref(),
                                 server_token.as_deref(),
                                 server_user_id.as_deref(),
                             )
                             .await;
-
-                            if let Some(next_track) = next_track {
-                                let next_track_path = next_track.path.to_string_lossy().into_owned();
-                                let _ = utils::lyrics::fetch_lyrics(
-                                    &next_track.artist,
-                                    &next_track.title,
-                                    &next_track.album,
-                                    next_track.duration,
-                                    &next_track_path,
-                                    server_url.as_deref(),
-                                    server_token.as_deref(),
-                                    server_user_id.as_deref(),
-                                )
-                                .await;
-                            }
                         });
                     }
                 }

--- a/kopuz/src/main.rs
+++ b/kopuz/src/main.rs
@@ -749,6 +749,7 @@ fn App() -> Element {
     let current_song_khz = use_signal(|| 0u32);
     let current_song_bitrate = use_signal(|| 0u16);
     let current_song_progress = use_signal(|| 0u64);
+    let current_track_snapshot = use_signal(|| None::<reader::Track>);
     let mut volume = use_signal(|| 1.0f32);
     let mut persisted_volume = use_signal(|| 1.0f32);
     let mut configured_music_dirs = use_signal(|| config.peek().music_directory.clone());
@@ -850,6 +851,7 @@ fn App() -> Element {
         current_song_duration,
         current_song_progress,
         current_song_cover_url,
+        current_track_snapshot,
         volume,
         library,
         config,


### PR DESCRIPTION
This pull request refactors how lyrics prefetching is handled in the player. Prefetching is now performed for the *next* track instead of the current one, and the logic is centralized in `use_player_task` rather than being spread across multiple locations. This should improve efficiency and prevent redundant lyrics fetches.

Fix for #227 #229 

**Lyrics Prefetching Refactor:**

* Removed the `prefetch_lyrics_for_track` method from `PlayerController`, eliminating lyrics prefetching for the current track during metadata hydration. [[1]](diffhunk://#diff-d43c32232797e99ce5a15a2dc7bb41d02d2ade6540f6da3f719eac12ea813493L154-L189) [[2]](diffhunk://#diff-d43c32232797e99ce5a15a2dc7bb41d02d2ade6540f6da3f719eac12ea813493L203)
* Updated `use_player_task` to prefetch lyrics for the next track in the queue (rather than the current track), and only when the next track changes. [[1]](diffhunk://#diff-577134fe3c708c55efb2f54efa2199b42a91c7a0a3216539d8e414794a08d07aL257-R270) [[2]](diffhunk://#diff-577134fe3c708c55efb2f54efa2199b42a91c7a0a3216539d8e414794a08d07aL288-L301) [[3]](diffhunk://#diff-577134fe3c708c55efb2f54efa2199b42a91c7a0a3216539d8e414794a08d07aL314)

**Track Metadata Handling:**

* Improved how track metadata is extracted in `Fullscreen` to use all relevant fields from the current track, falling back to current song state if no track is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synced lyrics highlighting and auto-scroll to keep the active line in view.
  * Prevented redundant lyric fetches by stabilizing the lyrics cache key when track snapshot is available.

* **Refactor**
  * Consolidated the right-hand panel into a single streamlined view with inline lyrics and queue rendering.
  * Simplified lyrics prefetching to focus on the upcoming track and increased playback sampling for smoother syncing.
* **Chores**
  * Removed legacy scroll-to-top behavior on tab change/play.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->