### PR TITLE
fix(find_folder_cover): fix case-insensitive cover detection

### DIFF
--- a/crates/reader/src/utils.rs
+++ b/crates/reader/src/utils.rs
@@ -36,10 +36,16 @@ pub fn find_folder_cover(dir: &Path) -> Option<PathBuf> {
         if !path.is_file() {
             continue;
         }
-        let stem = path.file_stem().and_then(|s| s.to_str())?;
-        let ext = path.extension().and_then(|e| e.to_str())?;
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Some(ext) = path.extension().and_then(|e| e.to_str()) else {
+            continue;
+        };
 
-        if candidates.iter().any(|c| c.eq_ignore_ascii_case(stem)) && extensions.iter().any(|e| e.eq_ignore_ascii_case(ext)) {
+        if candidates.iter().any(|c| c.eq_ignore_ascii_case(stem))
+            && extensions.iter().any(|e| e.eq_ignore_ascii_case(ext))
+        {
             return Some(path);
         }
     }

--- a/crates/reader/src/utils.rs
+++ b/crates/reader/src/utils.rs
@@ -27,12 +27,20 @@ fn remove_stale_cover_variants(album_id: &str, cache_dir: &Path, keep_path: &Pat
 }
 
 pub fn find_folder_cover(dir: &Path) -> Option<PathBuf> {
-    let candidates = ["cover.jpg", "cover.png", "folder.jpg", "album.jpg"];
+    let candidates = ["cover", "folder", "album"];
+    let extensions = ["jpg", "jpeg", "png", "webp"];
 
-    for name in candidates {
-        let p = dir.join(name);
-        if p.exists() {
-            return Some(p);
+    let entries = std::fs::read_dir(dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let stem = path.file_stem().and_then(|s| s.to_str())?;
+        let ext = path.extension().and_then(|e| e.to_str())?;
+
+        if candidates.iter().any(|c| c.eq_ignore_ascii_case(stem)) && extensions.iter().any(|e| e.eq_ignore_ascii_case(ext)) {
+            return Some(path);
         }
     }
     None


### PR DESCRIPTION
# Description

## Problem
find_folder_cover checks for cover art by joining hardcoded lowercase names (cover.jpg, folder.jpg, etc.) to the directory path and calling .exists(). On Linux (never tried other OS) this silently misses files like Cover.jpg or COVER.PNG since the filesystem is case-sensitive.
As a result, albums that already have folder art on disk get treated as coverless.

## Fix
This PR updates comparisons to use `eq_ignore_ascii_case`, enabling case-insensitive matching for file stems and extensions, so any casing variant is correctly matched.

fixes: #282 

## Preview

Before:
<img width="800" height="272" alt="image" src="https://github.com/user-attachments/assets/5dbe2ec0-a680-4d69-a57a-ee9969593392" />
After:
<img width="426" height="299" alt="image" src="https://github.com/user-attachments/assets/302db7b2-89e5-457b-aca8-e5d9958de530" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved folder cover image detection: the app now scans directories for files whose base name matches cover/folder/album (case-insensitive) and accepts jpg, jpeg, png, webp (case-insensitive). It returns the first matching image found, improving compatibility with varied naming and formats and increasing the likelihood a cover image is displayed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->