### PR TITLE
fix(playlists): use playlist cover art path

### DIFF
--- a/crates/pages/src/local/playlists.rs
+++ b/crates/pages/src/local/playlists.rs
@@ -84,18 +84,11 @@ pub fn LocalPlaylists(
             .as_ref()
             .and_then(|path| utils::format_artwork_url(Some(path)))
             .or_else(|| {
-                playlist
-                    .tracks
-                    .first()
-                    .and_then(|first_path| {
-                        lib.tracks.iter().find(|t| t.path == *first_path)
-                    })
-                    .and_then(|track| {
-                        lib.albums.iter().find(|a| a.id == track.album_id)
-                    })
-                    .and_then(|album| {
-                        utils::format_artwork_url(album.cover_path.as_ref())
-                    })
+                let first_path = playlist.tracks.first()?;
+                let track = lib.tracks.iter().find(|t| t.path == *first_path)?;
+                let album = lib.albums.iter().find(|a| a.id == track.album_id)?;
+    
+                utils::format_artwork_url(album.cover_path.as_ref())
             })
     };
 

--- a/crates/pages/src/local/playlists.rs
+++ b/crates/pages/src/local/playlists.rs
@@ -78,6 +78,13 @@ pub fn LocalPlaylists(
     let cover_for = |pid: &str| -> Option<utils::CoverUrl> {
         let store = playlist_store.read();
         let playlist = store.playlists.iter().find(|p| p.id == pid)?;
+
+        if let Some(path) = playlist.cover_path.as_ref() {
+            if let Some(url) = utils::format_artwork_url(Some(path)) {
+                return Some(url);
+            }
+        }
+
         let first_path = playlist.tracks.first()?;
         let track = lib.tracks.iter().find(|t| t.path == *first_path)?;
         let album = lib.albums.iter().find(|a| a.id == track.album_id)?;

--- a/crates/pages/src/local/playlists.rs
+++ b/crates/pages/src/local/playlists.rs
@@ -78,17 +78,25 @@ pub fn LocalPlaylists(
     let cover_for = |pid: &str| -> Option<utils::CoverUrl> {
         let store = playlist_store.read();
         let playlist = store.playlists.iter().find(|p| p.id == pid)?;
-
-        if let Some(path) = playlist.cover_path.as_ref() {
-            if let Some(url) = utils::format_artwork_url(Some(path)) {
-                return Some(url);
-            }
-        }
-
-        let first_path = playlist.tracks.first()?;
-        let track = lib.tracks.iter().find(|t| t.path == *first_path)?;
-        let album = lib.albums.iter().find(|a| a.id == track.album_id)?;
-        utils::format_artwork_url(album.cover_path.as_ref())
+    
+        playlist
+            .cover_path
+            .as_ref()
+            .and_then(|path| utils::format_artwork_url(Some(path)))
+            .or_else(|| {
+                playlist
+                    .tracks
+                    .first()
+                    .and_then(|first_path| {
+                        lib.tracks.iter().find(|t| t.path == *first_path)
+                    })
+                    .and_then(|track| {
+                        lib.albums.iter().find(|a| a.id == track.album_id)
+                    })
+                    .and_then(|album| {
+                        utils::format_artwork_url(album.cover_path.as_ref())
+                    })
+            })
     };
 
     rsx! {


### PR DESCRIPTION
fix or feet idk

resolve #272 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Playlist covers now prefer a playlist's custom cover (converted to a usable cover URL) when available, and otherwise fall back to using the album artwork from the playlist's first track. This improves visual consistency and ensures playlists display meaningful artwork even if a custom cover isn't set.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->