### PR TITLE
chore: delete Nix result symlink; gitignore Nix build results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ dist/
 devenv.local.nix
 devenv.local.yaml
 
-# direnv
+# Nix
 .direnv
+/result*
 
 # pre-commit
 .pre-commit-config.yaml

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/axqxhclxj69iw8w6g5xxbf7zr3zfa61z-kopuz-0.5.0


### PR DESCRIPTION
Part 1 of a large refactor as coordinated with @temidaradev. Removes the accidental `result` symlink copied into the repository, and permanently gitignores it to avoid similar accidents in the future.

Change-Id: I3379e6bc4e9e38616f4625499b9d671e6a6a6964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` configuration to refine ignored paths for development tooling, including expanded patterns for Nix-related directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->