### PR TITLE
feat(showcase): add sortable track columns and normal UI metadata layout

### DIFF
--- a/components/src/modern/showcase.rs
+++ b/components/src/modern/showcase.rs
@@ -179,7 +179,12 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                     {
                         let idx = *idx;
                         let is_playing = currently_playing_idx == Some(display_idx);
-                        let is_selected = props.selected_tracks.contains(&track.path);
+                        let is_selected = props.is_selection_mode && props.selected_tracks.contains(&track.path);
+                        let selection_shadow = if is_selected {
+                            "inset 0 0 0 9999px rgba(255,255,255,0.07)"
+                        } else {
+                            "none"
+                        };
                         let track_dur = fmt_dur(track.duration);
                         let artist = track.artist.clone();
                         let album = track.album.clone();
@@ -217,11 +222,9 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                                 key: "{track.path.display()}",
                                 class: "grid px-2 py-1.5 rounded-lg mx-1 group cursor-default transition-colors hover:bg-white/5",
                                 style: if is_playing {
-                                    format!("grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent);")
-                                } else if is_selected {
-                                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: rgba(255,255,255,0.07);".to_string()
+                                    format!("grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent); box-shadow: {selection_shadow};")
                                 } else {
-                                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px;".to_string()
+                                    format!("grid-template-columns: 40px 1fr 180px 180px 56px 40px; box-shadow: {selection_shadow};")
                                 },
                                 ondoubleclick: move |_| {
                                     ctrl.queue.set(play_queue.clone());

--- a/components/src/modern/showcase.rs
+++ b/components/src/modern/showcase.rs
@@ -30,20 +30,20 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
         .collect();
     let tracks_for_shuffle = sorted_tracks.clone();
 
-    let currently_playing_idx: Option<usize> = {
+    let currently_playing_path = {
         let queue = ctrl.queue.read();
         let idx = *ctrl.current_queue_index.read();
-        if queue.len() == sorted_tracks.len()
-            && queue
-                .iter()
-                .zip(sorted_tracks.iter())
-                .all(|(q, t)| q.path == t.path)
-        {
-            Some(idx)
+        let queue_idx = if *ctrl.shuffle.read() {
+            ctrl.shuffle_order.read().get(idx).copied().unwrap_or(idx)
         } else {
-            None
-        }
+            idx
+        };
+        queue.get(queue_idx).map(|track| track.path.clone())
     };
+    let current_song_title = ctrl.current_song_title.read().clone();
+    let current_song_artist = ctrl.current_song_artist.read().clone();
+    let current_song_album = ctrl.current_song_album.read().clone();
+    let current_song_duration = *ctrl.current_song_duration.read();
     let tracks_for_play_all = sorted_tracks.clone();
 
     rsx! {
@@ -178,7 +178,13 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                 for (display_idx, (track, idx)) in sorted_track_pairs.iter().enumerate() {
                     {
                         let idx = *idx;
-                        let is_playing = currently_playing_idx == Some(display_idx);
+                        let matches_current_path = currently_playing_path.as_ref() == Some(&track.path);
+                        let matches_current_metadata = !current_song_title.is_empty()
+                            && track.title == current_song_title
+                            && track.artist == current_song_artist
+                            && track.album == current_song_album
+                            && track.duration == current_song_duration;
+                        let is_playing: bool = matches_current_path || matches_current_metadata;
                         let is_selected = props.is_selection_mode && props.selected_tracks.contains(&track.path);
                         let selection_shadow = if is_selected {
                             "inset 0 0 0 9999px rgba(255,255,255,0.07)"

--- a/components/src/modern/showcase.rs
+++ b/components/src/modern/showcase.rs
@@ -2,7 +2,7 @@ use config::AppConfig;
 use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
 
-use crate::showcase::ShowcaseProps;
+use crate::showcase::{self, ShowcaseProps, SortField};
 
 #[component]
 pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
@@ -29,6 +29,8 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
 
     let tracks_for_shuffle = props.tracks.clone();
     let fmt_dur = |s: u64| format!("{}:{:02}", s / 60, s % 60);
+    let mut sort_state = use_signal(|| None);
+    let sorted_indices = showcase::sorted_track_indices(&props.tracks, *sort_state.read());
 
     rsx! {
         div { class: "w-full max-w-[1600px] mx-auto select-none pb-8",
@@ -132,22 +134,55 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                     class: "grid px-6 py-2 text-[10px] font-bold uppercase tracking-widest border-b",
                     style: "grid-template-columns: 40px 1fr 200px 200px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);",
                     div { class: "flex items-center", "#" }
-                    div { "{i18n::t(\"title\")}" }
-                    div { "{i18n::t(\"artist\")}" }
-                    div { "{i18n::t(\"album\")}" }
-                    div { class: "text-right", i { class: "fa-regular fa-clock" } }
+                    button {
+                        class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
+                        onclick: move |_| {
+                                                    let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
+                                                    sort_state.set(next);
+                                                },
+                        "{i18n::t(\"title\")}"
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[9px]" }
+                    }
+                    button {
+                        class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
+                        onclick: move |_| {
+                                                    let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
+                                                    sort_state.set(next);
+                                                },
+                        "{i18n::t(\"artist\")}"
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[9px]" }
+                    }
+                    button {
+                        class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
+                        onclick: move |_| {
+                                                    let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
+                                                    sort_state.set(next);
+                                                },
+                        "{i18n::t(\"album\")}"
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[9px]" }
+                    }
+                    button {
+                        class: "flex items-center justify-end gap-1 uppercase tracking-widest text-right hover:text-white transition-colors",
+                        onclick: move |_| {
+                                                    let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
+                                                    sort_state.set(next);
+                                                },
+                        i { class: "fa-regular fa-clock" }
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[9px]" }
+                    }
                     div {}
                 }
 
-                for (idx, track) in props.tracks.iter().enumerate() {
+                for (display_idx, idx) in sorted_indices.iter().copied().enumerate() {
                     {
+                        let track = &props.tracks[idx];
                         let is_playing = currently_playing_idx == Some(idx);
                         let is_selected = props.selected_tracks.contains(&track.path);
                         let track_dur = fmt_dur(track.duration);
-                        let title = track.title.clone();
+                        let title = track.title.clone(); // dead code
                         let artist = track.artist.clone();
                         let album = track.album.clone();
-                        let row_num = idx + 1;
+                        let row_num = display_idx + 1;
 
                         let cover_url: Option<utils::CoverUrl> = {
                             let path_str = track.path.to_string_lossy();
@@ -225,7 +260,7 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                                         } else {
                                             "color: rgba(255,255,255,0.9);"
                                         },
-                                        "{title}"
+                                        "{track.title}"
                                     }
                                 }
 

--- a/components/src/modern/showcase.rs
+++ b/components/src/modern/showcase.rs
@@ -14,13 +14,22 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
     let total_seconds: u64 = props.tracks.iter().map(|t| t.duration).sum();
     let duration_min = total_seconds / 60;
 
+    let fmt_dur = |s: u64| format!("{}:{:02}", s / 60, s % 60);
+    let mut sort_state = use_signal(|| None);
+    let sorted_indices = showcase::sorted_track_indices(&props.tracks, *sort_state.read());
+    let sorted_tracks: Vec<_> = sorted_indices
+        .iter()
+        .map(|&idx| props.tracks[idx].clone())
+        .collect();
+    let tracks_for_shuffle = sorted_tracks.clone();
+
     let currently_playing_idx: Option<usize> = {
         let queue = ctrl.queue.read();
         let idx = *ctrl.current_queue_index.read();
-        if queue.len() == props.tracks.len()
+        if queue.len() == sorted_tracks.len()
             && queue
                 .iter()
-                .zip(props.tracks.iter())
+                .zip(sorted_tracks.iter())
                 .all(|(q, t)| q.path == t.path)
         {
             Some(idx)
@@ -28,11 +37,7 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
             None
         }
     };
-
-    let tracks_for_shuffle = props.tracks.clone();
-    let fmt_dur = |s: u64| format!("{}:{:02}", s / 60, s % 60);
-    let mut sort_state = use_signal(|| None);
-    let sorted_indices = showcase::sorted_track_indices(&props.tracks, *sort_state.read());
+    let tracks_for_play_all = sorted_tracks.clone();
 
     rsx! {
         div { class: "w-full max-w-[1600px] mx-auto select-none pb-8",
@@ -83,7 +88,7 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                             button {
                                 class: "inline-flex items-center justify-center gap-2 h-9 px-5 rounded-full text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95",
                                 style: "background: var(--color-indigo-500);",
-                                onclick: move |_| props.on_play_all.call(()),
+                                onclick: move |_| ctrl.play_queue_linear(tracks_for_play_all.clone()),
                                 i { class: "fa-solid fa-play text-xs" }
                                 "{i18n::t(\"play\")}"
                             }
@@ -178,13 +183,16 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                 for (display_idx, idx) in sorted_indices.iter().copied().enumerate() {
                     {
                         let track = &props.tracks[idx];
-                        let is_playing = currently_playing_idx == Some(idx);
+                        let is_playing = currently_playing_idx == Some(display_idx);
                         let is_selected = props.selected_tracks.contains(&track.path);
                         let track_dur = fmt_dur(track.duration);
                         let artist = track.artist.clone();
                         let album = track.album.clone();
                         let album_id = track.album_id.clone();
                         let row_num = display_idx + 1;
+
+                        let play_queue = sorted_tracks.clone();
+                        let play_queue_button = sorted_tracks.clone();
 
                         let cover_url: Option<utils::CoverUrl> = {
                             let path_str = track.path.to_string_lossy();
@@ -220,7 +228,10 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                                 } else {
                                     "grid-template-columns: 40px 1fr 200px 200px 56px 40px;".to_string()
                                 },
-                                ondoubleclick: move |_| props.on_play.call(idx),
+                                ondoubleclick: move |_| {
+                                    ctrl.queue.set(play_queue.clone());
+                                    ctrl.play_track(display_idx);
+                                },
 
                                 div { class: "flex items-center",
                                     if is_playing {
@@ -236,7 +247,10 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                                         }
                                         button {
                                             class: "hidden group-hover:flex items-center justify-center",
-                                            onclick: move |_| props.on_play.call(idx),
+                                            onclick: move |_| {
+                                                ctrl.queue.set(play_queue_button.clone());
+                                                ctrl.play_track(display_idx);
+                                            },
                                             i { class: "fa-solid fa-play text-xs", style: "color: rgba(255,255,255,0.8);" }
                                         }
                                     }

--- a/components/src/modern/showcase.rs
+++ b/components/src/modern/showcase.rs
@@ -2,12 +2,14 @@ use config::AppConfig;
 use dioxus::prelude::*;
 use hooks::use_player_controller::PlayerController;
 
+use crate::NavigationController;
 use crate::showcase::{self, ShowcaseProps, SortField};
 
 #[component]
 pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
     let mut ctrl = use_context::<PlayerController>();
     let config = use_context::<Signal<AppConfig>>();
+    let nav_ctrl = use_context::<NavigationController>();
 
     let total_seconds: u64 = props.tracks.iter().map(|t| t.duration).sum();
     let duration_min = total_seconds / 60;
@@ -179,9 +181,9 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                         let is_playing = currently_playing_idx == Some(idx);
                         let is_selected = props.selected_tracks.contains(&track.path);
                         let track_dur = fmt_dur(track.duration);
-                        let title = track.title.clone(); // dead code
                         let artist = track.artist.clone();
                         let album = track.album.clone();
+                        let album_id = track.album_id.clone();
                         let row_num = display_idx + 1;
 
                         let cover_url: Option<utils::CoverUrl> = {
@@ -266,16 +268,30 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
 
                                 div { class: "flex items-center min-w-0 pr-4",
                                     span {
-                                        class: "text-sm truncate",
+                                        class: "text-sm truncate cursor-pointer hover:underline",
                                         style: "color: rgba(255,255,255,0.45);",
+                                        onclick: {
+                                            let artist = artist.clone();
+                                            move |evt: MouseEvent| {
+                                                evt.stop_propagation();
+                                                nav_ctrl.navigate_to_artist(artist.clone());
+                                            }
+                                        },
                                         "{artist}"
                                     }
                                 }
 
                                 div { class: "flex items-center min-w-0 pr-4",
                                     span {
-                                        class: "text-sm truncate",
+                                        class: "text-sm truncate cursor-pointer hover:underline",
                                         style: "color: rgba(255,255,255,0.35);",
+                                        onclick: {
+                                            let album_id = album_id.clone();
+                                            move |evt: MouseEvent| {
+                                                evt.stop_propagation();
+                                                nav_ctrl.navigate_to_album(album_id.clone());
+                                            }
+                                        },
                                         "{album}"
                                     }
                                 }

--- a/components/src/modern/showcase.rs
+++ b/components/src/modern/showcase.rs
@@ -138,8 +138,8 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                 }
             } else {
                 div {
-                    class: "grid px-6 py-2 text-[10px] font-bold uppercase tracking-widest border-b",
-                    style: "grid-template-columns: 40px 1fr 200px 200px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);",
+                    class: "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1",
+                    style: "grid-template-columns: 40px 1fr 180px 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);",
                     div { class: "flex items-center", "#" }
                     button {
                         class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
@@ -220,13 +220,13 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                         rsx! {
                             div {
                                 key: "{track.path.display()}",
-                                class: "grid px-6 py-1.5 rounded-lg mx-2 group cursor-default transition-colors hover:bg-white/5",
+                                class: "grid px-2 py-1.5 rounded-lg mx-1 group cursor-default transition-colors hover:bg-white/5",
                                 style: if is_playing {
-                                    format!("grid-template-columns: 40px 1fr 200px 200px 56px 40px; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent);")
+                                    format!("grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent);")
                                 } else if is_selected {
-                                    "grid-template-columns: 40px 1fr 200px 200px 56px 40px; background: rgba(255,255,255,0.07);".to_string()
+                                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: rgba(255,255,255,0.07);".to_string()
                                 } else {
-                                    "grid-template-columns: 40px 1fr 200px 200px 56px 40px;".to_string()
+                                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px;".to_string()
                                 },
                                 ondoubleclick: move |_| {
                                     ctrl.queue.set(play_queue.clone());

--- a/components/src/modern/showcase.rs
+++ b/components/src/modern/showcase.rs
@@ -274,6 +274,7 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                                         } else {
                                             "color: rgba(255,255,255,0.9);"
                                         },
+                                        ondoubleclick: move |evt| evt.stop_propagation(),
                                         "{track.title}"
                                     }
                                 }
@@ -289,6 +290,7 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                                                 nav_ctrl.navigate_to_artist(artist.clone());
                                             }
                                         },
+                                        ondoubleclick: move |evt| evt.stop_propagation(),
                                         "{artist}"
                                     }
                                 }
@@ -304,6 +306,7 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                                                 nav_ctrl.navigate_to_album(album_id.clone());
                                             }
                                         },
+                                        ondoubleclick: move |evt| evt.stop_propagation(),
                                         "{album}"
                                     }
                                 }

--- a/components/src/modern/showcase.rs
+++ b/components/src/modern/showcase.rs
@@ -15,11 +15,18 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
     let duration_min = total_seconds / 60;
 
     let fmt_dur = |s: u64| format!("{}:{:02}", s / 60, s % 60);
-    let mut sort_state = use_signal(|| None);
-    let sorted_indices = showcase::sorted_track_indices(&props.tracks, *sort_state.read());
-    let sorted_tracks: Vec<_> = sorted_indices
+    let sort_state = use_signal(|| None);
+    let indexed_tracks: Vec<_> = props
+        .tracks
         .iter()
-        .map(|&idx| props.tracks[idx].clone())
+        .cloned()
+        .enumerate()
+        .map(|(idx, track)| (track, idx))
+        .collect();
+    let sorted_track_pairs = showcase::sorted_track_pairs(&indexed_tracks, *sort_state.read());
+    let sorted_tracks: Vec<_> = sorted_track_pairs
+        .iter()
+        .map(|(track, _)| track.clone())
         .collect();
     let tracks_for_shuffle = sorted_tracks.clone();
 
@@ -143,46 +150,34 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                     div { class: "flex items-center", "#" }
                     button {
                         class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
-                        onclick: move |_| {
-                                                    let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
-                                                    sort_state.set(next);
-                                                },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Title),
                         "{i18n::t(\"title\")}"
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[9px]" }
                     }
                     button {
                         class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
-                        onclick: move |_| {
-                                                    let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
-                                                    sort_state.set(next);
-                                                },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Artist),
                         "{i18n::t(\"artist\")}"
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[9px]" }
                     }
                     button {
                         class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
-                        onclick: move |_| {
-                                                    let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
-                                                    sort_state.set(next);
-                                                },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Album),
                         "{i18n::t(\"album\")}"
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[9px]" }
                     }
                     button {
                         class: "flex items-center justify-end gap-1 uppercase tracking-widest text-right hover:text-white transition-colors",
-                        onclick: move |_| {
-                                                    let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
-                                                    sort_state.set(next);
-                                                },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Duration),
                         i { class: "fa-regular fa-clock" }
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[9px]" }
                     }
                     div {}
                 }
 
-                for (display_idx, idx) in sorted_indices.iter().copied().enumerate() {
+                for (display_idx, (track, idx)) in sorted_track_pairs.iter().enumerate() {
                     {
-                        let track = &props.tracks[idx];
+                        let idx = *idx;
                         let is_playing = currently_playing_idx == Some(display_idx);
                         let is_selected = props.selected_tracks.contains(&track.path);
                         let track_dur = fmt_dur(track.duration);

--- a/components/src/normal/showcase.rs
+++ b/components/src/normal/showcase.rs
@@ -16,11 +16,18 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
     let is_server_source = config.read().active_source == MusicSource::Server;
 
     let offline_tracks = config.read().offline_tracks.clone();
-    let mut sort_state = use_signal(|| None);
-    let sorted_indices = showcase::sorted_track_indices(&props.tracks, *sort_state.read());
-    let sorted_tracks: Vec<_> = sorted_indices
+    let sort_state = use_signal(|| None);
+    let indexed_tracks: Vec<_> = props
+        .tracks
         .iter()
-        .map(|&idx| props.tracks[idx].clone())
+        .cloned()
+        .enumerate()
+        .map(|(idx, track)| (track, idx))
+        .collect();
+    let sorted_track_pairs = showcase::sorted_track_pairs(&indexed_tracks, *sort_state.read());
+    let sorted_tracks: Vec<_> = sorted_track_pairs
+        .iter()
+        .map(|(track, _)| track.clone())
         .collect();
 
     let currently_playing_idx: Option<usize> = {
@@ -173,37 +180,25 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                                }
                                button {
                                    class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                                   onclick: move |_| {
-                                       let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
-                                       sort_state.set(next);
-                                   },
+                                   onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Title),
                                    "{i18n::t(\"title\")}"
                                    i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
                                }
                                button {
                                    class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                                   onclick: move |_| {
-                                       let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
-                                       sort_state.set(next);
-                                   },
+                                   onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Artist),
                                    "{i18n::t(\"artist\")}"
                                    i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
                                }
                                button {
                                    class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                                   onclick: move |_| {
-                                       let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
-                                       sort_state.set(next);
-                                   },
+                                   onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Album),
                                    "{i18n::t(\"album\")}"
                                    i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
                                }
                                button {
                                    class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
-                                   onclick: move |_| {
-                                       let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
-                                       sort_state.set(next);
-                                   },
+                                   onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Duration),
                                    i { class: "fa-regular fa-clock" }
                                    i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
                                }
@@ -214,9 +209,9 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                            }
                       }
 
-                     for (display_idx, idx) in sorted_indices.iter().copied().enumerate() {
+                     for (display_idx, (track, idx)) in sorted_track_pairs.iter().enumerate() {
                          {
-                             let track = &props.tracks[idx];
+                             let idx = *idx;
                              let cover_url = if is_server_source {
                                  if let Some(server) = &config.read().server {
                                      let path_str = track.path.to_string_lossy();

--- a/components/src/normal/showcase.rs
+++ b/components/src/normal/showcase.rs
@@ -30,20 +30,20 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
         .map(|(track, _)| track.clone())
         .collect();
 
-    let currently_playing_idx: Option<usize> = {
+    let currently_playing_path = {
         let queue = ctrl.queue.read();
         let idx = *ctrl.current_queue_index.read();
-        if queue.len() == sorted_tracks.len()
-            && queue
-                .iter()
-                .zip(sorted_tracks.iter())
-                .all(|(q, t)| q.path == t.path)
-        {
-            Some(idx)
+        let queue_idx = if *ctrl.shuffle.read() {
+            ctrl.shuffle_order.read().get(idx).copied().unwrap_or(idx)
         } else {
-            None
-        }
+            idx
+        };
+        queue.get(queue_idx).map(|track| track.path.clone())
     };
+    let current_song_title = ctrl.current_song_title.read().clone();
+    let current_song_artist = ctrl.current_song_artist.read().clone();
+    let current_song_album = ctrl.current_song_album.read().clone();
+    let current_song_duration = *ctrl.current_song_duration.read();
     let tracks_for_play_all = sorted_tracks.clone();
 
     let all_downloaded = !props.tracks.is_empty()
@@ -245,6 +245,13 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                              };
 
                              let is_selected = props.selected_tracks.contains(&track.path);
+                             let matches_current_path = currently_playing_path.as_ref() == Some(&track.path);
+                             let matches_current_metadata = !current_song_title.is_empty()
+                                 && track.title == current_song_title
+                                 && track.artist == current_song_artist
+                                 && track.album == current_song_album
+                                 && track.duration == current_song_duration;
+                             let is_currently_playing: bool = matches_current_path || matches_current_metadata;
                              let track_count = props.tracks.len();
                              let can_move_up = props.is_reorderable && idx > 0;
                              let can_move_down = props.is_reorderable && idx + 1 < track_count;
@@ -272,7 +279,7 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                                              is_selected: is_selected,
                                              is_downloaded: is_downloaded,
                                              is_downloading: is_downloading,
-                                             is_currently_playing: currently_playing_idx == Some(display_idx),
+                                             is_currently_playing,
                                              row_num: Some(display_idx + 1),
                                              on_select: move |selected| {
                                                 if let Some(handler) = &props.on_select {

--- a/components/src/normal/showcase.rs
+++ b/components/src/normal/showcase.rs
@@ -145,68 +145,73 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                          p { class: "text-lg", "{i18n::t(\"no_songs_here\")}" }
                      }
                  } else {
-                      div {
-                           class: "grid gap-6 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 mb-2 uppercase tracking-wider",
-                           style: "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;",
-                           div { class: "flex items-center w-10 shrink-0",
-                               if props.is_selection_mode {
-                                   if let Some(handler) = props.on_select_all {
-                                       div { class: "mr-4 flex items-center justify-center w-6 h-6 shrink-0",
-                                           button {
-                                               class: if props.all_selected {
-                                                   "w-4 h-4 rounded border border-indigo-400 bg-indigo-500 text-white flex items-center justify-center transition-colors"
-                                               } else {
-                                                   "w-4 h-4 rounded border border-white/20 bg-white/5 hover:border-white/50 transition-colors"
-                                               },
-                                               aria_label: if props.all_selected { "Deselect all tracks" } else { "Select all tracks" },
-                                               onclick: move |_| handler.call(!props.all_selected),
-                                               if props.all_selected {
-                                                   i { class: "fa-solid fa-check", style: "font-size: 9px;" }
+                      div { class: "flex items-center mb-2",
+                           div {
+                               class: "grid flex-1 gap-6 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 uppercase tracking-wider",
+                               style: "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;",
+                               div { class: "flex items-center w-10 shrink-0",
+                                   if props.is_selection_mode {
+                                       if let Some(handler) = props.on_select_all {
+                                           div { class: "mr-4 flex items-center justify-center w-6 h-6 shrink-0",
+                                               button {
+                                                   class: if props.all_selected {
+                                                       "w-4 h-4 rounded border border-indigo-400 bg-indigo-500 text-white flex items-center justify-center transition-colors"
+                                                   } else {
+                                                       "w-4 h-4 rounded border border-white/20 bg-white/5 hover:border-white/50 transition-colors"
+                                                   },
+                                                   aria_label: if props.all_selected { "Deselect all tracks" } else { "Select all tracks" },
+                                                   onclick: move |_| handler.call(!props.all_selected),
+                                                   if props.all_selected {
+                                                       i { class: "fa-solid fa-check", style: "font-size: 9px;" }
+                                                   }
                                                }
                                            }
                                        }
+                                   } else {
+                                       "#"
                                    }
-                               } else {
-                                   "#"
                                }
+                               button {
+                                   class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                                   onclick: move |_| {
+                                       let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
+                                       sort_state.set(next);
+                                   },
+                                   "{i18n::t(\"title\")}"
+                                   i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
+                               }
+                               button {
+                                   class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                                   onclick: move |_| {
+                                       let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
+                                       sort_state.set(next);
+                                   },
+                                   "{i18n::t(\"artist\")}"
+                                   i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
+                               }
+                               button {
+                                   class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                                   onclick: move |_| {
+                                       let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
+                                       sort_state.set(next);
+                                   },
+                                   "{i18n::t(\"album\")}"
+                                   i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
+                               }
+                               button {
+                                   class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
+                                   onclick: move |_| {
+                                       let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
+                                       sort_state.set(next);
+                                   },
+                                   i { class: "fa-regular fa-clock" }
+                                   i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
+                               }
+                               div {}
                            }
-                           button {
-                               class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                               onclick: move |_| {
-                                                                  let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
-                                                                  sort_state.set(next);
-                                                              },
-                               "{i18n::t(\"title\")}"
-                               i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
+                           if props.is_reorderable && !props.is_selection_mode {
+                               div { class: "pr-2 shrink-0", style: "width: 22px;" }
                            }
-                           button {
-                               class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                               onclick: move |_| {
-                                                                  let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
-                                                                  sort_state.set(next);
-                                                              },
-                               "{i18n::t(\"artist\")}"
-                               i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
-                           }
-                           button {
-                               class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                               onclick: move |_| {
-                                                                  let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
-                                                                  sort_state.set(next);
-                                                              },
-                               "{i18n::t(\"album\")}"
-                               i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
-                           }
-                           button {
-                               class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
-                               onclick: move |_| {
-                                                                  let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
-                                                                  sort_state.set(next);
-                                                              },
-                               i { class: "fa-regular fa-clock" }
-                               i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
-                           }
-                           div {}
                       }
 
                      for (display_idx, idx) in sorted_indices.iter().copied().enumerate() {

--- a/components/src/normal/showcase.rs
+++ b/components/src/normal/showcase.rs
@@ -1,5 +1,5 @@
 use crate::reorder_buttons::ReorderButtons;
-use crate::showcase::ShowcaseProps;
+use crate::showcase::{self, ShowcaseProps, SortField};
 use crate::track_row::TrackRow;
 use config::{AppConfig, MusicService, MusicSource};
 use dioxus::prelude::*;
@@ -16,12 +16,17 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
     let is_server_source = config.read().active_source == MusicSource::Server;
 
     let offline_tracks = config.read().offline_tracks.clone();
+    let mut sort_state = use_signal(|| None);
+    let sorted_indices = showcase::sorted_track_indices(&props.tracks, *sort_state.read());
 
     let currently_playing_idx: Option<usize> = {
         let queue = ctrl.queue.read();
         let idx = *ctrl.current_queue_index.read();
         if queue.len() == props.tracks.len()
-            && queue.iter().zip(props.tracks.iter()).all(|(q, t)| q.path == t.path)
+            && queue
+                .iter()
+                .zip(props.tracks.iter())
+                .all(|(q, t)| q.path == t.path)
         {
             Some(idx)
         } else {
@@ -135,8 +140,10 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                          p { class: "text-lg", "{i18n::t(\"no_songs_here\")}" }
                      }
                  } else {
-                      div { class: "grid grid-cols-[auto_1fr_1fr_auto_auto] gap-4 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 mb-2 uppercase tracking-wider",
-                           div { class: "flex items-center w-24 shrink-0",
+                      div {
+                           class: "grid gap-6 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 mb-2 uppercase tracking-wider",
+                           style: "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;",
+                           div { class: "flex items-center w-10 shrink-0",
                                if props.is_selection_mode {
                                    if let Some(handler) = props.on_select_all {
                                        div { class: "mr-4 flex items-center justify-center w-6 h-6 shrink-0",
@@ -158,12 +165,48 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                                    "#"
                                }
                            }
-                           div { "{i18n::t(\"title\")}" }
-                           div { "{i18n::t(\"artist\")}" }
+                           button {
+                               class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                               onclick: move |_| {
+                                                                  let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
+                                                                  sort_state.set(next);
+                                                              },
+                               "{i18n::t(\"title\")}"
+                               i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
+                           }
+                           button {
+                               class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                               onclick: move |_| {
+                                                                  let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
+                                                                  sort_state.set(next);
+                                                              },
+                               "{i18n::t(\"artist\")}"
+                               i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
+                           }
+                           button {
+                               class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                               onclick: move |_| {
+                                                                  let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
+                                                                  sort_state.set(next);
+                                                              },
+                               "{i18n::t(\"album\")}"
+                               i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
+                           }
+                           button {
+                               class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
+                               onclick: move |_| {
+                                                                  let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
+                                                                  sort_state.set(next);
+                                                              },
+                               i { class: "fa-regular fa-clock" }
+                               i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
+                           }
+                           div {}
                       }
 
-                     for (idx, track) in props.tracks.iter().enumerate() {
+                     for (display_idx, idx) in sorted_indices.iter().copied().enumerate() {
                          {
+                             let track = &props.tracks[idx];
                              let cover_url = if is_server_source {
                                  if let Some(server) = &config.read().server {
                                      let path_str = track.path.to_string_lossy();
@@ -224,6 +267,7 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                                              is_downloaded: is_downloaded,
                                              is_downloading: is_downloading,
                                              is_currently_playing: currently_playing_idx == Some(idx),
+                                             row_num: Some(display_idx + 1),
                                              on_select: move |selected| {
                                                 if let Some(handler) = &props.on_select {
                                                     handler.call((idx, selected));

--- a/components/src/normal/showcase.rs
+++ b/components/src/normal/showcase.rs
@@ -18,14 +18,18 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
     let offline_tracks = config.read().offline_tracks.clone();
     let mut sort_state = use_signal(|| None);
     let sorted_indices = showcase::sorted_track_indices(&props.tracks, *sort_state.read());
+    let sorted_tracks: Vec<_> = sorted_indices
+        .iter()
+        .map(|&idx| props.tracks[idx].clone())
+        .collect();
 
     let currently_playing_idx: Option<usize> = {
         let queue = ctrl.queue.read();
         let idx = *ctrl.current_queue_index.read();
-        if queue.len() == props.tracks.len()
+        if queue.len() == sorted_tracks.len()
             && queue
                 .iter()
-                .zip(props.tracks.iter())
+                .zip(sorted_tracks.iter())
                 .all(|(q, t)| q.path == t.path)
         {
             Some(idx)
@@ -33,6 +37,7 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
             None
         }
     };
+    let tracks_for_play_all = sorted_tracks.clone();
 
     let all_downloaded = !props.tracks.is_empty()
         && props.tracks.iter().all(|t| {
@@ -102,7 +107,7 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                         }
                         button {
                              class: "w-14 h-14 rounded-full bg-indigo-500 hover:bg-indigo-400 text-black flex items-center justify-center transition-transform hover:scale-105",
-                             onclick: move |_| props.on_play_all.call(()),
+                             onclick: move |_| ctrl.play_queue_linear(tracks_for_play_all.clone()),
                              i { class: "fa-solid fa-play text-xl ml-1" }
                          }
                          if props.on_download_all.is_some() || props.on_delete_all.is_some() {
@@ -252,6 +257,7 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                                  false
                              };
                              let is_downloading = false;
+                             let play_queue = sorted_tracks.clone();
 
                              rsx! {
                                  div {
@@ -266,7 +272,7 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                                              is_selected: is_selected,
                                              is_downloaded: is_downloaded,
                                              is_downloading: is_downloading,
-                                             is_currently_playing: currently_playing_idx == Some(idx),
+                                             is_currently_playing: currently_playing_idx == Some(display_idx),
                                              row_num: Some(display_idx + 1),
                                              on_select: move |selected| {
                                                 if let Some(handler) = &props.on_select {
@@ -313,7 +319,10 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                                                      handler.call(idx);
                                                  }
                                              },
-                                             on_play: move |_| props.on_play.call(idx)
+                                             on_play: move |_| {
+                                                 ctrl.queue.set(play_queue.clone());
+                                                 ctrl.play_track(display_idx);
+                                             }
                                          }
                                      }
                                      if props.is_reorderable && !props.is_selection_mode {

--- a/components/src/search_genre_detail.rs
+++ b/components/src/search_genre_detail.rs
@@ -32,13 +32,8 @@ pub fn SearchGenreDetail(
     let config = use_context::<Signal<AppConfig>>();
     let offline_tracks = config.read().offline_tracks.clone();
     let is_modern = config.read().ui_style == UiStyle::Modern;
-    let mut sort_state = use_signal(|| None);
-    let tracks_for_sorting: Vec<Track> = genre_tracks.iter().map(|(t, _)| t.clone()).collect();
-    let sorted_indices = showcase::sorted_track_indices(&tracks_for_sorting, *sort_state.read());
-    let sorted_genre_tracks: Vec<(Track, Option<utils::CoverUrl>)> = sorted_indices
-        .iter()
-        .map(|&idx| genre_tracks[idx].clone())
-        .collect();
+    let sort_state = use_signal(|| None);
+    let sorted_genre_tracks = showcase::sorted_track_pairs(&genre_tracks, *sort_state.read());
 
     rsx! {
         div {
@@ -161,37 +156,25 @@ pub fn SearchGenreDetail(
                 div { "#" }
                 button {
                     class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                    onclick: move |_| {
-                        let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
-                        sort_state.set(next);
-                    },
+                    onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Title),
                     "{i18n::t(\"title\")}"
                     i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
                 }
                 button {
                     class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                    onclick: move |_| {
-                        let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
-                        sort_state.set(next);
-                    },
+                    onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Artist),
                     "{i18n::t(\"artist\")}"
                     i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
                 }
                 button {
                     class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                    onclick: move |_| {
-                        let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
-                        sort_state.set(next);
-                    },
+                    onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Album),
                     "{i18n::t(\"album\")}"
                     i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
                 }
                 button {
                     class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
-                    onclick: move |_| {
-                        let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
-                        sort_state.set(next);
-                    },
+                    onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Duration),
                     i { class: "fa-regular fa-clock" }
                     i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
                 }

--- a/components/src/search_genre_detail.rs
+++ b/components/src/search_genre_detail.rs
@@ -1,3 +1,4 @@
+use crate::showcase::{self, SortField};
 use crate::track_row::TrackRow;
 use config::{AppConfig, UiStyle};
 use dioxus::prelude::*;
@@ -31,6 +32,13 @@ pub fn SearchGenreDetail(
     let config = use_context::<Signal<AppConfig>>();
     let offline_tracks = config.read().offline_tracks.clone();
     let is_modern = config.read().ui_style == UiStyle::Modern;
+    let mut sort_state = use_signal(|| None);
+    let tracks_for_sorting: Vec<Track> = genre_tracks.iter().map(|(t, _)| t.clone()).collect();
+    let sorted_indices = showcase::sorted_track_indices(&tracks_for_sorting, *sort_state.read());
+    let sorted_genre_tracks: Vec<(Track, Option<utils::CoverUrl>)> = sorted_indices
+        .iter()
+        .map(|&idx| genre_tracks[idx].clone())
+        .collect();
 
     rsx! {
         div {
@@ -79,7 +87,7 @@ pub fn SearchGenreDetail(
                                     class: "inline-flex items-center justify-center gap-2 h-9 px-5 rounded-full text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95",
                                     style: "background: var(--color-indigo-500);",
                                     onclick: {
-                                        let tracks_play: Vec<Track> = genre_tracks.iter().map(|(t, _)| t.clone()).collect();
+                                        let tracks_play: Vec<Track> = sorted_genre_tracks.iter().map(|(t, _)| t.clone()).collect();
                                         move |_| {
                                             let is_shuffle = *ctrl.shuffle.peek();
                                             if is_shuffle {
@@ -100,7 +108,7 @@ pub fn SearchGenreDetail(
                                         "background: color-mix(in oklab, var(--color-indigo-500) 25%, transparent); border: 1px solid color-mix(in oklab, var(--color-indigo-500) 40%, transparent);"
                                     },
                                     onclick: {
-                                        let tracks_shuffle: Vec<Track> = genre_tracks.iter().map(|(t, _)| t.clone()).collect();
+                                        let tracks_shuffle: Vec<Track> = sorted_genre_tracks.iter().map(|(t, _)| t.clone()).collect();
                                         move |_| {
                                             ctrl.toggle_shuffle();
                                             ctrl.play_queue_shuffled(tracks_shuffle.clone());
@@ -139,19 +147,58 @@ pub fn SearchGenreDetail(
                 }
             }
 
-            if is_modern {
-                div {
-                    class: "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1",
-                    style: "grid-template-columns: 40px 1fr 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);",
-                    div {}
-                    div { "{i18n::t(\"title\")}" }
-                    div { "{i18n::t(\"artist\")}" }
-                    div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
-                    div {}
+            div {
+                class: if is_modern {
+                    "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1"
+                } else {
+                    "grid gap-6 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 mb-2 uppercase tracking-wider"
+                },
+                style: if is_modern {
+                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);"
+                } else {
+                    "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;"
+                },
+                div { "#" }
+                button {
+                    class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                    onclick: move |_| {
+                        let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
+                        sort_state.set(next);
+                    },
+                    "{i18n::t(\"title\")}"
+                    i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
                 }
+                button {
+                    class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                    onclick: move |_| {
+                        let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
+                        sort_state.set(next);
+                    },
+                    "{i18n::t(\"artist\")}"
+                    i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
+                }
+                button {
+                    class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                    onclick: move |_| {
+                        let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
+                        sort_state.set(next);
+                    },
+                    "{i18n::t(\"album\")}"
+                    i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
+                }
+                button {
+                    class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
+                    onclick: move |_| {
+                        let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
+                        sort_state.set(next);
+                    },
+                    i { class: "fa-regular fa-clock" }
+                    i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
+                }
+                div {}
             }
             div { class: if is_modern { "pb-20" } else { "space-y-1 pb-20" },
-                 for (idx, (track, cover_url)) in genre_tracks.iter().enumerate() {
+                 for (idx, (track, cover_url)) in sorted_genre_tracks.iter().enumerate() {
                      {
                          let track = track.clone();
                          let track_key = track.path.display().to_string();
@@ -160,7 +207,7 @@ pub fn SearchGenreDetail(
                          let track_queue = track.clone();
                          let track_delete = track.clone();
                          let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
-                         let genre_tracks_list: Vec<Track> = genre_tracks.iter().map(|(t, _)| t.clone()).collect();
+                         let genre_tracks_list: Vec<Track> = sorted_genre_tracks.iter().map(|(t, _)| t.clone()).collect();
                          let item_id: Option<String> = {
                              let s = track.path.to_string_lossy();
                              if s.starts_with("jellyfin:") {

--- a/components/src/search_genre_detail.rs
+++ b/components/src/search_genre_detail.rs
@@ -34,6 +34,8 @@ pub fn SearchGenreDetail(
     let is_modern = config.read().ui_style == UiStyle::Modern;
     let sort_state = use_signal(|| None);
     let sorted_genre_tracks = showcase::sorted_track_pairs(&genre_tracks, *sort_state.read());
+    let genre_tracks_list: Vec<Track> =
+        sorted_genre_tracks.iter().map(|(t, _)| t.clone()).collect();
 
     rsx! {
         div {
@@ -82,7 +84,7 @@ pub fn SearchGenreDetail(
                                     class: "inline-flex items-center justify-center gap-2 h-9 px-5 rounded-full text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95",
                                     style: "background: var(--color-indigo-500);",
                                     onclick: {
-                                        let tracks_play: Vec<Track> = sorted_genre_tracks.iter().map(|(t, _)| t.clone()).collect();
+                                        let tracks_play = genre_tracks_list.clone();
                                         move |_| {
                                             let is_shuffle = *ctrl.shuffle.peek();
                                             if is_shuffle {
@@ -103,7 +105,7 @@ pub fn SearchGenreDetail(
                                         "background: color-mix(in oklab, var(--color-indigo-500) 25%, transparent); border: 1px solid color-mix(in oklab, var(--color-indigo-500) 40%, transparent);"
                                     },
                                     onclick: {
-                                        let tracks_shuffle: Vec<Track> = sorted_genre_tracks.iter().map(|(t, _)| t.clone()).collect();
+                                        let tracks_shuffle = genre_tracks_list.clone();
                                         move |_| {
                                             ctrl.toggle_shuffle();
                                             ctrl.play_queue_shuffled(tracks_shuffle.clone());
@@ -189,8 +191,8 @@ pub fn SearchGenreDetail(
                          let track_add = track.clone();
                          let track_queue = track.clone();
                          let track_delete = track.clone();
+                         let queue_source = genre_tracks_list.clone();
                          let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
-                         let genre_tracks_list: Vec<Track> = sorted_genre_tracks.iter().map(|(t, _)| t.clone()).collect();
                          let item_id: Option<String> = {
                              let s = track.path.to_string_lossy();
                              if s.starts_with("jellyfin:") {
@@ -243,7 +245,7 @@ pub fn SearchGenreDetail(
                                      }
                                  },
                                  on_play: move |_| {
-                                     queue.set(genre_tracks_list.clone());
+                                     queue.set(queue_source.clone());
                                      ctrl.play_track(idx);
                                  }
                              }

--- a/components/src/search_results.rs
+++ b/components/src/search_results.rs
@@ -32,13 +32,8 @@ pub fn SearchResults(
     let config = use_context::<Signal<AppConfig>>();
     let offline_tracks = config.read().offline_tracks.clone();
     let is_modern = config.read().ui_style == UiStyle::Modern;
-    let mut sort_state = use_signal(|| None);
-    let tracks_for_sorting: Vec<Track> = tracks.iter().map(|(t, _)| t.clone()).collect();
-    let sorted_indices = showcase::sorted_track_indices(&tracks_for_sorting, *sort_state.read());
-    let sorted_tracks: Vec<(Track, Option<utils::CoverUrl>)> = sorted_indices
-        .iter()
-        .map(|&idx| tracks[idx].clone())
-        .collect();
+    let sort_state = use_signal(|| None);
+    let sorted_tracks = showcase::sorted_track_pairs(&tracks, *sort_state.read());
 
     rsx! {
         div { class: "mt-8 space-y-8",
@@ -59,37 +54,25 @@ pub fn SearchResults(
                         div { "#" }
                         button {
                             class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                            onclick: move |_| {
-                                let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
-                                sort_state.set(next);
-                            },
+                            onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Title),
                             "{i18n::t(\"title\")}"
                             i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
                         }
                         button {
                             class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                            onclick: move |_| {
-                                let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
-                                sort_state.set(next);
-                            },
+                            onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Artist),
                             "{i18n::t(\"artist\")}"
                             i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
                         }
                         button {
                             class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                            onclick: move |_| {
-                                let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
-                                sort_state.set(next);
-                            },
+                            onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Album),
                             "{i18n::t(\"album\")}"
                             i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
                         }
                         button {
                             class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
-                            onclick: move |_| {
-                                let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
-                                sort_state.set(next);
-                            },
+                            onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Duration),
                             i { class: "fa-regular fa-clock" }
                             i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
                         }

--- a/components/src/search_results.rs
+++ b/components/src/search_results.rs
@@ -34,6 +34,7 @@ pub fn SearchResults(
     let is_modern = config.read().ui_style == UiStyle::Modern;
     let sort_state = use_signal(|| None);
     let sorted_tracks = showcase::sorted_track_pairs(&tracks, *sort_state.read());
+    let search_queue: Vec<Track> = sorted_tracks.iter().map(|(t, _)| t.clone()).collect();
 
     rsx! {
         div { class: "mt-8 space-y-8",
@@ -87,8 +88,8 @@ pub fn SearchResults(
                                 let track_add = track.clone();
                                 let track_queue = track.clone();
                                 let track_delete = track.clone();
+                                let queue_source = search_queue.clone();
                                 let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
-                                let search_queue: Vec<Track> = sorted_tracks.iter().map(|(t, _)| t.clone()).collect();
                                 let item_id: Option<String> = {
                                     let s = track.path.to_string_lossy();
                                     if s.starts_with("jellyfin:") {
@@ -141,7 +142,7 @@ pub fn SearchResults(
                                             }
                                         },
                                         on_play: move |_| {
-                                            queue.set(search_queue.clone());
+                                            queue.set(queue_source.clone());
                                             ctrl.play_track(idx);
                                         }
                                     }

--- a/components/src/search_results.rs
+++ b/components/src/search_results.rs
@@ -1,3 +1,4 @@
+use crate::showcase::{self, SortField};
 use crate::track_row::TrackRow;
 use config::{AppConfig, UiStyle};
 use dioxus::prelude::*;
@@ -31,25 +32,71 @@ pub fn SearchResults(
     let config = use_context::<Signal<AppConfig>>();
     let offline_tracks = config.read().offline_tracks.clone();
     let is_modern = config.read().ui_style == UiStyle::Modern;
+    let mut sort_state = use_signal(|| None);
+    let tracks_for_sorting: Vec<Track> = tracks.iter().map(|(t, _)| t.clone()).collect();
+    let sorted_indices = showcase::sorted_track_indices(&tracks_for_sorting, *sort_state.read());
+    let sorted_tracks: Vec<(Track, Option<utils::CoverUrl>)> = sorted_indices
+        .iter()
+        .map(|&idx| tracks[idx].clone())
+        .collect();
 
     rsx! {
         div { class: "mt-8 space-y-8",
             if !tracks.is_empty() {
                 div {
                     h2 { class: "text-xl font-semibold text-white/80 mb-4", "{i18n::t(\"tracks\")}" }
-                    if is_modern {
-                        div {
-                            class: "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1",
-                            style: "grid-template-columns: 40px 1fr 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);",
-                            div {}
-                            div { "{i18n::t(\"title\")}" }
-                            div { "{i18n::t(\"artist\")}" }
-                            div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
-                            div {}
+                    div {
+                        class: if is_modern {
+                            "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1"
+                        } else {
+                            "grid gap-6 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 mb-2 uppercase tracking-wider"
+                        },
+                        style: if is_modern {
+                            "grid-template-columns: 40px 1fr 180px 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);"
+                        } else {
+                            "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;"
+                        },
+                        div { "#" }
+                        button {
+                            class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                            onclick: move |_| {
+                                let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
+                                sort_state.set(next);
+                            },
+                            "{i18n::t(\"title\")}"
+                            i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
                         }
+                        button {
+                            class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                            onclick: move |_| {
+                                let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
+                                sort_state.set(next);
+                            },
+                            "{i18n::t(\"artist\")}"
+                            i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
+                        }
+                        button {
+                            class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                            onclick: move |_| {
+                                let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
+                                sort_state.set(next);
+                            },
+                            "{i18n::t(\"album\")}"
+                            i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
+                        }
+                        button {
+                            class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
+                            onclick: move |_| {
+                                let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
+                                sort_state.set(next);
+                            },
+                            i { class: "fa-regular fa-clock" }
+                            i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
+                        }
+                        div {}
                     }
                     div { class: if is_modern { "" } else { "space-y-2" },
-                        for (idx, (track, cover_url)) in tracks.iter().enumerate() {
+                        for (idx, (track, cover_url)) in sorted_tracks.iter().enumerate() {
                             {
                                 let track = track.clone();
                                 let track_key = track.path.display().to_string();
@@ -58,7 +105,7 @@ pub fn SearchResults(
                                 let track_queue = track.clone();
                                 let track_delete = track.clone();
                                 let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
-                                let search_queue: Vec<Track> = tracks.iter().map(|(t, _)| t.clone()).collect();
+                                let search_queue: Vec<Track> = sorted_tracks.iter().map(|(t, _)| t.clone()).collect();
                                 let item_id: Option<String> = {
                                     let s = track.path.to_string_lossy();
                                     if s.starts_with("jellyfin:") {

--- a/components/src/showcase.rs
+++ b/components/src/showcase.rs
@@ -1,8 +1,77 @@
 use config::AppConfig;
 use dioxus::prelude::*;
 use reader::{Library, Track};
+use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SortField {
+    Title,
+    Artist,
+    Album,
+    Duration,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SortDirection {
+    Asc,
+    Desc,
+}
+
+pub type SortState = Option<(SortField, SortDirection)>;
+
+pub fn next_sort_state(current: SortState, field: SortField) -> SortState {
+    match current {
+        Some((current_field, SortDirection::Asc)) if current_field == field => {
+            Some((field, SortDirection::Desc))
+        }
+        Some((current_field, SortDirection::Desc)) if current_field == field => None,
+        _ => Some((field, SortDirection::Asc)),
+    }
+}
+
+pub fn sort_icon(sort_state: SortState, field: SortField) -> &'static str {
+    match sort_state {
+        Some((current_field, SortDirection::Asc)) if current_field == field => {
+            "fa-solid fa-sort-up"
+        }
+        Some((current_field, SortDirection::Desc)) if current_field == field => {
+            "fa-solid fa-sort-down"
+        }
+        _ => "fa-solid fa-sort",
+    }
+}
+
+pub fn sorted_track_indices(tracks: &[Track], sort_state: SortState) -> Vec<usize> {
+    let mut indices: Vec<usize> = (0..tracks.len()).collect();
+
+    if let Some((field, direction)) = sort_state {
+        indices.sort_by(|&left_idx, &right_idx| {
+            let left = &tracks[left_idx];
+            let right = &tracks[right_idx];
+
+            let ordering = match field {
+                SortField::Title => compare_text(&left.title, &right.title),
+                SortField::Artist => compare_text(&left.artist, &right.artist),
+                SortField::Album => compare_text(&left.album, &right.album),
+                SortField::Duration => left.duration.cmp(&right.duration),
+            }
+            .then_with(|| left_idx.cmp(&right_idx));
+
+            match direction {
+                SortDirection::Asc => ordering,
+                SortDirection::Desc => ordering.reverse(),
+            }
+        });
+    }
+
+    indices
+}
+
+fn compare_text(left: &str, right: &str) -> Ordering {
+    left.to_lowercase().cmp(&right.to_lowercase())
+}
 
 #[derive(Props, Clone, PartialEq)]
 pub struct ShowcaseProps {

--- a/components/src/showcase.rs
+++ b/components/src/showcase.rs
@@ -51,18 +51,17 @@ pub fn sorted_track_indices(tracks: &[Track], sort_state: SortState) -> Vec<usiz
             let left = &tracks[left_idx];
             let right = &tracks[right_idx];
 
-            let ordering = match field {
+            let primary = match field {
                 SortField::Title => compare_text(&left.title, &right.title),
                 SortField::Artist => compare_text(&left.artist, &right.artist),
                 SortField::Album => compare_text(&left.album, &right.album),
                 SortField::Duration => left.duration.cmp(&right.duration),
-            }
-            .then_with(|| left_idx.cmp(&right_idx));
-
-            match direction {
-                SortDirection::Asc => ordering,
-                SortDirection::Desc => ordering.reverse(),
-            }
+            };
+            let directional = match direction {
+                SortDirection::Asc => primary,
+                SortDirection::Desc => primary.reverse(),
+            };
+            directional.then_with(|| left_idx.cmp(&right_idx))
         });
     }
 

--- a/components/src/showcase.rs
+++ b/components/src/showcase.rs
@@ -31,6 +31,11 @@ pub fn next_sort_state(current: SortState, field: SortField) -> SortState {
     }
 }
 
+pub fn toggle_sort_state(mut sort_state: Signal<SortState>, field: SortField) {
+    let next = next_sort_state(*sort_state.peek(), field);
+    sort_state.set(next);
+}
+
 pub fn sort_icon(sort_state: SortState, field: SortField) -> &'static str {
     match sort_state {
         Some((current_field, SortDirection::Asc)) if current_field == field => {
@@ -41,6 +46,17 @@ pub fn sort_icon(sort_state: SortState, field: SortField) -> &'static str {
         }
         _ => "fa-solid fa-sort",
     }
+}
+
+pub fn sorted_track_pairs<T: Clone>(
+    tracks: &[(Track, T)],
+    sort_state: SortState,
+) -> Vec<(Track, T)> {
+    let tracks_for_sorting: Vec<Track> = tracks.iter().map(|(track, _)| track.clone()).collect();
+    sorted_track_indices(&tracks_for_sorting, sort_state)
+        .into_iter()
+        .map(|idx| tracks[idx].clone())
+        .collect()
 }
 
 pub fn sorted_track_indices(tracks: &[Track], sort_state: SortState) -> Vec<usize> {

--- a/components/src/track_row.rs
+++ b/components/src/track_row.rs
@@ -141,11 +141,11 @@ pub fn TrackRow(
             div {
                 class: "grid px-2 py-1.5 rounded-lg mx-1 group cursor-default transition-colors hover:bg-white/5 select-none",
                 style: if is_currently_playing {
-                    "grid-template-columns: 40px 1fr 180px 56px 40px; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent);"
+                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent);"
                 } else if is_selected {
-                    "grid-template-columns: 40px 1fr 180px 56px 40px; background: rgba(255,255,255,0.07);"
+                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: rgba(255,255,255,0.07);"
                 } else {
-                    "grid-template-columns: 40px 1fr 180px 56px 40px;"
+                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px;"
                 },
                 onclick: move |evt| {
                     evt.stop_propagation();
@@ -257,6 +257,23 @@ pub fn TrackRow(
                             }
                         },
                         "{track.artist}"
+                    }
+                }
+
+                div { class: "flex items-center min-w-0 pr-3",
+                    span {
+                        class: "text-sm truncate cursor-pointer hover:underline",
+                        style: "color: rgba(255,255,255,0.35);",
+                        onclick: {
+                            let album_id = track.album_id.clone();
+                            move |evt: MouseEvent| {
+                                evt.stop_propagation();
+                                if !is_selection_mode {
+                                    nav_ctrl.navigate_to_album(album_id.clone());
+                                }
+                            }
+                        },
+                        "{track.album}"
                     }
                 }
 
@@ -400,6 +417,7 @@ pub fn TrackRow(
             div { class: "min-w-0 pr-4",
                 p {
                     class: "text-sm text-slate-500 truncate cursor-pointer hover:underline hover:text-slate-400 transition-colors",
+                    style: "color: rgba(255,255,255,0.45);",
                     onclick: {
                         let artist = track.artist.clone();
                         move |evt: MouseEvent| {
@@ -416,6 +434,7 @@ pub fn TrackRow(
             div { class: "min-w-0 pr-4",
                 p {
                     class: "text-sm text-slate-500 truncate cursor-pointer hover:underline hover:text-slate-400 transition-colors",
+                    style: "color: rgba(255,255,255,0.3);",
                     onclick: {
                         let album_id = track.album_id.clone();
                         move |evt: MouseEvent| {
@@ -430,7 +449,7 @@ pub fn TrackRow(
             }
 
             div { class: "flex items-center justify-end",
-                span { class: "text-xs font-mono text-slate-500", "{duration_str}" }
+                span { class: "text-xs font-mono text-slate-500", style: "color: rgba(255,255,255,0.3);", "{duration_str}" }
             }
 
             div { class: "flex items-center justify-end",

--- a/components/src/track_row.rs
+++ b/components/src/track_row.rs
@@ -237,6 +237,7 @@ pub fn TrackRow(
                                 }
                             }
                         },
+                        ondoubleclick: move |evt| evt.stop_propagation(),
                         "{track.title}"
                     }
                     if is_downloaded {
@@ -260,6 +261,7 @@ pub fn TrackRow(
                                 }
                             }
                         },
+                        ondoubleclick: move |evt| evt.stop_propagation(),
                         "{track.artist}"
                     }
                 }
@@ -277,6 +279,7 @@ pub fn TrackRow(
                                 }
                             }
                         },
+                        ondoubleclick: move |evt| evt.stop_propagation(),
                         "{track.album}"
                     }
                 }
@@ -412,6 +415,7 @@ pub fn TrackRow(
                             }
                         }
                     },
+                    ondoubleclick: move |evt| evt.stop_propagation(),
                     "{track.title}"
                 }
             }
@@ -429,6 +433,7 @@ pub fn TrackRow(
                             }
                         }
                     },
+                    ondoubleclick: move |evt| evt.stop_propagation(),
                     "{track.artist}"
                 }
             }
@@ -446,6 +451,7 @@ pub fn TrackRow(
                             }
                         }
                     },
+                    ondoubleclick: move |evt| evt.stop_propagation(),
                     "{track.album}"
                 }
             }

--- a/components/src/track_row.rs
+++ b/components/src/track_row.rs
@@ -1,5 +1,5 @@
-use crate::dots_menu::{DotsMenu, MenuAction};
 use crate::NavigationController;
+use crate::dots_menu::{DotsMenu, MenuAction};
 use config::{AppConfig, UiStyle};
 use dioxus::prelude::*;
 use reader::models::Track;
@@ -301,16 +301,16 @@ pub fn TrackRow(
         };
     }
 
-    rsx! {
+    // normal UI
+    return rsx! {
         div {
-            class: format!(
-                "flex items-center p-2 rounded-lg hover:bg-white/5 group transition-colors relative select-none {}",
-                if is_selected { "bg-white/10" } else { "" }
-            ),
+            class: "grid items-center p-2 rounded-lg hover:bg-white/5 group transition-colors relative select-none",
             style: if is_currently_playing {
-                "background-color: color-mix(in oklab, var(--color-indigo-500) 12%, transparent);"
+                "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; column-gap: 1.5rem; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent);"
+            } else if is_selected {
+                "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; column-gap: 1.5rem; background: rgba(255,255,255,0.07);"
             } else {
-                ""
+                "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; column-gap: 1.5rem;"
             },
             onclick: move |evt| {
                 evt.stop_propagation();
@@ -338,8 +338,8 @@ pub fn TrackRow(
                 }
             },
 
-            if on_select.is_some() && is_selection_mode {
-                div { class: "mr-4 flex items-center justify-center w-6 h-6 shrink-0",
+            div { class: "flex items-center w-10 shrink-0",
+                if on_select.is_some() && is_selection_mode {
                     button {
                         class: if is_selected {
                             "w-4 h-4 rounded border border-indigo-400 bg-indigo-500 text-white flex items-center justify-center transition-colors"
@@ -355,25 +355,28 @@ pub fn TrackRow(
                             i { class: "fa-solid fa-check", style: "font-size: 9px;" }
                         }
                     }
+                } else if is_currently_playing {
+                    i { class: "fa-solid fa-volume-high text-xs", style: "color: var(--color-indigo-500);" }
+                } else if let Some(n) = row_num {
+                    span { class: "text-xs text-slate-500", "{n}" }
                 }
             }
 
-            div { class: "relative w-10 h-10 bg-white/5 rounded overflow-hidden flex items-center justify-center mr-4 shrink-0",
-                i { class: "fa-solid fa-music text-white/20 absolute" }
-                if let Some(url) = cover_url {
-                    div {
-                        class: "absolute inset-0 bg-cover bg-center",
-                        style: "background-image: url('{url.as_ref()}');"
+            div { class: "flex items-center min-w-0 pr-4",
+                div { class: "relative w-10 h-10 bg-white/5 rounded overflow-hidden flex items-center justify-center mr-4 shrink-0",
+                    i { class: "fa-solid fa-music text-white/20 absolute" }
+                    if let Some(url) = cover_url {
+                        div {
+                            class: "absolute inset-0 bg-cover bg-center",
+                            style: "background-image: url('{url.as_ref()}');"
+                        }
+                    }
+                    if is_downloaded && !is_currently_playing {
+                        div { class: "absolute bottom-0 right-0 w-3 h-3 bg-indigo-500 rounded-tl flex items-center justify-center",
+                            i { class: "fa-solid fa-check text-white", style: "font-size: 6px;" }
+                        }
                     }
                 }
-                if is_downloaded && !is_currently_playing {
-                    div { class: "absolute bottom-0 right-0 w-3 h-3 bg-indigo-500 rounded-tl flex items-center justify-center",
-                        i { class: "fa-solid fa-check text-white", style: "font-size: 6px;" }
-                    }
-                }
-            }
-
-            div { class: "flex-1 min-w-0 pr-4",
                 p {
                     class: "text-sm font-medium truncate cursor-pointer hover:underline",
                     style: if is_currently_playing {
@@ -392,8 +395,11 @@ pub fn TrackRow(
                     },
                     "{track.title}"
                 }
+            }
+
+            div { class: "min-w-0 pr-4",
                 p {
-                    class: "text-xs text-slate-500 truncate cursor-pointer hover:underline hover:text-slate-400 transition-colors",
+                    class: "text-sm text-slate-500 truncate cursor-pointer hover:underline hover:text-slate-400 transition-colors",
                     onclick: {
                         let artist = track.artist.clone();
                         move |evt: MouseEvent| {
@@ -407,40 +413,50 @@ pub fn TrackRow(
                 }
             }
 
-            if !is_selection_mode {
-                DotsMenu {
-                    actions,
-                    is_open: is_menu_open,
-                    on_open: move |_| on_click_menu.call(()),
-                    on_close: move |_| on_close_menu.call(()),
-                    button_class: "opacity-0 group-hover:opacity-100 focus:opacity-100".to_string(),
-                    anchor: "right".to_string(),
-                    on_action: move |idx: usize| {
-                        if let Some(queue_idx) = add_to_queue_idx {
-                            if idx == queue_idx {
-                                if let Some(handler) = on_queue {
+            div { class: "min-w-0 pr-4",
+                p { class: "text-sm text-slate-500 truncate", "{track.album}" }
+            }
+
+            div { class: "flex items-center justify-end",
+                span { class: "text-xs font-mono text-slate-500", "{duration_str}" }
+            }
+
+            div { class: "flex items-center justify-end",
+                if !is_selection_mode {
+                    DotsMenu {
+                        actions,
+                        is_open: is_menu_open,
+                        on_open: move |_| on_click_menu.call(()),
+                        on_close: move |_| on_close_menu.call(()),
+                        button_class: "opacity-0 group-hover:opacity-100 focus:opacity-100".to_string(),
+                        anchor: "right".to_string(),
+                        on_action: move |idx: usize| {
+                            if let Some(queue_idx) = add_to_queue_idx {
+                                if idx == queue_idx {
+                                    if let Some(handler) = on_queue {
+                                        handler.call(());
+                                    }
+                                    return;
+                                }
+                            }
+
+                            if idx == add_to_playlist_idx {
+                                on_add_to_playlist.call(());
+                            } else if remove_action_idx == Some(idx) {
+                                if let Some(handler) = on_remove_from_playlist {
                                     handler.call(());
                                 }
-                                return;
+                            } else if has_download && idx == download_action_idx {
+                                if let Some(handler) = on_download {
+                                    handler.call(());
+                                }
+                            } else if idx == delete_action_idx {
+                                on_delete.call(());
                             }
-                        }
-
-                        if idx == add_to_playlist_idx {
-                            on_add_to_playlist.call(());
-                        } else if remove_action_idx == Some(idx) {
-                            if let Some(handler) = on_remove_from_playlist {
-                                handler.call(());
-                            }
-                        } else if has_download && idx == download_action_idx {
-                            if let Some(handler) = on_download {
-                                handler.call(());
-                            }
-                        } else if idx == delete_action_idx {
-                            on_delete.call(());
-                        }
-                    },
+                        },
+                    }
                 }
             }
         }
-    }
+    };
 }

--- a/components/src/track_row.rs
+++ b/components/src/track_row.rs
@@ -414,7 +414,19 @@ pub fn TrackRow(
             }
 
             div { class: "min-w-0 pr-4",
-                p { class: "text-sm text-slate-500 truncate", "{track.album}" }
+                p {
+                    class: "text-sm text-slate-500 truncate cursor-pointer hover:underline hover:text-slate-400 transition-colors",
+                    onclick: {
+                        let album_id = track.album_id.clone();
+                        move |evt: MouseEvent| {
+                            evt.stop_propagation();
+                            if !is_selection_mode {
+                                nav_ctrl.navigate_to_album(album_id.clone());
+                            }
+                        }
+                    },
+                    "{track.album}"
+                }
             }
 
             div { class: "flex items-center justify-end",

--- a/components/src/track_row.rs
+++ b/components/src/track_row.rs
@@ -399,7 +399,7 @@ pub fn TrackRow(
                     style: if is_currently_playing {
                         "color: var(--color-indigo-500);"
                     } else {
-                        "opacity: 0.9;"
+                        "color: rgba(255,255,255,0.9);"
                     },
                     onclick: {
                         let album_id = track.album_id.clone();

--- a/components/src/track_row.rs
+++ b/components/src/track_row.rs
@@ -42,6 +42,12 @@ pub fn TrackRow(
     let config = use_context::<Signal<AppConfig>>();
     let nav_ctrl = use_context::<NavigationController>();
     let is_modern = config.read().ui_style == UiStyle::Modern;
+    let show_selection_highlight = is_selection_mode && is_selected;
+    let selection_shadow = if show_selection_highlight {
+        "inset 0 0 0 9999px rgba(255,255,255,0.07)"
+    } else {
+        "none"
+    };
     let add_to_queue_text = i18n::t("add_to_queue").to_string();
     let add_to_playlist_text = i18n::t("add_to_playlist").to_string();
     let remove_from_playlist_text = i18n::t("remove_from_playlist").to_string();
@@ -141,11 +147,9 @@ pub fn TrackRow(
             div {
                 class: "grid px-2 py-1.5 rounded-lg mx-1 group cursor-default transition-colors hover:bg-white/5 select-none",
                 style: if is_currently_playing {
-                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent);"
-                } else if is_selected {
-                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: rgba(255,255,255,0.07);"
+                    format!("grid-template-columns: 40px 1fr 180px 180px 56px 40px; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent); box-shadow: {selection_shadow};")
                 } else {
-                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px;"
+                    format!("grid-template-columns: 40px 1fr 180px 180px 56px 40px; box-shadow: {selection_shadow};")
                 },
                 onclick: move |evt| {
                     evt.stop_propagation();
@@ -323,11 +327,9 @@ pub fn TrackRow(
         div {
             class: "grid items-center p-2 rounded-lg hover:bg-white/5 group transition-colors relative select-none",
             style: if is_currently_playing {
-                "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; column-gap: 1.5rem; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent);"
-            } else if is_selected {
-                "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; column-gap: 1.5rem; background: rgba(255,255,255,0.07);"
+                format!("grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; column-gap: 1.5rem; background: color-mix(in oklab, var(--color-indigo-500) 12%, transparent); box-shadow: {selection_shadow};")
             } else {
-                "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; column-gap: 1.5rem;"
+                format!("grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; column-gap: 1.5rem; box-shadow: {selection_shadow};")
             },
             onclick: move |evt| {
                 evt.stop_propagation();

--- a/pages/src/local/favorites.rs
+++ b/pages/src/local/favorites.rs
@@ -25,7 +25,7 @@ pub fn LocalFavorites(
     // Multi-selection state
     let mut is_selection_mode = use_signal(|| false);
     let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
-    let mut sort_state = use_signal(|| None);
+    let sort_state = use_signal(|| None);
 
     let displayed_tracks: Vec<(reader::models::Track, Option<utils::CoverUrl>)> = {
         let store = favorites_store.read();
@@ -52,14 +52,8 @@ pub fn LocalFavorites(
             .collect()
     };
 
-    let tracks_for_sorting: Vec<reader::models::Track> =
-        displayed_tracks.iter().map(|(t, _)| t.clone()).collect();
-    let sorted_indices = showcase::sorted_track_indices(&tracks_for_sorting, *sort_state.read());
-    let sorted_displayed_tracks: Vec<(reader::models::Track, Option<utils::CoverUrl>)> =
-        sorted_indices
-            .iter()
-            .map(|&idx| displayed_tracks[idx].clone())
-            .collect();
+    let sorted_displayed_tracks =
+        showcase::sorted_track_pairs(&displayed_tracks, *sort_state.read());
 
     let queue_tracks: Vec<reader::models::Track> = sorted_displayed_tracks
         .iter()
@@ -71,7 +65,10 @@ pub fn LocalFavorites(
         let queue = ctrl.queue.read();
         let q_idx = *ctrl.current_queue_index.read();
         if queue.len() == queue_tracks.len()
-            && queue.iter().zip(queue_tracks.iter()).all(|(q, t)| q.path == t.path)
+            && queue
+                .iter()
+                .zip(queue_tracks.iter())
+                .all(|(q, t)| q.path == t.path)
         {
             Some(q_idx)
         } else {
@@ -303,37 +300,25 @@ pub fn LocalFavorites(
                     div {}
                     button {
                         class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                        onclick: move |_| {
-                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
-                            sort_state.set(next);
-                        },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Title),
                         "{i18n::t(\"title\")}"
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
                     }
                     button {
                         class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                        onclick: move |_| {
-                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
-                            sort_state.set(next);
-                        },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Artist),
                         "{i18n::t(\"artist\")}"
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
                     }
                     button {
                         class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                        onclick: move |_| {
-                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
-                            sort_state.set(next);
-                        },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Album),
                         "{i18n::t(\"album\")}"
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
                     }
                     button {
                         class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
-                        onclick: move |_| {
-                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
-                            sort_state.set(next);
-                        },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Duration),
                         i { class: "fa-regular fa-clock" }
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
                     }

--- a/pages/src/local/favorites.rs
+++ b/pages/src/local/favorites.rs
@@ -61,19 +61,15 @@ pub fn LocalFavorites(
         .collect();
     let queue_tracks_for_selection = queue_tracks.clone();
 
-    let currently_playing_idx: Option<usize> = {
+    let currently_playing_path = {
         let queue = ctrl.queue.read();
-        let q_idx = *ctrl.current_queue_index.read();
-        if queue.len() == queue_tracks.len()
-            && queue
-                .iter()
-                .zip(queue_tracks.iter())
-                .all(|(q, t)| q.path == t.path)
-        {
-            Some(q_idx)
+        let idx = *ctrl.current_queue_index.read();
+        let queue_idx = if *ctrl.shuffle.read() {
+            ctrl.shuffle_order.read().get(idx).copied().unwrap_or(idx)
         } else {
-            None
-        }
+            idx
+        };
+        queue.get(queue_idx).map(|track| track.path.clone())
     };
 
     let is_empty = displayed_tracks.is_empty();
@@ -95,7 +91,7 @@ pub fn LocalFavorites(
                 let track_key = format!("{}-{}", track.path.display(), idx);
                 let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
                 let is_selected = selected_tracks.read().contains(&track_path);
-                let is_currently_playing = currently_playing_idx == Some(idx);
+                let matches_current_path = currently_playing_path.as_ref() == Some(&track.path);
 
                 rsx! {
                     div {
@@ -106,7 +102,7 @@ pub fn LocalFavorites(
                             cover_url: cover_url.clone(),
                             row_num: Some(idx + 1),
                         is_menu_open,
-                        is_currently_playing,
+                        is_currently_playing: matches_current_path,
                         is_selection_mode: is_selection_mode(),
                         is_selected,
                         on_long_press: move |_| {

--- a/pages/src/local/favorites.rs
+++ b/pages/src/local/favorites.rs
@@ -1,5 +1,6 @@
 use components::playlist_modal::PlaylistModal;
 use components::selection_bar::SelectionBar;
+use components::showcase::{self, SortField};
 use components::track_row::TrackRow;
 use config::{AppConfig, UiStyle};
 use dioxus::prelude::*;
@@ -24,6 +25,7 @@ pub fn LocalFavorites(
     // Multi-selection state
     let mut is_selection_mode = use_signal(|| false);
     let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
+    let mut sort_state = use_signal(|| None);
 
     let displayed_tracks: Vec<(reader::models::Track, Option<utils::CoverUrl>)> = {
         let store = favorites_store.read();
@@ -50,8 +52,19 @@ pub fn LocalFavorites(
             .collect()
     };
 
-    let queue_tracks: Vec<reader::models::Track> =
+    let tracks_for_sorting: Vec<reader::models::Track> =
         displayed_tracks.iter().map(|(t, _)| t.clone()).collect();
+    let sorted_indices = showcase::sorted_track_indices(&tracks_for_sorting, *sort_state.read());
+    let sorted_displayed_tracks: Vec<(reader::models::Track, Option<utils::CoverUrl>)> =
+        sorted_indices
+            .iter()
+            .map(|&idx| displayed_tracks[idx].clone())
+            .collect();
+
+    let queue_tracks: Vec<reader::models::Track> = sorted_displayed_tracks
+        .iter()
+        .map(|(t, _)| t.clone())
+        .collect();
     let queue_tracks_for_selection = queue_tracks.clone();
 
     let currently_playing_idx: Option<usize> = {
@@ -70,7 +83,7 @@ pub fn LocalFavorites(
     let is_modern = config.read().ui_style == UiStyle::Modern;
 
     let tracks_nodes =
-        displayed_tracks
+        sorted_displayed_tracks
             .iter()
             .cloned()
             .enumerate()
@@ -288,10 +301,42 @@ pub fn LocalFavorites(
                         "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;"
                     },
                     div {}
-                    div { "{i18n::t(\"title\")}" }
-                    div { "{i18n::t(\"artist\")}" }
-                    div { "{i18n::t(\"album\")}" }
-                    div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
+                    button {
+                        class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                        onclick: move |_| {
+                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
+                            sort_state.set(next);
+                        },
+                        "{i18n::t(\"title\")}"
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
+                    }
+                    button {
+                        class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                        onclick: move |_| {
+                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
+                            sort_state.set(next);
+                        },
+                        "{i18n::t(\"artist\")}"
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
+                    }
+                    button {
+                        class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                        onclick: move |_| {
+                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
+                            sort_state.set(next);
+                        },
+                        "{i18n::t(\"album\")}"
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
+                    }
+                    button {
+                        class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
+                        onclick: move |_| {
+                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
+                            sort_state.set(next);
+                        },
+                        i { class: "fa-regular fa-clock" }
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
+                    }
                     div {}
                 }
                 div {

--- a/pages/src/local/favorites.rs
+++ b/pages/src/local/favorites.rs
@@ -276,16 +276,23 @@ pub fn LocalFavorites(
                     }
                     span { "{i18n::t(\"select_all\")}" }
                 }
-                if is_modern {
-                    div {
-                        class: "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1",
-                        style: "grid-template-columns: 40px 1fr 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);",
-                        div {}
-                        div { "{i18n::t(\"title\")}" }
-                        div { "{i18n::t(\"artist\")}" }
-                        div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
-                        div {}
-                    }
+                div {
+                    class: if is_modern {
+                        "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1"
+                    } else {
+                        "grid gap-6 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 mb-2 uppercase tracking-wider"
+                    },
+                    style: if is_modern {
+                        "grid-template-columns: 40px 1fr 180px 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);"
+                    } else {
+                        "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;"
+                    },
+                    div {}
+                    div { "{i18n::t(\"title\")}" }
+                    div { "{i18n::t(\"artist\")}" }
+                    div { "{i18n::t(\"album\")}" }
+                    div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
+                    div {}
                 }
                 div {
                     class: if is_modern { "" } else { "space-y-1" },

--- a/pages/src/local/library.rs
+++ b/pages/src/local/library.rs
@@ -393,16 +393,23 @@ div {
                 }
             }
 
-            if is_modern {
-                div {
-                    class: "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1",
-                    style: "grid-template-columns: 40px 1fr 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);",
-                    div {}
-                    div { "{i18n::t(\"title\")}" }
-                    div { "{i18n::t(\"artist\")}" }
-                    div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
-                    div {}
-                }
+            div {
+                class: if is_modern {
+                    "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1"
+                } else {
+                    "grid gap-6 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 mb-2 uppercase tracking-wider"
+                },
+                style: if is_modern {
+                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);"
+                } else {
+                    "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;"
+                },
+                div {}
+                div { "{i18n::t(\"title\")}" }
+                div { "{i18n::t(\"artist\")}" }
+                div { "{i18n::t(\"album\")}" }
+                div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
+                div {}
             }
 
             div {

--- a/pages/src/server/favorites.rs
+++ b/pages/src/server/favorites.rs
@@ -28,7 +28,7 @@ pub fn JellyfinFavorites(
     // Multi-selection state
     let mut is_selection_mode = use_signal(|| false);
     let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
-    let mut sort_state = use_signal(|| None);
+    let sort_state = use_signal(|| None);
     let mut show_playlist_modal = use_signal(|| false);
     let mut selected_track_for_playlist = use_signal(|| None::<PathBuf>);
     let download_queue = use_context::<Signal<DownloadQueue>>();
@@ -126,14 +126,8 @@ pub fn JellyfinFavorites(
             .collect()
     };
 
-    let tracks_for_sorting: Vec<reader::models::Track> =
-        displayed_tracks.iter().map(|(t, _)| t.clone()).collect();
-    let sorted_indices = showcase::sorted_track_indices(&tracks_for_sorting, *sort_state.read());
-    let sorted_displayed_tracks: Vec<(reader::models::Track, Option<utils::CoverUrl>)> =
-        sorted_indices
-            .iter()
-            .map(|&idx| displayed_tracks[idx].clone())
-            .collect();
+    let sorted_displayed_tracks =
+        showcase::sorted_track_pairs(&displayed_tracks, *sort_state.read());
 
     let queue_tracks: Vec<reader::models::Track> = sorted_displayed_tracks
         .iter()
@@ -457,37 +451,25 @@ pub fn JellyfinFavorites(
                     div {}
                     button {
                         class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                        onclick: move |_| {
-                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
-                            sort_state.set(next);
-                        },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Title),
                         "{i18n::t(\"title\")}"
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
                     }
                     button {
                         class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                        onclick: move |_| {
-                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
-                            sort_state.set(next);
-                        },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Artist),
                         "{i18n::t(\"artist\")}"
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
                     }
                     button {
                         class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
-                        onclick: move |_| {
-                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
-                            sort_state.set(next);
-                        },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Album),
                         "{i18n::t(\"album\")}"
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
                     }
                     button {
                         class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
-                        onclick: move |_| {
-                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
-                            sort_state.set(next);
-                        },
+                        onclick: move |_| showcase::toggle_sort_state(sort_state, SortField::Duration),
                         i { class: "fa-regular fa-clock" }
                         i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
                     }

--- a/pages/src/server/favorites.rs
+++ b/pages/src/server/favorites.rs
@@ -427,16 +427,23 @@ pub fn JellyfinFavorites(
                     }
                     span { "{i18n::t(\"select_all\")}" }
                 }
-                if is_modern {
-                    div {
-                        class: "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1",
-                        style: "grid-template-columns: 40px 1fr 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);",
-                        div {}
-                        div { "{i18n::t(\"title\")}" }
-                        div { "{i18n::t(\"artist\")}" }
-                        div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
-                        div {}
-                    }
+                div {
+                    class: if is_modern {
+                        "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1"
+                    } else {
+                        "grid gap-6 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 mb-2 uppercase tracking-wider"
+                    },
+                    style: if is_modern {
+                        "grid-template-columns: 40px 1fr 180px 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);"
+                    } else {
+                        "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;"
+                    },
+                    div {}
+                    div { "{i18n::t(\"title\")}" }
+                    div { "{i18n::t(\"artist\")}" }
+                    div { "{i18n::t(\"album\")}" }
+                    div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
+                    div {}
                 }
                 div {
                     class: if is_modern { "" } else { "space-y-1" },

--- a/pages/src/server/favorites.rs
+++ b/pages/src/server/favorites.rs
@@ -3,6 +3,7 @@ use ::server::jellyfin::JellyfinClient;
 use ::server::subsonic::SubsonicClient;
 use components::playlist_modal::PlaylistModal;
 use components::selection_bar::SelectionBar;
+use components::showcase::{self, SortField};
 use components::track_row::TrackRow;
 use config::{AppConfig, MusicService, UiStyle};
 use dioxus::prelude::*;
@@ -27,6 +28,7 @@ pub fn JellyfinFavorites(
     // Multi-selection state
     let mut is_selection_mode = use_signal(|| false);
     let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
+    let mut sort_state = use_signal(|| None);
     let mut show_playlist_modal = use_signal(|| false);
     let mut selected_track_for_playlist = use_signal(|| None::<PathBuf>);
     let download_queue = use_context::<Signal<DownloadQueue>>();
@@ -124,14 +126,28 @@ pub fn JellyfinFavorites(
             .collect()
     };
 
-    let queue_tracks: Vec<reader::models::Track> =
+    let tracks_for_sorting: Vec<reader::models::Track> =
         displayed_tracks.iter().map(|(t, _)| t.clone()).collect();
+    let sorted_indices = showcase::sorted_track_indices(&tracks_for_sorting, *sort_state.read());
+    let sorted_displayed_tracks: Vec<(reader::models::Track, Option<utils::CoverUrl>)> =
+        sorted_indices
+            .iter()
+            .map(|&idx| displayed_tracks[idx].clone())
+            .collect();
+
+    let queue_tracks: Vec<reader::models::Track> = sorted_displayed_tracks
+        .iter()
+        .map(|(t, _)| t.clone())
+        .collect();
 
     let currently_playing_idx: Option<usize> = {
         let queue = ctrl.queue.read();
         let q_idx = *ctrl.current_queue_index.read();
         if queue.len() == queue_tracks.len()
-            && queue.iter().zip(queue_tracks.iter()).all(|(q, t)| q.path == t.path)
+            && queue
+                .iter()
+                .zip(queue_tracks.iter())
+                .all(|(q, t)| q.path == t.path)
         {
             Some(q_idx)
         } else {
@@ -139,11 +155,11 @@ pub fn JellyfinFavorites(
         }
     };
 
-    let displayed_tracks_for_selection = displayed_tracks.clone();
+    let displayed_tracks_for_selection = sorted_displayed_tracks.clone();
     let is_empty = displayed_tracks.is_empty();
     let is_modern = config.read().ui_style == UiStyle::Modern;
 
-    let tracks_nodes = displayed_tracks
+    let tracks_nodes = sorted_displayed_tracks
         .iter()
         .cloned()
         .enumerate()
@@ -439,10 +455,42 @@ pub fn JellyfinFavorites(
                         "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;"
                     },
                     div {}
-                    div { "{i18n::t(\"title\")}" }
-                    div { "{i18n::t(\"artist\")}" }
-                    div { "{i18n::t(\"album\")}" }
-                    div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
+                    button {
+                        class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                        onclick: move |_| {
+                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Title);
+                            sort_state.set(next);
+                        },
+                        "{i18n::t(\"title\")}"
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Title)} text-[10px]" }
+                    }
+                    button {
+                        class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                        onclick: move |_| {
+                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Artist);
+                            sort_state.set(next);
+                        },
+                        "{i18n::t(\"artist\")}"
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Artist)} text-[10px]" }
+                    }
+                    button {
+                        class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
+                        onclick: move |_| {
+                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Album);
+                            sort_state.set(next);
+                        },
+                        "{i18n::t(\"album\")}"
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Album)} text-[10px]" }
+                    }
+                    button {
+                        class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
+                        onclick: move |_| {
+                            let next = showcase::next_sort_state(*sort_state.peek(), SortField::Duration);
+                            sort_state.set(next);
+                        },
+                        i { class: "fa-regular fa-clock" }
+                        i { class: "{showcase::sort_icon(*sort_state.read(), SortField::Duration)} text-[10px]" }
+                    }
                     div {}
                 }
                 div {

--- a/pages/src/server/favorites.rs
+++ b/pages/src/server/favorites.rs
@@ -134,19 +134,15 @@ pub fn JellyfinFavorites(
         .map(|(t, _)| t.clone())
         .collect();
 
-    let currently_playing_idx: Option<usize> = {
+    let currently_playing_path = {
         let queue = ctrl.queue.read();
-        let q_idx = *ctrl.current_queue_index.read();
-        if queue.len() == queue_tracks.len()
-            && queue
-                .iter()
-                .zip(queue_tracks.iter())
-                .all(|(q, t)| q.path == t.path)
-        {
-            Some(q_idx)
+        let idx = *ctrl.current_queue_index.read();
+        let queue_idx = if *ctrl.shuffle.read() {
+            ctrl.shuffle_order.read().get(idx).copied().unwrap_or(idx)
         } else {
-            None
-        }
+            idx
+        };
+        queue.get(queue_idx).map(|track| track.path.clone())
     };
 
     let displayed_tracks_for_selection = sorted_displayed_tracks.clone();
@@ -167,7 +163,7 @@ pub fn JellyfinFavorites(
             let track_key = format!("{}-{}", track.path.display(), idx);
             let is_menu_open = active_menu_track.read().as_ref() == Some(&track.path);
             let is_selected = selected_tracks.read().contains(&track_path);
-            let is_currently_playing = currently_playing_idx == Some(idx);
+            let matches_current_path = currently_playing_path.as_ref() == Some(&track.path);
 
             let path_str = track.path.to_string_lossy().to_string();
             let item_id: String = path_str.split(':').nth(1).unwrap_or("").to_string();
@@ -188,7 +184,7 @@ pub fn JellyfinFavorites(
                     cover_url: cover_url.clone(),
                     row_num: Some(idx + 1),
                     is_menu_open,
-                    is_currently_playing,
+                    is_currently_playing: matches_current_path,
                     is_selection_mode: is_selection_mode(),
                     is_selected,
                     is_downloaded,

--- a/pages/src/server/library.rs
+++ b/pages/src/server/library.rs
@@ -567,16 +567,23 @@ pub fn JellyfinLibrary(
                 }
             }
 
-            if is_modern {
-                div {
-                    class: "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1",
-                    style: "grid-template-columns: 40px 1fr 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);",
-                    div {}
-                    div { "{i18n::t(\"title\")}" }
-                    div { "{i18n::t(\"artist\")}" }
-                    div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
-                    div {}
-                }
+            div {
+                class: if is_modern {
+                    "grid px-3 py-2 text-[10px] font-bold uppercase tracking-widest border-b mb-1"
+                } else {
+                    "grid gap-6 px-2 py-2 border-b border-white/5 text-sm font-medium text-slate-500 mb-2 uppercase tracking-wider"
+                },
+                style: if is_modern {
+                    "grid-template-columns: 40px 1fr 180px 180px 56px 40px; color: rgba(255,255,255,0.25); border-color: rgba(255,255,255,0.06);"
+                } else {
+                    "grid-template-columns: 40px minmax(0, 1fr) 200px 200px 64px 40px; align-items: center;"
+                },
+                div {}
+                div { "{i18n::t(\"title\")}" }
+                div { "{i18n::t(\"artist\")}" }
+                div { "{i18n::t(\"album\")}" }
+                div { class: "text-right pr-2", i { class: "fa-regular fa-clock" } }
+                div {}
             }
 
             div {


### PR DESCRIPTION
I added sorting for tracks by Title, Album, Artist, Duration for both normal and vaxry UI

Demo: 

<img width="1644" height="762" alt="image" src="https://github.com/user-attachments/assets/64fb5b14-3e2c-4f63-9864-d4853a69930b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client-side sortable track lists with clickable column headers and active sort icons; visible ordering now drives Play / Play All / Shuffle / queue actions across showcases, search, library, and favorites.

* **Style**
  * Updated track-row grid layouts for modern and normal views.
  * Secondary line now shows album; artist and album cells are clickable.
  * Refreshed row controls (play/volume indicator, numbering, cover/download overlay, menu).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->