### PR TITLE
Add polish and english locale for playing and shuffling in albums

### DIFF
--- a/locales/ar.ftl
+++ b/locales/ar.ftl
@@ -76,6 +76,10 @@ create = إنشاء
 save = حفظ
 enabled = مفعّل
 disabled = مُعطّل
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = المقاطع

--- a/locales/de.ftl
+++ b/locales/de.ftl
@@ -76,6 +76,10 @@ create = Erstellen
 save = Speichern
 enabled = AKTIVIERT
 disabled = DEAKTIVIERT
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Titel

--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -142,6 +142,8 @@ maximize = Maximize
 close = Close
 enabled = ENABLED
 disabled = DISABLED
+play = Play
+shuffle = Shuffle
 
 # Navigation & Headers
 tracks = Tracks

--- a/locales/es.ftl
+++ b/locales/es.ftl
@@ -76,6 +76,10 @@ create = Crear
 save = Guardar
 enabled = Habilitado
 disabled = Deshabilitado
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Pistas

--- a/locales/fr.ftl
+++ b/locales/fr.ftl
@@ -72,6 +72,10 @@ create = Crée
 save = Sauvegarder
 enabled = Activé
 disabled = Désactivé
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Tracks

--- a/locales/gr.ftl
+++ b/locales/gr.ftl
@@ -76,6 +76,10 @@ create = Δημιουργία
 save = Αποθήκευση
 enabled = Ενεργό
 disabled = Ανενεργό
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Κομμάτια

--- a/locales/he.ftl
+++ b/locales/he.ftl
@@ -76,6 +76,10 @@ create = יצירה
 save = שמירה
 enabled = מופעל
 disabled = מושבת
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = שירים

--- a/locales/hu.ftl
+++ b/locales/hu.ftl
@@ -76,6 +76,10 @@ create = Létrehozás
 save = Mentés
 enabled = BE
 disabled = KI
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Dalok

--- a/locales/id.ftl
+++ b/locales/id.ftl
@@ -131,6 +131,10 @@ maximize = Maksimalkan
 close = Tutup
 enabled = AKTIF
 disabled = NONAKTIF
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Lagu

--- a/locales/ja.ftl
+++ b/locales/ja.ftl
@@ -76,6 +76,10 @@ create = 作成
 save = 保存
 enabled = 有効
 disabled = 無効
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = トラック

--- a/locales/ko.ftl
+++ b/locales/ko.ftl
@@ -76,6 +76,10 @@ create = 만들기
 save = 저장
 enabled = 켜짐
 disabled = 꺼짐
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = 트랙

--- a/locales/pl.ftl
+++ b/locales/pl.ftl
@@ -74,6 +74,8 @@ create = Utwórz
 save = Zapisz
 enabled = WŁĄCZONE
 disabled = WYŁĄCZONE
+shuffle = Odtwarzaj losowo
+play = Odtwórz
 
 # Navigation & Headers
 tracks = Ścieżki

--- a/locales/pt-BR.ftl
+++ b/locales/pt-BR.ftl
@@ -131,6 +131,10 @@ maximize = Maximizar
 close = Fechar
 enabled = ATIVADO
 disabled = DESATIVADO
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Faixas

--- a/locales/ro.ftl
+++ b/locales/ro.ftl
@@ -76,6 +76,10 @@ create = Creează
 save = Salvează
 enabled = PORNIT
 disabled = OPRIT
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Piese

--- a/locales/ru.ftl
+++ b/locales/ru.ftl
@@ -76,6 +76,10 @@ create = Создать
 save = Сохранить
 enabled = АКТИВНО
 disabled = ОТКЛЮЧЕНО
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Треки

--- a/locales/tok-SP.ftl
+++ b/locales/tok-SP.ftl
@@ -72,6 +72,10 @@ create = 󱥄󱥉
 save = 󱥄󱤖󱤓
 enabled = 󱤬
 disabled = 󱤬󱤂
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = 󱤕󱤻

--- a/locales/tok.ftl
+++ b/locales/tok.ftl
@@ -76,6 +76,10 @@ create = o pali
 save = o kama jo
 enabled = LON
 disabled = LON ALA
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = kalama musi

--- a/locales/tr.ftl
+++ b/locales/tr.ftl
@@ -76,6 +76,10 @@ create = Oluştur
 save = Kaydet
 enabled = ETKİN
 disabled = DEVRE DIŞI
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Parçalar

--- a/locales/uk.ftl
+++ b/locales/uk.ftl
@@ -76,6 +76,10 @@ create = Створити
 save = Зберегти
 enabled = УВІМКНЕНО
 disabled = ВИМКНЕНО
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = Треки

--- a/locales/zh-CN.ftl
+++ b/locales/zh-CN.ftl
@@ -76,6 +76,10 @@ create = 创建
 save = 保存
 enabled = 已启用
 disabled = 已禁用
+# TODO: Translate lines below
+play = Play
+shuffle = Shuffle
+# ------
 
 # Navigation & Headers
 tracks = 曲目


### PR DESCRIPTION
Resolves https://github.com/Kopuz-org/kopuz/issues/304 and also adds TODOs for other languages so CI won't complain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized UI strings for the player controls "Play" and "Shuffle" in 20 languages (including English, German, French, Spanish, Polish, Japanese, Chinese, Korean, etc.). Some locales include completed translations (e.g., Polish); many entries are marked TODO and will be completed in follow-up updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->