### PR TITLE
fix: update favorite handling to use current track snapshot in bottombar components

### DIFF
--- a/components/src/modern/bottombar.rs
+++ b/components/src/modern/bottombar.rs
@@ -55,7 +55,8 @@ pub fn BottombarModern(
     let mut ctrl = use_context::<PlayerController>();
     let nav_ctrl = use_context::<NavigationController>();
 
-    let is_favorite = get_favorite(&queue, &current_queue_index, &favorites_store);
+    let current_track_snapshot = ctrl.current_track_snapshot.read().clone();
+    let is_favorite = get_favorite(current_track_snapshot.as_ref(), &favorites_store);
     let heart_class = if is_favorite {
         "text-red-400 hover:text-red-300 transition-colors"
     } else {
@@ -205,7 +206,7 @@ pub fn BottombarModern(
                 button {
                     class: "{heart_class} w-7 h-7 flex items-center justify-center",
                     title: if is_favorite { i18n::t("remove_from_favorites").to_string() } else { i18n::t("add_to_favorites").to_string() },
-                    onclick: move |_| toggle_favorite(queue, current_queue_index, favorites_store, config),
+                    onclick: move |_| toggle_favorite(ctrl.current_track_snapshot.read().clone(), favorites_store, config),
                     i { class: "{heart_icon} text-xs" }
                 }
                 div {

--- a/components/src/modern/bottombar.rs
+++ b/components/src/modern/bottombar.rs
@@ -143,8 +143,10 @@ pub fn BottombarModern(
                     span {
                         class: "text-xs font-semibold text-white/90 truncate hover:underline cursor-pointer shrink-0 max-w-[40%]",
                         onclick: move |_| {
-                            let idx = *current_queue_index.read();
-                            let album_id = queue.read().get(idx).map(|t| t.album_id.clone()).unwrap_or_default();
+                            let album_id = current_track_snapshot
+                                .as_ref()
+                                .map(|track| track.album_id.clone())
+                                .unwrap_or_default();
                             nav_ctrl.navigate_to_album(album_id);
                         },
                         "{current_song_title}"

--- a/components/src/normal/bottombar.rs
+++ b/components/src/normal/bottombar.rs
@@ -91,8 +91,10 @@ pub fn BottombarNormal(
                     span {
                         class: "text-sm font-bold text-white/90 truncate hover:underline cursor-pointer",
                         onclick: move |_| {
-                            let idx = *current_queue_index.read();
-                            let album_id = queue.read().get(idx).map(|t| t.album_id.clone()).unwrap_or_default();
+                            let album_id = current_track_snapshot
+                                .as_ref()
+                                .map(|track| track.album_id.clone())
+                                .unwrap_or_default();
                             nav_ctrl.navigate_to_album(album_id);
                         },
                         "{current_song_title}"

--- a/components/src/normal/bottombar.rs
+++ b/components/src/normal/bottombar.rs
@@ -51,7 +51,8 @@ pub fn BottombarNormal(
     let mut ctrl = use_context::<PlayerController>();
     let nav_ctrl = use_context::<NavigationController>();
 
-    let is_favorite = get_favorite(&queue, &current_queue_index, &favorites_store);
+    let current_track_snapshot = ctrl.current_track_snapshot.read().clone();
+    let is_favorite = get_favorite(current_track_snapshot.as_ref(), &favorites_store);
     let heart_class = if is_favorite {
         "ml-2 text-red-400 hover:text-red-300 transition-colors"
     } else {
@@ -108,7 +109,7 @@ pub fn BottombarNormal(
                 button {
                     class: "{heart_class}",
                     title: if is_favorite { i18n::t("remove_from_favorites").to_string() } else { i18n::t("add_to_favorites").to_string() },
-                    onclick: move |_| toggle_favorite(queue, current_queue_index, favorites_store, config),
+                    onclick: move |_| toggle_favorite(ctrl.current_track_snapshot.read().clone(), favorites_store, config),
                     i { class: "{heart_icon}" }
                 }
             }

--- a/components/src/shared.rs
+++ b/components/src/shared.rs
@@ -12,13 +12,10 @@ pub fn fmt_time(secs: u64) -> String {
 }
 
 pub fn get_favorite(
-    queue: &Signal<Vec<reader::models::Track>>,
-    current_queue_index: &Signal<usize>,
+    current_track: Option<&reader::models::Track>,
     favorites_store: &Signal<FavoritesStore>,
 ) -> bool {
-    let q = queue.read();
-    let idx = *current_queue_index.read();
-    if let Some(track) = q.get(idx) {
+    if let Some(track) = current_track {
         let path_str = track.path.to_string_lossy();
         if path_str.starts_with("jellyfin:")
             || path_str.starts_with("subsonic:")
@@ -39,15 +36,11 @@ pub fn get_favorite(
 }
 
 pub fn toggle_favorite(
-    queue: Signal<Vec<reader::models::Track>>,
-    current_queue_index: Signal<usize>,
+    current_track: Option<reader::models::Track>,
     mut favorites_store: Signal<FavoritesStore>,
     config: Signal<config::AppConfig>,
 ) {
-    let q = queue.read();
-    let idx = *current_queue_index.read();
-    if let Some(track) = q.get(idx).cloned() {
-        drop(q);
+    if let Some(track) = current_track {
         let path_str = track.path.to_string_lossy().to_string();
         let is_server_item = path_str.starts_with("jellyfin:")
             || path_str.starts_with("subsonic:")

--- a/pages/src/local/artist.rs
+++ b/pages/src/local/artist.rs
@@ -224,7 +224,6 @@ pub fn LocalArtist(
                                         }
                                     }
                                     h3 { class: "text-white font-medium truncate text-center w-full group-hover:text-indigo-400 transition-colors", "{artist}" }
-                                    p { class: "text-xs text-slate-500 uppercase tracking-wider mt-1", "{i18n::t(\"artist\")}" }
                                 }
                             }
                         }
@@ -467,7 +466,7 @@ pub fn LocalArtist(
                         } else {
                             components::showcase::Showcase {
                                 name: name.clone(),
-                                description: i18n::t("artist").to_string(),
+                                description: String::new(),
                                 cover_url: artist_cover(),
                                 tracks: artist_tracks(),
                                 library,

--- a/pages/src/server/artist.rs
+++ b/pages/src/server/artist.rs
@@ -339,7 +339,6 @@ pub fn JellyfinArtist(
                                         }
                                     }
                                     h3 { class: "text-white font-medium truncate text-center w-full group-hover:text-indigo-400 transition-colors", "{artist}" }
-                                    p { class: "text-xs text-slate-500 uppercase tracking-wider mt-1", "{i18n::t(\"artist\")}" }
                                 }
                             }
                         }
@@ -771,7 +770,7 @@ pub fn JellyfinArtist(
                         } else {
                             components::showcase::Showcase {
                                 name: name.clone(),
-                                description: i18n::t("artist").to_string(),
+                                description: String::new(),
                                 cover_url: artist_cover(),
                                 tracks: artist_tracks(),
                                 library,


### PR DESCRIPTION
This pull request refactors how the favorite status of tracks is determined and toggled in both the modern and normal bottom bar components. Instead of relying on the queue and index, the code now uses the current track snapshot directly, simplifying the logic and reducing potential errors. Additionally, some minor UI text changes were made in artist pages.

**Favorite logic improvements:**

* Refactored `get_favorite` and `toggle_favorite` to use the current track snapshot instead of the queue and index, simplifying and centralizing favorite-checking logic. (`components/src/shared.rs`) [[1]](diffhunk://#diff-fe3e2b1cb392988a83279c460dd4eec9cabc7a5ed90e3b62db6ec582cc5b52fdL15-R18) [[2]](diffhunk://#diff-fe3e2b1cb392988a83279c460dd4eec9cabc7a5ed90e3b62db6ec582cc5b52fdL42-R43)
* Updated `BottombarModern` and `BottombarNormal` to use the new favorite logic by passing the current track snapshot, both for displaying favorite status and toggling favorites. (`components/src/modern/bottombar.rs`, `components/src/normal/bottombar.rs`) [[1]](diffhunk://#diff-f8c79dcdaa81489b27efd6daae922ec4c1dd331ee12b73021e69c0af33560811L58-R59) [[2]](diffhunk://#diff-f8c79dcdaa81489b27efd6daae922ec4c1dd331ee12b73021e69c0af33560811L208-R209) [[3]](diffhunk://#diff-85302ab26dfa64e103e665d8d9239904d8d8eb5ec4fea8746fdc3e3180646d13L54-R55) [[4]](diffhunk://#diff-85302ab26dfa64e103e665d8d9239904d8d8eb5ec4fea8746fdc3e3180646d13L111-R112)

**UI text changes in artist pages:**

* Removed the "artist" label from the subtitle in local and Jellyfin artist pages, and set the showcase description to an empty string instead of "artist". (`pages/src/local/artist.rs`, `pages/src/server/artist.rs`) [[1]](diffhunk://#diff-1c4cf7fb67b72a53effd2d83432b0ba4d47b9f92ff0333b9a5ab2e27a1b9a70dL227) [[2]](diffhunk://#diff-1c4cf7fb67b72a53effd2d83432b0ba4d47b9f92ff0333b9a5ab2e27a1b9a70dL470-R469) [[3]](diffhunk://#diff-bda372248777054ed08bb5a31266e9e5615245421de0221fc699f56fc753b6a9L342) [[4]](diffhunk://#diff-bda372248777054ed08bb5a31266e9e5615245421de0221fc699f56fc753b6a9L774-R773)
It's really redundant having Artist label under every artist on the Artists page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Favorites state and the favorite/unfavorite action now reflect the currently playing track, improving accuracy of the heart button and favorite toggles.
  * Album navigation from the bottom bar now reliably opens the album for the current track.

* **Style**
  * Removed redundant "Artist" labels under artist thumbnails and from artist showcase descriptions for a cleaner UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->