### PR TITLE
fix(reader): fall back to symphonia duration when Lofty returns 0

### DIFF
--- a/reader/src/metadata.rs
+++ b/reader/src/metadata.rs
@@ -198,8 +198,12 @@ pub fn read(track_path: &Path, cover_cache: &Path, library: &mut Library) -> Opt
         let (s_duration, s_sample_rate, s_bitrate) = symphonia_duration(track_path);
         if s_duration > 0 {
             track.duration = s_duration;
-            track.khz = s_sample_rate;
-            track.bitrate = s_bitrate;
+            if s_sample_rate > 0 {
+                track.khz = s_sample_rate;
+            }
+            if s_bitrate > 0 {
+                track.bitrate = s_bitrate;
+            }
         }
     }
 

--- a/reader/src/metadata.rs
+++ b/reader/src/metadata.rs
@@ -155,7 +155,7 @@ pub fn read(track_path: &Path, cover_cache: &Path, library: &mut Library) -> Opt
         .primary_tag()
         .or_else(|| tagged_file.first_tag());
 
-    let track = extract_metadata(tag, properties, track_path);
+    let mut track = extract_metadata(tag, properties, track_path);
     let album_id = track.album_id.clone();
 
     let album_artist = tag
@@ -194,8 +194,68 @@ pub fn read(track_path: &Path, cover_cache: &Path, library: &mut Library) -> Opt
         });
     }
 
+    if track.duration == 0 {
+        let (s_duration, s_sample_rate, s_bitrate) = symphonia_duration(track_path);
+        if s_duration > 0 {
+            track.duration = s_duration;
+            track.khz = s_sample_rate;
+            track.bitrate = s_bitrate;
+        }
+    }
+
     library.add_track(track.clone());
     Some(track)
+}
+
+fn symphonia_duration(track_path: &Path) -> (u64, u32, u16) {
+    let file = match std::fs::File::open(track_path) {
+        Ok(f) => f,
+        Err(_) => return (0, 0, 0),
+    };
+    let file_size = file.metadata().ok().map(|m| m.len()).unwrap_or(0);
+
+    let mut hint = Hint::new();
+    if let Some(ext) = track_path.extension().and_then(|ext| ext.to_str()) {
+        hint.with_extension(ext);
+    }
+
+    let mut sample_rate = 0u32;
+    let mut duration = 0u64;
+
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    if let Ok(probed) = symphonia::default::get_probe().format(
+        &hint,
+        mss,
+        &FormatOptions::default(),
+        &MetadataOptions::default(),
+    ) {
+        if let Some(track_info) = probed
+            .format
+            .tracks()
+            .iter()
+            .find(|track| track.codec_params.codec != CODEC_TYPE_NULL)
+            .or_else(|| probed.format.tracks().first())
+        {
+            let codec_params = &track_info.codec_params;
+            sample_rate = codec_params.sample_rate.unwrap_or(0);
+            duration = codec_params
+                .time_base
+                .zip(codec_params.n_frames)
+                .map(|(time_base, n_frames)| {
+                    let time = time_base.calc_time(n_frames);
+                    time.seconds + u64::from(time.frac > 0.0)
+                })
+                .unwrap_or(0);
+        }
+    }
+
+    let bitrate = if duration > 0 {
+        ((file_size * 8) / duration / 1000).min(u16::MAX as u64) as u16
+    } else {
+        0
+    };
+
+    (duration, sample_rate, bitrate)
 }
 
 fn is_matroska_audio(track_path: &Path) -> bool {


### PR DESCRIPTION
## Description
When Lofty cannot read metadata duration from certain audio files (e.g. YouTube downloads, MP4 audio without proper tags), `track.duration` was set to 0. This caused the progress bar in `use_player_task.rs` to evaluate `pos.as_secs().min(0) == 0`, permanently clamping the progress display to 0.

## Fix
Added `symphonia_duration()` in `reader/src/metadata.rs:210-259` that re-opens the file with Symphonia's format probe and extracts the real duration from codec `time_base × n_frames`. If this yields `duration > 0`, the `Track` fields `duration`, `khz` (sample rate), and `bitrate` are updated.

The fix is applied at the **scanner** level so all downstream consumers (UI, SMTC, scrobbler) see the correct duration immediately.

Part of the ongoing progress-bar correctness fixes. See also PR #251 (async safety & comments).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio files with missing or zero duration metadata are now automatically analyzed to determine duration, sample rate, and bitrate by probing the media file.

* **Bug Fixes**
  * More reliable handling and population of track metadata when original metadata is incomplete or zero, reducing incorrect zero-duration entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->