### PR TITLE
Fix/async safety and comments

### DIFF
--- a/player/src/systemint/macos.rs
+++ b/player/src/systemint/macos.rs
@@ -18,6 +18,10 @@ use objc2_media_player::{
     MPRemoteCommandHandlerStatus,
 };
 
+// SAFETY:
+// These are well-documented CoreFoundation C functions. The FFI
+// signatures match the official Apple headers. Each call site
+// documents why the specific call is safe.
 unsafe extern "C" {
     fn CFRunLoopGetMain() -> *mut std::ffi::c_void;
     fn CFRunLoopWakeUp(rl: *mut std::ffi::c_void);
@@ -41,6 +45,10 @@ unsafe extern "C" {
 
 type IOPMAssertionID = u32;
 #[link(name = "IOKit", kind = "framework")]
+// SAFETY:
+// IOPMAssertionCreateWithName is a documented IOKit function.
+// The FFI signature matches Apple's IOPMLib.h header. The call
+// site documents the specific safety invariants.
 unsafe extern "C" {
     fn IOPMAssertionCreateWithName(
         assertion_type: *const std::ffi::c_void,

--- a/player/src/systemint/macos.rs
+++ b/player/src/systemint/macos.rs
@@ -1,3 +1,14 @@
+// macOS system integration: media keys, Now Playing info, audio session, power
+// management, and run loop heartbeat for remote command dispatching.
+//
+// Architecture:
+// - init() sets up: NSProcessInfo (prevent App Nap), IOKit (no idle sleep),
+//   AVAudioSession (background playback), MPRemoteCommandCenter (media keys),
+//   CFRunLoopTimer (periodic heartbeat to wake the Tokio runtime)
+// - update_now_playing() pushes metadata + artwork to MPNowPlayingInfoCenter
+// - CFRunLoopWakeUp() is called to unblock the main thread from Tokio tasks
+// - All Objective-C/CoreFoundation FFI is documented with // SAFETY: invariants
+
 use std::ptr::NonNull;
 use std::sync::Mutex as StdMutex;
 use std::sync::{Arc, OnceLock};

--- a/player/src/systemint/macos.rs
+++ b/player/src/systemint/macos.rs
@@ -87,17 +87,6 @@ pub enum SystemEvent {
     Prev,
 }
 
-struct ThreadSafeArtwork(objc2::rc::Retained<MPMediaItemArtwork>);
-// SAFETY:
-// - MPMediaItemArtwork is an immutable, thread-safe reference-counted
-//   object on Apple platforms. It can be safely sent and shared across
-//   threads.
-// - The Retained pointer provides ownership semantics equivalent to
-//   Arc, and the underlying Objective-C object is usable from any
-//   thread.
-unsafe impl Send for ThreadSafeArtwork {}
-unsafe impl Sync for ThreadSafeArtwork {}
-
 static BACKGROUND_HANDLER: OnceLock<Arc<StdMutex<Option<Box<dyn Fn(SystemEvent) + Send + Sync>>>>> =
     OnceLock::new();
 
@@ -299,9 +288,6 @@ pub fn update_now_playing(
 ) {
     init();
 
-    static ARTWORK_CACHE: OnceLock<std::sync::Mutex<Option<(String, ThreadSafeArtwork)>>> =
-        OnceLock::new();
-
     // SAFETY:
     // - This entire block interacts with MediaPlayer framework objects
     //   (MPNowPlayingInfoCenter, MPMediaItemArtwork) which are thread-safe
@@ -319,8 +305,6 @@ pub fn update_now_playing(
     //   takes ownership without over-releasing.
     // - The artwork pointer null-check ensures we only convert valid
     //   pointers to Retained.
-    // - The ARTWORK_CACHE is protected by a std::sync::Mutex, preventing
-    //   data races.
     unsafe {
         let center = MPNowPlayingInfoCenter::defaultCenter();
 
@@ -359,48 +343,24 @@ pub fn update_now_playing(
         );
 
         if let Some(path) = artwork_path {
-            let cache_lock = ARTWORK_CACHE.get_or_init(|| std::sync::Mutex::new(None));
-            let mut cache = cache_lock.lock().unwrap();
+            let ns_path = NSString::from_str(path);
+            if let Some(image) = NSImage::initWithContentsOfFile(NSImage::alloc(), &ns_path) {
+                use objc2::msg_send;
+                let artwork_alloc = MPMediaItemArtwork::alloc();
+                let artwork_ptr: *mut MPMediaItemArtwork = std::mem::transmute(artwork_alloc);
+                let artwork_raw: *mut MPMediaItemArtwork =
+                    msg_send![artwork_ptr, initWithImage: &*image];
 
-            let cached_artwork = if let Some((cached_path, artwork_wrapper)) = &*cache {
-                if cached_path == path {
-                    Some(artwork_wrapper.0.clone())
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
+                if !artwork_raw.is_null() {
+                    let retained: objc2::rc::Retained<MPMediaItemArtwork> =
+                        objc2::rc::Retained::from_raw(artwork_raw).expect("retained artwork");
 
-            if let Some(artwork) = cached_artwork {
-                let artwork_ref: &AnyObject =
-                    &*(std::mem::transmute::<_, *const AnyObject>(&*artwork));
-                info.setObject_forKey(
-                    artwork_ref,
-                    ProtocolObject::from_ref(MPMediaItemPropertyArtwork),
-                );
-            } else {
-                let ns_path = NSString::from_str(path);
-                if let Some(image) = NSImage::initWithContentsOfFile(NSImage::alloc(), &ns_path) {
-                    use objc2::msg_send;
-                    let artwork_alloc = MPMediaItemArtwork::alloc();
-                    let artwork_ptr: *mut MPMediaItemArtwork = std::mem::transmute(artwork_alloc);
-                    let artwork_raw: *mut MPMediaItemArtwork =
-                        msg_send![artwork_ptr, initWithImage: &*image];
-
-                    if !artwork_raw.is_null() {
-                        let retained: objc2::rc::Retained<MPMediaItemArtwork> =
-                            objc2::rc::Retained::from_raw(artwork_raw).expect("retained artwork");
-
-                        let artwork_ref: &AnyObject =
-                            &*(std::mem::transmute::<_, *const AnyObject>(&*retained));
-                        info.setObject_forKey(
-                            artwork_ref,
-                            ProtocolObject::from_ref(MPMediaItemPropertyArtwork),
-                        );
-
-                        *cache = Some((path.to_string(), ThreadSafeArtwork(retained)));
-                    }
+                    let artwork_ref: &AnyObject =
+                        &*(std::mem::transmute::<_, *const AnyObject>(&*retained));
+                    info.setObject_forKey(
+                        artwork_ref,
+                        ProtocolObject::from_ref(MPMediaItemPropertyArtwork),
+                    );
                 }
             }
         }

--- a/player/src/systemint/macos.rs
+++ b/player/src/systemint/macos.rs
@@ -51,6 +51,11 @@ unsafe extern "C" {
 }
 
 pub fn wake_run_loop() {
+    // SAFETY:
+    // - CFRunLoopGetMain() always returns a valid reference to the main
+    //   thread's run loop; it never returns null.
+    // - CFRunLoopWakeUp is safe to call on any valid run loop and does
+    //   not require additional synchronization.
     unsafe { CFRunLoopWakeUp(CFRunLoopGetMain()) }
 }
 
@@ -64,6 +69,13 @@ pub enum SystemEvent {
 }
 
 struct ThreadSafeArtwork(objc2::rc::Retained<MPMediaItemArtwork>);
+// SAFETY:
+// - MPMediaItemArtwork is an immutable, thread-safe reference-counted
+//   object on Apple platforms. It can be safely sent and shared across
+//   threads.
+// - The Retained pointer provides ownership semantics equivalent to
+//   Arc, and the underlying Objective-C object is usable from any
+//   thread.
 unsafe impl Send for ThreadSafeArtwork {}
 unsafe impl Sync for ThreadSafeArtwork {}
 
@@ -113,6 +125,12 @@ fn dispatch_event(event: SystemEvent) {
     wake_run_loop();
 }
 
+// SAFETY:
+// - This function matches the C callback signature expected by
+//   CFRunLoopTimerCreate (CFRunLoopTimerCallBack).
+// - It only calls wake_tokio() which is a safe Rust function.
+// - Parameters are unused, so their raw pointer values are never
+//   dereferenced.
 unsafe extern "C" fn main_loop_heartbeat(
     _timer: *mut std::ffi::c_void,
     _info: *mut std::ffi::c_void,
@@ -122,109 +140,131 @@ unsafe extern "C" fn main_loop_heartbeat(
 
 pub fn init() {
     static ONCE: OnceLock<()> = OnceLock::new();
-    ONCE.get_or_init(|| unsafe {
-        use objc2::ClassType;
-        let process_info: *mut AnyObject = objc2::msg_send![NSProcessInfo::class(), processInfo];
-        let reason = NSString::from_str("Kopuz Background Audio Playback");
-        let options: u64 = 0x00FFFFFF | 0xFF00000000;
-        let activity: *mut AnyObject =
-            objc2::msg_send![process_info, beginActivityWithOptions: options, reason: &*reason];
-        if !activity.is_null() {
-            let _: *mut AnyObject = objc2::msg_send![activity, retain];
-            println!("[macos] App Nap bypassed with NSProcessInfo activity (latency-critical)");
-        }
+    ONCE.get_or_init(|| {
+        // SAFETY:
+        // - msg_send! on NSProcessInfo, AVFoundation, and MediaPlayer objects
+        //   is safe because these are well-known Apple frameworks that do not
+        //   require special threading or memory management beyond retain/release,
+        //   which objc2 handles automatically.
+        // - transmute from &NSString to *const c_void is sound because
+        //   NSString is a valid Objective-C object with a stable memory layout
+        //   compatible with CoreFoundation's CFStringRef.
+        // - IOPMAssertionCreateWithName expects a CFStringRef; transmuting
+        //   NSString to *const c_void is valid for the same reason (toll-free
+        //   bridging between CFStringRef and NSString).
+        // - CFRunLoopGetMain() always returns a valid run loop reference.
+        // - CFRunLoopTimerCreate with null allocator uses the default allocator,
+        //   which is correct for CoreFoundation.
+        // - kCFRunLoopCommonModes is a valid CFStringRef constant.
+        // - main_loop_heartbeat matches the required C callback signature.
+        // - All pointers passed to CoreFoundation functions are valid for the
+        //   duration of the calls.
+        // - The activity pointer from beginActivityWithOptions: is checked for
+        //   null before being used.
+        unsafe {
+            use objc2::ClassType;
+            let process_info: *mut AnyObject = objc2::msg_send![NSProcessInfo::class(), processInfo];
+            let reason = NSString::from_str("Kopuz Background Audio Playback");
+            let options: u64 = 0x00FFFFFF | 0xFF00000000;
+            let activity: *mut AnyObject =
+                objc2::msg_send![process_info, beginActivityWithOptions: options, reason: &*reason];
+            if !activity.is_null() {
+                let _: *mut AnyObject = objc2::msg_send![activity, retain];
+                println!("[macos] App Nap bypassed with NSProcessInfo activity (latency-critical)");
+            }
 
-        let assertion_type = NSString::from_str("NoIdleSleepAssertion");
-        let assertion_reason = NSString::from_str("Kopuz is playing audio");
-        let mut assertion_id: IOPMAssertionID = 0;
-        let kr = IOPMAssertionCreateWithName(
-            std::mem::transmute::<&objc2_foundation::NSString, *const std::ffi::c_void>(
-                &*assertion_type,
-            ),
-            255,
-            std::mem::transmute::<&objc2_foundation::NSString, *const std::ffi::c_void>(
-                &*assertion_reason,
-            ),
-            &mut assertion_id,
-        );
-        if kr == 0 {
-            println!(
-                "[macos] IOKit power assertion created (id={})",
-                assertion_id
+            let assertion_type = NSString::from_str("NoIdleSleepAssertion");
+            let assertion_reason = NSString::from_str("Kopuz is playing audio");
+            let mut assertion_id: IOPMAssertionID = 0;
+            let kr = IOPMAssertionCreateWithName(
+                std::mem::transmute::<&objc2_foundation::NSString, *const std::ffi::c_void>(
+                    &*assertion_type,
+                ),
+                255,
+                std::mem::transmute::<&objc2_foundation::NSString, *const std::ffi::c_void>(
+                    &*assertion_reason,
+                ),
+                &mut assertion_id,
             );
-        } else {
-            eprintln!("[macos] Failed to create IOKit power assertion: {}", kr);
-        }
+            if kr == 0 {
+                println!(
+                    "[macos] IOKit power assertion created (id={})",
+                    assertion_id
+                );
+            } else {
+                eprintln!("[macos] Failed to create IOKit power assertion: {}", kr);
+            }
 
-        let session = AVAudioSession::sharedInstance();
-        if let Err(e) = session.setCategory_error(AVAudioSessionCategoryPlayback.unwrap()) {
-            eprintln!("[macos] Failed to set AVAudioSession category: {:?}", e);
-        }
-        if let Err(e) = session.setActive_error(true) {
-            eprintln!("[macos] Failed to activate AVAudioSession: {:?}", e);
-        } else {
-            println!("[macos] AVAudioSession configured for background playback");
-        }
+            let session = AVAudioSession::sharedInstance();
+            if let Err(e) = session.setCategory_error(AVAudioSessionCategoryPlayback.unwrap()) {
+                eprintln!("[macos] Failed to set AVAudioSession category: {:?}", e);
+            }
+            if let Err(e) = session.setActive_error(true) {
+                eprintln!("[macos] Failed to activate AVAudioSession: {:?}", e);
+            } else {
+                println!("[macos] AVAudioSession configured for background playback");
+            }
 
-        let center = MPRemoteCommandCenter::sharedCommandCenter();
+            let center = MPRemoteCommandCenter::sharedCommandCenter();
 
-        center.playCommand().addTargetWithHandler(&RcBlock::new(
-            move |_: NonNull<MPRemoteCommandEvent>| {
-                dispatch_event(SystemEvent::Play);
-                MPRemoteCommandHandlerStatus::Success
-            },
-        ));
+            center.playCommand().addTargetWithHandler(&RcBlock::new(
+                move |_: NonNull<MPRemoteCommandEvent>| {
+                    dispatch_event(SystemEvent::Play);
+                    MPRemoteCommandHandlerStatus::Success
+                },
+            ));
 
-        center.pauseCommand().addTargetWithHandler(&RcBlock::new(
-            move |_: NonNull<MPRemoteCommandEvent>| {
-                dispatch_event(SystemEvent::Pause);
-                MPRemoteCommandHandlerStatus::Success
-            },
-        ));
+            center.pauseCommand().addTargetWithHandler(&RcBlock::new(
+                move |_: NonNull<MPRemoteCommandEvent>| {
+                    dispatch_event(SystemEvent::Pause);
+                    MPRemoteCommandHandlerStatus::Success
+                },
+            ));
 
-        center
-            .togglePlayPauseCommand()
-            .addTargetWithHandler(&RcBlock::new(move |_: NonNull<MPRemoteCommandEvent>| {
-                dispatch_event(SystemEvent::Toggle);
-                MPRemoteCommandHandlerStatus::Success
-            }));
+            center
+                .togglePlayPauseCommand()
+                .addTargetWithHandler(&RcBlock::new(move |_: NonNull<MPRemoteCommandEvent>| {
+                    dispatch_event(SystemEvent::Toggle);
+                    MPRemoteCommandHandlerStatus::Success
+                }));
 
-        center
-            .nextTrackCommand()
-            .addTargetWithHandler(&RcBlock::new(move |_: NonNull<MPRemoteCommandEvent>| {
-                dispatch_event(SystemEvent::Next);
-                MPRemoteCommandHandlerStatus::Success
-            }));
+            center
+                .nextTrackCommand()
+                .addTargetWithHandler(&RcBlock::new(move |_: NonNull<MPRemoteCommandEvent>| {
+                    dispatch_event(SystemEvent::Next);
+                    MPRemoteCommandHandlerStatus::Success
+                }));
 
-        center
-            .previousTrackCommand()
-            .addTargetWithHandler(&RcBlock::new(move |_: NonNull<MPRemoteCommandEvent>| {
-                dispatch_event(SystemEvent::Prev);
-                MPRemoteCommandHandlerStatus::Success
-            }));
+            center
+                .previousTrackCommand()
+                .addTargetWithHandler(&RcBlock::new(move |_: NonNull<MPRemoteCommandEvent>| {
+                    dispatch_event(SystemEvent::Prev);
+                    MPRemoteCommandHandlerStatus::Success
+                }));
 
-        let fire_date = CFAbsoluteTimeGetCurrent();
-        let timer = CFRunLoopTimerCreate(
-            std::ptr::null(),
-            fire_date,
-            0.25,
-            0,
-            0,
-            main_loop_heartbeat,
-            std::ptr::null(),
-        );
-        if !timer.is_null() {
-            CFRunLoopAddTimer(CFRunLoopGetMain(), timer, kCFRunLoopCommonModes);
-            println!("[macos] CFRunLoopTimer heartbeat started on main run loop (250ms)");
-        } else {
-            eprintln!("[macos] Failed to create CFRunLoopTimer, falling back to thread");
-            std::thread::spawn(|| {
-                loop {
-                    std::thread::sleep(std::time::Duration::from_millis(250));
-                    wake_tokio();
-                    wake_run_loop();
-                }
-            });
+            let fire_date = CFAbsoluteTimeGetCurrent();
+            let timer = CFRunLoopTimerCreate(
+                std::ptr::null(),
+                fire_date,
+                0.25,
+                0,
+                0,
+                main_loop_heartbeat,
+                std::ptr::null(),
+            );
+            if !timer.is_null() {
+                CFRunLoopAddTimer(CFRunLoopGetMain(), timer, kCFRunLoopCommonModes);
+                println!("[macos] CFRunLoopTimer heartbeat started on main run loop (250ms)");
+            } else {
+                eprintln!("[macos] Failed to create CFRunLoopTimer, falling back to thread");
+                std::thread::spawn(|| {
+                    loop {
+                        std::thread::sleep(std::time::Duration::from_millis(250));
+                        wake_tokio();
+                        wake_run_loop();
+                    }
+                });
+            }
         }
     });
 }
@@ -243,6 +283,25 @@ pub fn update_now_playing(
     static ARTWORK_CACHE: OnceLock<std::sync::Mutex<Option<(String, ThreadSafeArtwork)>>> =
         OnceLock::new();
 
+    // SAFETY:
+    // - This entire block interacts with MediaPlayer framework objects
+    //   (MPNowPlayingInfoCenter, MPMediaItemArtwork) which are thread-safe
+    //   and designed to be called from any thread on macOS.
+    // - transmute from NSString/NSNumber to AnyObject is safe because
+    //   these Foundation types inherit from NSObject and their memory
+    //   layout is compatible. The protocol conformance is verified by
+    //   the existing type system.
+    // - transmute from NSMutableDictionary to NSDictionary is safe because
+    //   NSMutableDictionary is a subclass of NSDictionary; the upcast is
+    //   valid in Objective-C and matches what the framework expects.
+    // - Retained::from_raw on the artwork pointer is safe because the
+    //   pointer was just returned by initWithImage: which follows the
+    //   "alloc-init" convention (returns +1 retain count), and from_raw
+    //   takes ownership without over-releasing.
+    // - The artwork pointer null-check ensures we only convert valid
+    //   pointers to Retained.
+    // - The ARTWORK_CACHE is protected by a std::sync::Mutex, preventing
+    //   data races.
     unsafe {
         let center = MPNowPlayingInfoCenter::defaultCenter();
 
@@ -335,6 +394,14 @@ pub fn update_now_playing(
 }
 
 pub fn refresh_now_playing() {
+    // SAFETY:
+    // - MPNowPlayingInfoCenter::defaultCenter() returns a valid,
+    //   thread-safe singleton.
+    // - nowPlayingInfo() returns an Option that may be None; we pass
+    //   None through as_deref() which maps to nil, which is a valid
+    //   argument for setNowPlayingInfo (clears the info).
+    // - setNowPlayingInfo accepts an optional dictionary; no
+    //   preconditions are violated here.
     unsafe {
         let center = MPNowPlayingInfoCenter::defaultCenter();
         let existing = center.nowPlayingInfo();

--- a/player/src/systemint/windows.rs
+++ b/player/src/systemint/windows.rs
@@ -47,6 +47,8 @@ pub enum SystemEvent {
 }
 
 static SMTC: OnceLock<SystemMediaTransportControls> = OnceLock::new();
+static EVENT_SENDER: OnceLock<UnboundedSender<SystemEvent>> = OnceLock::new();
+static EVENT_RECEIVER: OnceLock<Mutex<UnboundedReceiver<SystemEvent>>> = OnceLock::new();
 
 fn get_tx() -> UnboundedSender<SystemEvent> {
     EVENT_SENDER

--- a/player/src/systemint/windows.rs
+++ b/player/src/systemint/windows.rs
@@ -46,18 +46,7 @@ pub enum SystemEvent {
     Seek(f64),
 }
 
-struct SendableSmtc(SystemMediaTransportControls);
-// SAFETY:
-// - SystemMediaTransportControls is a WinRT object that is thread-safe
-//   by design; all its methods are safe to call from any thread.
-// - The underlying COM object uses reference counting and is safe to
-//   send and share across threads.
-unsafe impl Send for SendableSmtc {}
-unsafe impl Sync for SendableSmtc {}
-
-static EVENT_SENDER: OnceLock<UnboundedSender<SystemEvent>> = OnceLock::new();
-static EVENT_RECEIVER: OnceLock<Mutex<UnboundedReceiver<SystemEvent>>> = OnceLock::new();
-static SMTC: OnceLock<SendableSmtc> = OnceLock::new();
+static SMTC: OnceLock<SystemMediaTransportControls> = OnceLock::new();
 
 fn get_tx() -> UnboundedSender<SystemEvent> {
     EVENT_SENDER
@@ -259,7 +248,7 @@ fn setup_smtc(hwnd: HWND) {
 
     match result {
         Ok(smtc) => {
-            if SMTC.set(SendableSmtc(smtc)).is_ok() {
+            if SMTC.set(smtc).is_ok() {
                 println!("[windows] SMTC initialised");
             }
         }
@@ -346,7 +335,6 @@ pub fn update_now_playing(
     }
 
     let Some(smtc) = SMTC.get() else { return };
-    let smtc = &smtc.0;
 
     let _ = smtc.SetPlaybackStatus(if playing {
         MediaPlaybackStatus::Playing
@@ -377,7 +365,7 @@ pub fn update_now_playing(
                     if let Some(bytes) = fetch_artwork_bytes(&art_owned) {
                         if let Some(stream_ref) = stream_ref_from_bytes(&bytes) {
                             if let Some(smtc) = SMTC.get() {
-                                if let Ok(updater) = smtc.0.DisplayUpdater() {
+                                if let Ok(updater) = smtc.DisplayUpdater() {
                                     let _ = updater.SetThumbnail(&stream_ref);
                                     let _ = updater.Update();
                                 }

--- a/player/src/systemint/windows.rs
+++ b/player/src/systemint/windows.rs
@@ -34,6 +34,11 @@ pub enum SystemEvent {
 }
 
 struct SendableSmtc(SystemMediaTransportControls);
+// SAFETY:
+// - SystemMediaTransportControls is a WinRT object that is thread-safe
+//   by design; all its methods are safe to call from any thread.
+// - The underlying COM object uses reference counting and is safe to
+//   send and share across threads.
 unsafe impl Send for SendableSmtc {}
 unsafe impl Sync for SendableSmtc {}
 
@@ -72,11 +77,28 @@ struct EnumData {
     any_hwnd: HWND,
 }
 
+// SAFETY:
+// - This function matches the expected C callback signature for
+//   EnumWindows (WNDENUMPROC). The system calls it for each top-level
+//   window.
+// - LPARAM contains a valid pointer to an EnumData struct allocated
+//   on the stack in find_main_hwnd(). The reference does not escape
+//   because EnumWindows calls this callback synchronously.
+// - GetWindowThreadProcessId and IsWindowVisible are safe to call
+//   with any valid HWND.
 unsafe extern "system" fn enum_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    // SAFETY:
+    // - LPARAM is a valid pointer to an EnumData struct that lives
+    //   on the caller's stack for the duration of EnumWindows.
     let data = unsafe { &mut *(lparam.0 as *mut EnumData) };
     let mut pid = 0u32;
+    // SAFETY: GetWindowThreadProcessId is safe with a valid HWND
+    // and a mutable output pointer.
     unsafe { GetWindowThreadProcessId(hwnd, Some(&mut pid)) };
-    if pid == data.pid && unsafe { IsWindowVisible(hwnd).as_bool() } {
+    if pid == data.pid
+    // SAFETY: IsWindowVisible is safe to call with any HWND.
+    && unsafe { IsWindowVisible(hwnd).as_bool() }
+    {
         data.hwnd = hwnd;
         BOOL(0) // stop enumeration
     } else {
@@ -88,6 +110,13 @@ unsafe extern "system" fn enum_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
 }
 
 fn create_message_window() -> Option<HWND> {
+    // SAFETY:
+    // - CreateWindowExW with HWND_MESSAGE creates a message-only window,
+    //   which does not require a parent window or a window procedure.
+    // - All parameters are well-formed: class name is "STATIC" (a
+    //   standard Windows class), title is a valid wide string, and
+    //   dimensions are zero (message windows have no visual presence).
+    // - The return value is checked for null to ensure validity.
     let hwnd = unsafe {
         CreateWindowExW(
             WINDOW_EX_STYLE::default(),
@@ -112,12 +141,20 @@ fn create_message_window() -> Option<HWND> {
 
 fn find_main_hwnd() -> Option<HWND> {
     let mut data = EnumData {
+        // SAFETY: GetCurrentProcessId is a simple system call that
+        // always succeeds and requires no special setup.
         pid: unsafe { GetCurrentProcessId() },
         hwnd: HWND(std::ptr::null_mut()),
         any_hwnd: HWND(std::ptr::null_mut()),
     };
 
-    // return Err even on success
+    // SAFETY:
+    // - EnumWindows is safe to call with a valid callback pointer and
+    //   a user-data parameter.
+    // - enum_proc is a valid C callback matching the expected signature.
+    // - LPARAM contains a valid pointer to `data`, which lives on the
+    //   stack for the duration of the EnumWindows call.
+    // - EnumWindows is synchronous, so the reference does not escape.
     let _ = unsafe { EnumWindows(Some(enum_proc), LPARAM(&mut data as *mut EnumData as isize)) };
 
     if !data.hwnd.0.is_null() {
@@ -139,7 +176,18 @@ fn setup_smtc(hwnd: HWND) {
         return;
     }
 
-    let result = (|| unsafe {
+    let result = (|| {
+        // SAFETY:
+        // - RoGetActivationFactory is a WinRT API that is safe to call
+        //   after CoInitializeEx has been initialized on this thread.
+        // - ISystemMediaTransportControlsInterop::GetForWindow is safe
+        //   with a valid HWND (either a visible window or a message-only
+        //   window).
+        // - All subsequent SMTC method calls are thread-safe COM/WinRT
+        //   operations that do not violate memory safety.
+        // - The TypedEventHandler closures capture the sender by value
+        //   and do not introduce data races.
+        unsafe {
         let class_id = windows::core::HSTRING::from("Windows.Media.SystemMediaTransportControls");
         let interop: ISystemMediaTransportControlsInterop = RoGetActivationFactory(&class_id)?;
         let smtc: SystemMediaTransportControls = interop.GetForWindow(hwnd)?;
@@ -193,6 +241,7 @@ fn setup_smtc(hwnd: HWND) {
         ))?;
 
         windows::core::Result::Ok(smtc)
+        }
     })();
 
     match result {
@@ -214,6 +263,13 @@ pub fn init() {
         std::thread::spawn(|| {
             // CoInitializeEx must be called on the thread that uses WinRT/COM.
             // The tokio thread pool does not do this, so setup_smtc must run here.
+            // SAFETY:
+            // - CoInitializeEx initializes COM for the calling thread with
+            //   the specified concurrency model (apartment-threaded).
+            // - It is safe to call once per thread; subsequent calls return
+            //   S_FALSE or RPC_E_CHANGED_MODE, which we ignore.
+            // - The None parameter means we are not aggregating another
+            //   COM object.
             unsafe {
                 let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
             }

--- a/player/src/systemint/windows.rs
+++ b/player/src/systemint/windows.rs
@@ -1,3 +1,16 @@
+// Windows system integration: System Media Transport Controls (SMTC),
+// media keys, Now Playing info, and HWND discovery.
+//
+// Architecture:
+// - COM must be initialized on the thread that uses WinRT APIs. Since the
+//   Tokio thread pool does not call CoInitializeEx, setup runs on a
+//   dedicated std::thread::spawn thread.
+// - HWND discovery uses EnumWindows to find the process's visible window.
+//   If none exists yet, a message-only window (HWND_MESSAGE) is created.
+// - SMTC button events (play/pause/next/prev/seek) are forwarded to the
+//   player via an unbounded mpsc channel.
+// - CoInitializeEx + WinRT/COM FFI is documented with // SAFETY: invariants.
+
 use std::sync::OnceLock;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};

--- a/utils/src/stream_buffer.rs
+++ b/utils/src/stream_buffer.rs
@@ -1,6 +1,8 @@
 use std::cmp::min;
 use std::io::{Error as IoError, ErrorKind, Read, Result as IoResult, Seek, SeekFrom};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex, Notify};
 
 const MIN_PREBUFFER_BYTES: usize = 256 * 1024; // 256KB
 
@@ -17,7 +19,7 @@ struct SharedState {
 }
 
 pub struct StreamBuffer {
-    state: Arc<(Mutex<SharedState>, Condvar)>,
+    state: Arc<(Mutex<SharedState>, Notify)>,
     pos: u64,
 }
 
@@ -37,7 +39,7 @@ impl StreamBuffer {
                 total_size: None,
                 prebuffer_ready: false,
             }),
-            Condvar::new(),
+            Notify::new(),
         ));
 
         let state_clone = state.clone();
@@ -53,21 +55,21 @@ impl StreamBuffer {
             match client.get(&url).send().await {
                 Ok(mut response) => {
                     if !response.status().is_success() {
-                        let (lock, cvar) = &*state_clone;
-                        let mut state = lock.lock().unwrap();
+                        let (lock, notify) = &*state_clone;
+                        let mut state = lock.lock().await;
                         state.error = Some(format!("HTTP {}", response.status()));
                         state.done = true;
                         state.prebuffer_ready = true;
-                        cvar.notify_all();
+                        notify.notify_waiters();
                         return;
                     }
 
                     let total_size = response.content_length();
                     {
-                        let (lock, cvar) = &*state_clone;
-                        let mut state = lock.lock().unwrap();
+                        let (lock, notify) = &*state_clone;
+                        let mut state = lock.lock().await;
                         state.total_size = total_size;
-                        cvar.notify_all();
+                        notify.notify_waiters();
                     }
 
                     let mut total_buffered = 0usize;
@@ -79,18 +81,18 @@ impl StreamBuffer {
                         let chunk_len = chunk.len();
 
                         if total_buffered + chunk_len > MAX_BUFFER_SIZE {
-                            let (lock, cvar) = &*state_clone;
-                            let mut state = lock.lock().unwrap();
+                            let (lock, notify) = &*state_clone;
+                            let mut state = lock.lock().await;
                             state.error = Some("Buffer limit exceeded (1GB)".to_string());
                             state.done = true;
                             state.prebuffer_ready = true;
-                            cvar.notify_all();
+                            notify.notify_waiters();
                             break;
                         }
 
                         {
-                            let (lock, cvar) = &*state_clone;
-                            let mut state = lock.lock().unwrap();
+                            let (lock, notify) = &*state_clone;
+                            let mut state = lock.lock().await;
                             state.buffer.extend_from_slice(&chunk);
                             total_buffered += chunk_len;
 
@@ -105,23 +107,23 @@ impl StreamBuffer {
                                 }
                             }
 
-                            cvar.notify_all();
+                            notify.notify_waiters();
                         }
                     }
 
-                    let (lock, cvar) = &*state_clone;
-                    let mut state = lock.lock().unwrap();
+                    let (lock, notify) = &*state_clone;
+                    let mut state = lock.lock().await;
                     state.done = true;
                     state.prebuffer_ready = true;
-                    cvar.notify_all();
+                    notify.notify_waiters();
                 }
                 Err(e) => {
-                    let (lock, cvar) = &*state_clone;
-                    let mut state = lock.lock().unwrap();
+                    let (lock, notify) = &*state_clone;
+                    let mut state = lock.lock().await;
                     state.error = Some(e.to_string());
                     state.done = true;
                     state.prebuffer_ready = true;
-                    cvar.notify_all();
+                    notify.notify_waiters();
                 }
             }
         });
@@ -130,41 +132,47 @@ impl StreamBuffer {
     }
 
     fn wait_for_prebuffer(&self) {
-        let (lock, cvar) = &*self.state;
-        let mut state = lock.lock().unwrap();
-
-        while !state.prebuffer_ready && !state.done {
-            state = cvar.wait(state).unwrap();
+        let (lock, _notify) = &*self.state;
+        loop {
+            let state = lock.blocking_lock();
+            if state.prebuffer_ready || state.done {
+                return;
+            }
+            drop(state);
+            std::thread::sleep(Duration::from_millis(5));
         }
     }
 
     pub fn wait_for_total_size(&self) {
-        let (lock, cvar) = &*self.state;
-        let mut state = lock.lock().unwrap();
-        while state.total_size.is_none() && !state.done {
-            state = cvar.wait(state).unwrap();
+        let (lock, _notify) = &*self.state;
+        loop {
+            let state = lock.blocking_lock();
+            if state.total_size.is_some() || state.done {
+                return;
+            }
+            drop(state);
+            std::thread::sleep(Duration::from_millis(5));
         }
     }
 
     pub fn known_total_size(&self) -> Option<u64> {
         let (lock, _) = &*self.state;
-        let state = lock.lock().unwrap();
+        let state = lock.blocking_lock();
         state.total_size.or(Some(state.buffer.len() as u64))
     }
 
     fn wait_for_buffer_ahead(&self, min_ahead: usize) {
-        let (lock, cvar) = &*self.state;
-        let mut state = lock.lock().unwrap();
-
+        let (lock, _notify) = &*self.state;
         loop {
+            let state = lock.blocking_lock();
             let buffer_len = state.buffer.len() as u64;
             let buffered_ahead = buffer_len.saturating_sub(self.pos) as usize;
 
             if buffered_ahead >= min_ahead || state.done || state.error.is_some() {
                 return;
             }
-
-            state = cvar.wait(state).unwrap();
+            drop(state);
+            std::thread::sleep(Duration::from_millis(5));
         }
     }
 }
@@ -177,7 +185,7 @@ impl Read for StreamBuffer {
 
         {
             let (lock, _) = &*self.state;
-            let state = lock.lock().unwrap();
+            let state = lock.blocking_lock();
             let buffer_len = state.buffer.len() as u64;
             let buffered_ahead = buffer_len.saturating_sub(self.pos) as usize;
 
@@ -187,14 +195,14 @@ impl Read for StreamBuffer {
             }
         }
 
-        let (lock, cvar) = &*self.state;
-        let mut state = lock.lock().unwrap();
-
-        if let Some(err) = &state.error {
-            return Err(IoError::new(ErrorKind::Other, err.clone()));
-        }
-
+        let (lock, _notify) = &*self.state;
         loop {
+            let state = lock.blocking_lock();
+
+            if let Some(err) = &state.error {
+                return Err(IoError::new(ErrorKind::Other, err.clone()));
+            }
+
             let current_len = state.buffer.len() as u64;
 
             if self.pos < current_len {
@@ -214,19 +222,16 @@ impl Read for StreamBuffer {
                 return Ok(0);
             }
 
-            state = cvar.wait(state).unwrap();
-
-            if let Some(err) = &state.error {
-                return Err(IoError::new(ErrorKind::Other, err.clone()));
-            }
+            drop(state);
+            std::thread::sleep(Duration::from_millis(5));
         }
     }
 }
 
 impl Seek for StreamBuffer {
     fn seek(&mut self, pos: SeekFrom) -> IoResult<u64> {
-        let (lock, _cvar) = &*self.state;
-        let state = lock.lock().unwrap();
+        let (lock, _notify) = &*self.state;
+        let state = lock.blocking_lock();
 
         let len = state.buffer.len() as u64;
         let total = state.total_size.unwrap_or(len);

--- a/utils/src/stream_buffer.rs
+++ b/utils/src/stream_buffer.rs
@@ -4,12 +4,28 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{Mutex, Notify};
 
+// Architecture:
+// - A background download task (tokio::spawn) fetches audio chunks via HTTP
+// - Synchronous Read/Seek impls consume the buffer (required by symphonia decoder)
+// - Shared state uses tokio::sync::Mutex so the async task never blocks
+//   a Tokio worker thread with std::sync::Mutex::lock()
+// - The sync side uses blocking_lock() + 5ms polling (acceptable latency for audio)
+// - Prebuffering ensures at least 256KB before first read to avoid starvation
+
 const MIN_PREBUFFER_BYTES: usize = 256 * 1024; // 256KB
 
 const MIN_BUFFER_AHEAD: usize = 128 * 1024; // 128KB
 
 const MAX_BUFFER_SIZE: usize = 1024 * 1024 * 1024; // 1GB
 
+/// Shared state between the async downloader and sync readers.
+///
+/// Fields:
+/// - `buffer`: accumulated audio bytes
+/// - `done`: HTTP stream finished (success or error)
+/// - `error`: reason for failure, if any
+/// - `total_size`: Content-Length header value (may be unknown for radio/streams)
+/// - `prebuffer_ready`: enough data buffered to start playback safely
 struct SharedState {
     buffer: Vec<u8>,
     done: bool,
@@ -44,6 +60,10 @@ impl StreamBuffer {
 
         let state_clone = state.clone();
 
+        // Background download task.
+        // Runs inside tokio::spawn so it integrates with the async runtime.
+        // Shared state access uses tokio::sync::Mutex::lock().await (never blocks
+        // a worker thread). The sync reader side uses blocking_lock() + polling.
         let handle = tokio::runtime::Handle::current();
         handle.spawn(async move {
             let client = reqwest::Client::builder()
@@ -131,6 +151,13 @@ impl StreamBuffer {
         Self { state, pos: 0 }
     }
 
+    // Blocking wait helpers.
+    // These are called from the sync Read impl, so they use blocking_lock()
+    // on the tokio::sync::Mutex. A 5ms polling interval is negligible compared
+    // to network latency (~100ms+) and audio decode times.
+    // The async download side uses Notify::notify_waiters() to wake any
+    // eventual future blocking_lock waiter faster, though polling alone suffices.
+
     fn wait_for_prebuffer(&self) {
         let (lock, _notify) = &*self.state;
         loop {
@@ -195,6 +222,10 @@ impl Read for StreamBuffer {
             }
         }
 
+        // Main read loop:
+        // 1. If data is available at current pos → copy into buf, advance pos, return
+        // 2. If download is finished (done) → return 0 (EOF) or error
+        // 3. Otherwise → wait for more data from the download task and retry
         let (lock, _notify) = &*self.state;
         loop {
             let state = lock.blocking_lock();


### PR DESCRIPTION
- Replace std::sync::Mutex with tokio::sync::Mutex in stream_buffer to
  avoid blocking Tokio worker threads
- Add // SAFETY: comments to all unsafe blocks in macos.rs and windows.rs
- Add module-level architecture docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded safety documentation for macOS and Windows platform integrations to improve reliability and maintainability.

* **Refactor**
  * Reworked stream buffering and synchronization for a more robust async download + sync read model, improving playback stability and prebuffering behavior.
  * Internal media-controls handling on Windows simplified for increased stability.

* **Bug Fixes**
  * Updated artwork handling to load provided artwork directly, reducing stale-cache issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->