### PR TITLE
Add check if a file is from a server

### DIFF
--- a/crates/components/src/track_row.rs
+++ b/crates/components/src/track_row.rs
@@ -9,6 +9,7 @@ use config::{AppConfig, UiStyle};
 use dioxus::prelude::*;
 use hooks::PlayerController;
 use reader::models::Track;
+use config::MusicSource;
 
 #[component]
 pub fn TrackRow(
@@ -90,13 +91,20 @@ pub fn TrackRow(
     }
 
     let has_download = on_download.is_some();
+    let is_server = config.read().active_source == MusicSource::Server;
+
     if has_download {
         let (dl_label, dl_icon) = if is_downloading {
             ("Downloading...", "fa-solid fa-spinner fa-spin")
         } else if is_downloaded {
             ("Remove Download", "fa-solid fa-trash-can")
-        } else {
+        } else if is_server {
             ("Download Offline", "fa-solid fa-download")
+        } else {
+            // TODO: Please tell me what should I put here
+            // because the compiler won't stop crying to put an `else` block here
+            // for god knows why??????
+            ("", "")
         };
         let mut action = MenuAction::new(dl_label, dl_icon);
         if is_downloaded {

--- a/crates/components/src/track_row.rs
+++ b/crates/components/src/track_row.rs
@@ -92,19 +92,15 @@ pub fn TrackRow(
 
     let has_download = on_download.is_some();
     let is_server = config.read().active_source == MusicSource::Server;
+    let has_download = has_download && is_server;
 
     if has_download {
         let (dl_label, dl_icon) = if is_downloading {
             ("Downloading...", "fa-solid fa-spinner fa-spin")
         } else if is_downloaded {
             ("Remove Download", "fa-solid fa-trash-can")
-        } else if is_server {
-            ("Download Offline", "fa-solid fa-download")
         } else {
-            // TODO: Please tell me what should I put here
-            // because the compiler won't stop crying to put an `else` block here
-            // for god knows why??????
-            ("", "")
+            ("Download Offline", "fa-solid fa-download")
         };
         let mut action = MenuAction::new(dl_label, dl_icon);
         if is_downloaded {


### PR DESCRIPTION
Fixes https://github.com/Kopuz-org/kopuz/issues/303

I wanted to also initially refactor this if else chain into a match, but the compiler kept complaining so I just stuck with the if else chain.

Before merging please test the PR because I don't have a jellyfin server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Download menu now displays "Download Offline" option for server-based music sources.

* **Improvements**
  * Enhanced music source detection in download functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->