### PR TITLE
fix: add GSETTINGS_SCHEMA_DIR to devshell for nixos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
             shellHook = ''
               export RUSTFLAGS="-C link-arg=-fuse-ld=lld"
               export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules/"
+              export GSETTINGS_SCHEMA_DIR=${pkgs.glib.getSchemaPath pkgs.gtk3}
               export LD_LIBRARY_PATH="${pkgs.lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH"
               export WEBKIT_DISABLE_COMPOSITING_MODE="1"
             '';


### PR DESCRIPTION
glib can't find the schema directory on nixos so it results in a messed up ui
<img width="1920" height="1080" alt="20260517_17h22m08s_grim" src="https://github.com/user-attachments/assets/b40fd11f-a0d7-4c4b-bad4-4a16c2a94d8e" />
with it logging 
`(kopuz): GLib-GIO-CRITICAL: g_settings_schema_source_lookup: assertion 'source != NULL' failed`
fixed it by adding GSETTINGS_SCHEMA_DIR to the devshell pointing to the correct directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to improve local setup compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->