### PR TITLE
ci: add PR-only Nix checks and Rust i18n key validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,11 @@ jobs:
       - name: Check locale parity against en.ftl
         run: nix shell nixpkgs#nushell --command nu scripts/check_locales.nu
 
-  build:
+      - name: Check Rust i18n usage against en.ftl
+        run: nix shell nixpkgs#nushell --command nu scripts/check_i18n_usage.nu
+
+  pr-build:
+    if: github.event_name == 'pull_request'
     strategy:
       matrix:
         include:
@@ -36,3 +40,44 @@ jobs:
 
       - name: Run Nix checks
         run: nix build .#checks.${{ matrix.system }}.default
+
+  push-build:
+    if: github.event_name == 'push'
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            system: x86_64-linux
+          - os: macos-latest
+            system: aarch64-darwin
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: cachix/cachix-action@v14
+        with:
+          name: kopuz
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build Nix package
+        run: nix build .#packages.${{ matrix.system }}.default
+
+      - name: Push result to Cachix
+        run: cachix push kopuz result
+
+  windows-build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build Windows app
+        run: cargo build -p kopuz --locked

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,5 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@main
 
-      - uses: cachix/cachix-action@v14
-        with:
-          name: kopuz
-          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-
-      - name: Build package
-        run: |
-          nix build .#packages.${{ matrix.system }}.default
-          cachix push kopuz result
+      - name: Run Nix checks
+        run: nix build .#checks.${{ matrix.system }}.default

--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,10 @@
         }
       );
 
+      checks = forAllSystems (system: {
+        default = self.packages.${system}.default;
+      });
+
       apps = forAllSystems (system: {
         default = {
           type = "app";

--- a/locales/ar.ftl
+++ b/locales/ar.ftl
@@ -332,6 +332,7 @@ crossfade = تلاشي متقاطع
 crossfade_off = إيقاف
 
 continue_listening = متابعة الاستماع
+music = موسيقى
 made_for_you = صُنع من أجلك
 recently_added = أُضيف مؤخراً
 customize_home = تخصيص الرئيسية

--- a/locales/de.ftl
+++ b/locales/de.ftl
@@ -326,6 +326,7 @@ crossfade = Überblendung
 crossfade_off = Aus
 
 continue_listening = Weiterhören
+music = Musik
 made_for_you = Für dich gemacht
 recently_added = Kürzlich hinzugefügt
 customize_home = Startseite anpassen

--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -243,6 +243,7 @@ folder_playlists = Folder Playlists
 folder_playlist = Folder
 featured_album = Featured Album
 continue_listening = Continue Listening
+music = Music
 made_for_you = Made For You
 recently_added = Recently Added
 customize_home = Customize Home

--- a/locales/es.ftl
+++ b/locales/es.ftl
@@ -327,6 +327,7 @@ crossfade = Fundido cruzado
 crossfade_off = Apagado
 
 continue_listening = Seguir escuchando
+music = Música
 made_for_you = Hecho para ti
 recently_added = Añadido recientemente
 customize_home = Personalizar inicio

--- a/locales/fr.ftl
+++ b/locales/fr.ftl
@@ -327,6 +327,7 @@ crossfade = Fondu enchaîné
 crossfade_off = Désactivé
 
 continue_listening = Continuer l'écoute
+music = Musique
 made_for_you = Fait pour vous
 recently_added = Ajouté récemment
 customize_home = Personnaliser l'accueil

--- a/locales/gr.ftl
+++ b/locales/gr.ftl
@@ -326,6 +326,7 @@ crossfade = Crossfade (Σταδιακή μίξη)
 crossfade_off = Ανενεργό
 
 continue_listening = Συνέχιση ακρόασης
+music = Μουσική
 made_for_you = Φτιαγμένο για σένα
 recently_added = Προστέθηκαν πρόσφατα
 customize_home = Προσαρμογή αρχικής

--- a/locales/he.ftl
+++ b/locales/he.ftl
@@ -326,6 +326,7 @@ crossfade = מעבר הדרגתי
 crossfade_off = כבוי
 
 continue_listening = המשך האזנה
+music = מוזיקה
 made_for_you = נוצר עבורך
 recently_added = נוסף לאחרונה
 customize_home = התאמת הבית

--- a/locales/hu.ftl
+++ b/locales/hu.ftl
@@ -326,6 +326,7 @@ crossfade = Áttűnés
 crossfade_off = Ki
 
 continue_listening = Hallgatás folytatása
+music = Zene
 made_for_you = Neked készült
 recently_added = Nemrég hozzáadott
 customize_home = Kezdőlap testreszabása

--- a/locales/id.ftl
+++ b/locales/id.ftl
@@ -325,6 +325,7 @@ crossfade = Crossfade
 crossfade_off = Mati
 
 continue_listening = Lanjutkan mendengarkan
+music = Musik
 made_for_you = Dibuat untukmu
 recently_added = Baru ditambahkan
 customize_home = Sesuaikan beranda

--- a/locales/ja.ftl
+++ b/locales/ja.ftl
@@ -332,6 +332,7 @@ crossfade = クロスフェード
 crossfade_off = オフ
 
 continue_listening = 続きを聴く
+music = 音楽
 made_for_you = あなたのために
 recently_added = 最近追加
 customize_home = ホームをカスタマイズ

--- a/locales/ko.ftl
+++ b/locales/ko.ftl
@@ -326,6 +326,7 @@ crossfade = 크로스페이드
 crossfade_off = 끄기
 
 continue_listening = 계속 듣기
+music = 음악
 made_for_you = 당신을 위해
 recently_added = 최근 추가됨
 customize_home = 홈 맞춤설정

--- a/locales/pl.ftl
+++ b/locales/pl.ftl
@@ -326,6 +326,7 @@ crossfade = Płynne przejście
 crossfade_off = Wył.
 
 continue_listening = Słuchaj dalej
+music = Muzyka
 made_for_you = Stworzone dla Ciebie
 recently_added = Ostatnio dodane
 customize_home = Dostosuj stronę główną

--- a/locales/pt-BR.ftl
+++ b/locales/pt-BR.ftl
@@ -325,6 +325,7 @@ crossfade = Transição Contínua
 crossfade_off = Desligado
 
 continue_listening = Continuar ouvindo
+music = Música
 made_for_you = Feito para você
 recently_added = Adicionado recentemente
 customize_home = Personalizar início

--- a/locales/ro.ftl
+++ b/locales/ro.ftl
@@ -326,6 +326,7 @@ crossfade = Întrepătrundere
 crossfade_off = Oprit
 
 continue_listening = Continuă ascultarea
+music = Muzică
 made_for_you = Făcut pentru tine
 recently_added = Adăugate recent
 customize_home = Personalizează pagina principală

--- a/locales/ru.ftl
+++ b/locales/ru.ftl
@@ -326,6 +326,7 @@ crossfade = Кроссфейд
 crossfade_off = Выкл
 
 continue_listening = Продолжить прослушивание
+music = Музыка
 made_for_you = Подобрано для вас
 recently_added = Недавно добавленные
 customize_home = Настроить главную

--- a/locales/tok-SP.ftl
+++ b/locales/tok-SP.ftl
@@ -327,6 +327,7 @@ crossfade = 󱥭 󱤴
 crossfade_off = 󱤄
 
 continue_listening = Continue Listening
+music = 󱤕󱤻
 made_for_you = Made For You
 recently_added = Recently Added
 customize_home = Customize Home

--- a/locales/tok.ftl
+++ b/locales/tok.ftl
@@ -326,6 +326,7 @@ crossfade = ante kalama
 crossfade_off = ala
 
 continue_listening = o kute sin
+music = kalama musi
 made_for_you = pali tawa sina
 recently_added = kalama sin pi tenpo poka
 customize_home = o ante e tomo

--- a/locales/tr.ftl
+++ b/locales/tr.ftl
@@ -326,6 +326,7 @@ crossfade = Çapraz Geçiş
 crossfade_off = Kapalı
 
 continue_listening = Dinlemeye devam et
+music = Müzik
 made_for_you = Sana özel
 recently_added = Son eklenenler
 customize_home = Ana sayfayı özelleştir

--- a/locales/uk.ftl
+++ b/locales/uk.ftl
@@ -326,6 +326,7 @@ crossfade = Кросфейд
 crossfade_off = Вимкнено
 
 continue_listening = Продовжити слухати
+music = Музика
 made_for_you = Створено для вас
 recently_added = Нещодавно додано
 customize_home = Налаштувати головну

--- a/locales/zh-CN.ftl
+++ b/locales/zh-CN.ftl
@@ -326,6 +326,7 @@ crossfade = 交叉淡入淡出
 crossfade_off = 关闭
 
 continue_listening = 继续收听
+music = 音乐
 made_for_you = 为你定制
 recently_added = 最近添加
 customize_home = 自定义主页

--- a/scripts/check_i18n_usage.nu
+++ b/scripts/check_i18n_usage.nu
@@ -10,12 +10,27 @@ def extract-locale-keys [path: path] {
 }
 
 def extract-rust-i18n-usages [repo_root: path] {
-  let pattern = 'i18n::t\("([^"]+)"\)'
+  glob ($repo_root | path join "**" "*.rs")
+  | each {|file|
+      open $file
+      | lines
+      | enumerate
+      | each {|row|
+          let line = ($row.index + 1)
+          let fragments = ($row.item | split row 'i18n::t("' | skip 1)
 
-  ^rg --no-heading --line-number --color never -g '*.rs' $pattern $repo_root
-  | lines
-  | parse -r '^(?<path>.*?):(?<line>\d+):(?<text>.*i18n::t\("(?<key>[^"]+)"\).*)$'
-  | update line {|row| $row.line | into int }
+          $fragments
+          | each {|fragment|
+              {
+                path: ($file | into string)
+                line: $line
+                key: ($fragment | split row '"' | first)
+              }
+            }
+        }
+    }
+  | flatten
+  | flatten
 }
 
 def main [] {

--- a/scripts/check_i18n_usage.nu
+++ b/scripts/check_i18n_usage.nu
@@ -1,0 +1,49 @@
+#!/usr/bin/env nu
+
+def extract-locale-keys [path: path] {
+  open $path
+  | lines
+  | parse -r '^(?<key>[A-Za-z0-9_-]+)\s*='
+  | get key
+  | uniq
+  | sort
+}
+
+def extract-rust-i18n-usages [repo_root: path] {
+  let pattern = 'i18n::t\("([^"]+)"\)'
+
+  ^rg --no-heading --line-number --color never -g '*.rs' $pattern $repo_root
+  | lines
+  | parse -r '^(?<path>.*?):(?<line>\d+):(?<text>.*i18n::t\("(?<key>[^"]+)"\).*)$'
+  | update line {|row| $row.line | into int }
+}
+
+def main [] {
+  let script_dir = $env.FILE_PWD
+  let repo_root = ($script_dir | path dirname)
+  let baseline = ($repo_root | path join "locales" "en.ftl")
+
+  if not ($baseline | path exists) {
+    print --stderr "Missing baseline locale: locales/en.ftl"
+    exit 1
+  }
+
+  let locale_keys = (extract-locale-keys $baseline)
+  let usages = (extract-rust-i18n-usages $repo_root)
+  let missing = (
+    $usages
+    | where {|usage| $usage.key not-in $locale_keys }
+    | sort-by key path line
+  )
+
+  if not ($missing | is-empty) {
+    print --stderr "Missing en.ftl keys for Rust i18n::t(...) usages:"
+    $missing
+    | each {|usage|
+        print --stderr $"  ($usage.key) -> ($usage.path):($usage.line)"
+      }
+    exit 1
+  }
+
+  print "All Rust i18n::t(...) keys exist in locales/en.ftl."
+}


### PR DESCRIPTION
This pull request introduces several improvements to the build system and internationalization support. The main changes are the addition of a new `music` translation key across all supported locales, enhancements to the GitHub Actions workflow for better CI/CD handling (including split jobs for pull requests, pushes, and Windows builds), and the introduction of a Nix `checks` attribute for improved package validation.

**CI/CD Workflow Improvements:**

* Updated `.github/workflows/build.yml` to:
  - Add a job to check Rust i18n usage against `en.ftl` for better translation coverage.
  - Split build jobs into `pr-build` (for pull requests), `push-build` (for pushes), and a new `windows-build` job for Windows compatibility. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L21-R45) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L42-R83)
  - Separate Nix package build and Cachix push steps for clarity and reliability.

**Nix Integration:**

* Added a `checks` attribute to `flake.nix` for system-specific package validation, integrating with the new workflow checks.This pull request introduces improvements to the build workflow and enhances localization support across multiple languages. The main changes include adding a new `music` translation key to all supported locales, updating the Nix build configuration to include checks, and restructuring the GitHub Actions workflow for better CI/CD coverage.

**Build Workflow Improvements:**
* Refactored `.github/workflows/build.yml` to split build jobs by event type (`pull_request`, `push`) and platform, added a Windows build, and separated the Cachix push step for clarity and reliability. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L21-R45) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L42-R83)
* Introduced a new step to check Rust i18n usage against the English locale file to ensure all strings are properly internationalized.

**Nix Configuration:**
* Added a `checks` attribute in `flake.nix` to expose package checks for all supported systems, integrating better with the new workflow.This pull request updates the Nix build workflow to streamline the CI process and introduces a new `checks` attribute in `flake.nix`. The main changes involve removing the Cachix cache push step and building the new `checks` output instead of the package directly.

**CI workflow improvements:**

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L37-R38): Removed the Cachix cache push step and replaced the package build with a build of the new `checks` output, simplifying the workflow and focusing on checks rather than artifact caching.

**Nix flake enhancements:**

* [`flake.nix`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R95-R98): Added a `checks` attribute for all systems, which builds the default package as a check, enabling the new workflow step to verify package builds via the `checks` output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the "Music" label translation across many locales (e.g., Arabic, German, English, Spanish, French, Greek, Hebrew, Hungarian, Indonesian, Japanese, Korean, Polish, Portuguese-BR, Romanian, Russian, Turkish, Ukrainian, Chinese, and token variants).

* **Chores**
  * Updated CI build workflow to use Nix checks.
  * Added an i18n validation check to ensure runtime strings match the baseline translations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->