### PR TITLE
Add yt-dlp related dependencies as optional dependencies in the PKGBUILD

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -17,7 +17,7 @@ depends=(
     'dbus'
     'cmake'
     'opus'
-    'extra/python-mutagen'
+    'python-mutagen'
 )
 makedepends=(
     'rust'

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -17,6 +17,7 @@ depends=(
     'dbus'
     'cmake'
     'opus'
+    'extra/python-mutagen'
 )
 makedepends=(
     'rust'

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -17,8 +17,13 @@ depends=(
     'dbus'
     'cmake'
     'opus'
+)
+
+optdepends=(
+    'yt-dlp'
     'python-mutagen'
 )
+
 makedepends=(
     'rust'
     'cargo'


### PR DESCRIPTION
When downloading the package through AUR, it should show some information about optional dependencies you can download for the app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Arch packaging metadata to add an optional runtime dependency: python-mutagen.
  * Packaging otherwise unchanged (no modifications to build steps, install logic, or other metadata).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->