### PR TITLE
fix(showcase): make play button respect shuffle toggle

### DIFF
--- a/crates/components/src/modern/showcase.rs
+++ b/crates/components/src/modern/showcase.rs
@@ -108,7 +108,13 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                             button {
                                 class: "inline-flex items-center justify-center gap-2 h-9 px-5 rounded-full text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95",
                                 style: "background: var(--color-indigo-500);",
-                                onclick: move |_| ctrl.play_queue_linear(tracks_for_play_all.clone()),
+                                onclick: move |_| {
+                                    if *ctrl.shuffle.peek() {
+                                        ctrl.play_queue_shuffled(tracks_for_play_all.clone());
+                                    } else {
+                                        ctrl.play_queue_linear(tracks_for_play_all.clone());
+                                    }
+                                },
                                 i { class: "fa-solid fa-play text-xs" }
                                 "{i18n::t(\"play\")}"
                             }

--- a/crates/components/src/modern/showcase.rs
+++ b/crates/components/src/modern/showcase.rs
@@ -109,7 +109,8 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                                 class: "inline-flex items-center justify-center gap-2 h-9 px-5 rounded-full text-sm font-semibold text-white transition-opacity hover:opacity-90 active:scale-95",
                                 style: "background: var(--color-indigo-500);",
                                 onclick: move |_| {
-                                    if *ctrl.shuffle.peek() {
+                                    let is_shuffle = *ctrl.shuffle.peek();
+                                    if is_shuffle {
                                         ctrl.play_queue_shuffled(tracks_for_play_all.clone());
                                     } else {
                                         ctrl.play_queue_linear(tracks_for_play_all.clone());

--- a/crates/components/src/normal/showcase.rs
+++ b/crates/components/src/normal/showcase.rs
@@ -126,7 +126,8 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                         button {
                              class: "w-14 h-14 rounded-full bg-indigo-500 hover:bg-indigo-400 text-black flex items-center justify-center transition-transform hover:scale-105",
                              onclick: move |_| {
-                                if *ctrl.shuffle.peek() {
+                                let is_shuffle = *ctrl.shuffle.peek();
+                                if is_shuffle {
                                     ctrl.play_queue_shuffled(tracks_for_play_all.clone());
                                 } else {
                                     ctrl.play_queue_linear(tracks_for_play_all.clone());

--- a/crates/components/src/normal/showcase.rs
+++ b/crates/components/src/normal/showcase.rs
@@ -125,7 +125,13 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                         }
                         button {
                              class: "w-14 h-14 rounded-full bg-indigo-500 hover:bg-indigo-400 text-black flex items-center justify-center transition-transform hover:scale-105",
-                             onclick: move |_| ctrl.play_queue_linear(tracks_for_play_all.clone()),
+                             onclick: move |_| {
+                                if *ctrl.shuffle.peek() {
+                                    ctrl.play_queue_shuffled(tracks_for_play_all.clone());
+                                } else {
+                                    ctrl.play_queue_linear(tracks_for_play_all.clone());
+                                }
+                             },
                              i { class: "fa-solid fa-play text-xl ml-1" }
                          }
                          if props.on_download_all.is_some() || props.on_delete_all.is_some() {


### PR DESCRIPTION
# Description
The play button in ShowcaseModern and ShowcaseNormal calls play_queue_linear regardless of the shuffle toggle, clicking play on a playlist, local album or artist would always start with the first track even with the shuffle toggle on

### Affected pages:
- Local Album detail
- Playlist detail
- Artist detail

- (Partial) Server Album detail: previously the play button already had the correct shuffle logic but would always display the first track playing within the tracklist

### Fix: 
Add a `ctrl.shuffle` check like in `pages/src/server/album.rs:556` to `components/src/modern/showcase.rs:111` and `components/src/normal/showcase.rs:128` 

Tested on linux on subsonic server and local album, artist and playlist pages 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed play button to respect the shuffle toggle. Playback now respects your shuffle setting, queuing songs in shuffled order when enabled and normal order when disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->