### PR TITLE
Fix active line lookup condition

### DIFF
--- a/crates/components/src/lyrics_view.rs
+++ b/crates/components/src/lyrics_view.rs
@@ -87,15 +87,16 @@ pub fn LyricsView(
 
                 loop {
                     let current_time = ctrl.displayed_progress_secs_f64();
+                    // Binary search to find the active line.
+                    // `partition_point(|t| t <= current_time)` returns the index of the first
+                    // timestamp greater than `current_time`.
+                    // Therefore `n - 1` is the last timestamp less than or equal to it.
+                    // If the result is 0, we are before the first line.
                     if let Some(current_line_index) =
-                        // Binary search to find the next line to display
-                        // `partition_point` returns the index of the first element that is greater or equal than `current_time`
-                        // so we subtract 1 to get the index of the last element that is less than to `current_time`.
-                        // 0 means that the first element is greater or equal than `current_time`, so we are before the first line.
-                        match times.partition_point(|&t| t < current_time) {
-                                0 => None,
-                                n => Some(n - 1),
-                            }
+                        match times.partition_point(|&t| t <= current_time) {
+                            0 => None,
+                            n => Some(n - 1),
+                        }
                     {
                         let _ = eval(&format!("window.__{layout}_updateLyrics({current_line_index})"));
 


### PR DESCRIPTION
This ensures that when `current_time` exactly matches a timestamp, the corresponding line is selected as active rather than the previous one. This was likely only noticeable when manually seeking through line selection while the playback was paused.

Also cleaned up and clarified the comments about the `partition_point` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timing accuracy for lyric line synchronization during playback to better align with current audio position.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->