### PR TITLE
fix: cache jellyfin client

### DIFF
--- a/hooks/src/use_player_task.rs
+++ b/hooks/src/use_player_task.rs
@@ -25,6 +25,14 @@ enum BgCmd {
     Prev,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct JellyfinCacheKey {
+    url: String,
+    access_token: Option<String>,
+    device_id: String,
+    user_id: Option<String>,
+}
+
 static BG_CMD_TX: std::sync::OnceLock<std::sync::Mutex<std::sync::mpsc::Sender<BgCmd>>> =
     std::sync::OnceLock::new();
 static BG_CMD_RX: std::sync::OnceLock<std::sync::Mutex<std::sync::mpsc::Receiver<BgCmd>>> =
@@ -206,6 +214,7 @@ pub fn use_player_task(ctrl: PlayerController) {
             let mut last_recent_path: Option<String> = None;
             #[cfg(not(target_arch = "wasm32"))]
             let bg_notify = BG_NOTIFY.get_or_init(tokio::sync::Notify::new);
+            let mut jellyfin_client_cache: Option<(JellyfinCacheKey, Arc<JellyfinClient>)> = None;
             loop {
                 #[cfg(not(target_arch = "wasm32"))]
                 tokio::select! {
@@ -327,12 +336,28 @@ pub fn use_player_task(ctrl: PlayerController) {
 
                 if let Some((server, device_id)) = jellyfin_info {
                     if server.service == MusicService::Jellyfin {
-                        let remote = Arc::new(JellyfinClient::new(
-                            &server.url,
-                            server.access_token.as_deref(),
-                            &device_id,
-                            server.user_id.as_deref(),
-                        ));
+                        let key = JellyfinCacheKey {
+                            url: server.url.clone(),
+                            access_token: server.access_token,
+                            device_id: device_id.clone(),
+                            user_id: server.user_id,
+                        };
+
+                        let remote = match &jellyfin_client_cache {
+                            Some((cached_key, cached_client)) if cached_key == &key => {
+                                cached_client.clone()
+                            }
+                            _ => {
+                                let client = Arc::new(JellyfinClient::new(
+                                    &key.url,
+                                    key.access_token.as_deref(),
+                                    &key.device_id,
+                                    key.user_id.as_deref(),
+                                ));
+                                jellyfin_client_cache = Some((key, client.clone()));
+                                client
+                            }
+                        };
 
                         if last_ping.elapsed().as_secs() >= 30 {
                             let remote = remote.clone();


### PR DESCRIPTION
cache the jellyfin client, so it does not get created each 250ms. This drops the CPU usage from 10%~20% to 0%~3% in idle for me

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Jellyfin client connection reuse in playback tasks to avoid unnecessary client recreation when connection parameters remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->