### PR TITLE
fix: add musicbrainz metadata as additional info on scrobbling

### DIFF
--- a/crates/components/src/playlist_detail.rs
+++ b/crates/components/src/playlist_detail.rs
@@ -66,9 +66,19 @@ pub fn PlaylistDetail(
                     let server_info = {
                         let conf = config.peek();
                         conf.server.as_ref().and_then(|server| {
-                            if let (Some(token), Some(user_id)) = (&server.access_token, &server.user_id) {
-                                Some((server.service.clone(), server.url.clone(), token.clone(), conf.device_id.clone(), user_id.clone()))
-                            } else { None }
+                            if let (Some(token), Some(user_id)) =
+                                (&server.access_token, &server.user_id)
+                            {
+                                Some((
+                                    server.service.clone(),
+                                    server.url.clone(),
+                                    token.clone(),
+                                    conf.device_id.clone(),
+                                    user_id.clone(),
+                                ))
+                            } else {
+                                None
+                            }
                         })
                     };
                     if let Some((service, url, token, device_id, user_id)) = server_info {
@@ -80,121 +90,109 @@ pub fn PlaylistDetail(
                                     &device_id,
                                     Some(&user_id),
                                 );
-                                    if let Ok(items) = remote.get_playlist_items(&pid_clone).await {
-                                        let mut new_tracks = Vec::new();
-                                        for item in items {
-                                            let duration_secs =
-                                                item.run_time_ticks.unwrap_or(0) / 10_000_000;
-                                            let mut path_str = format!("jellyfin:{}", item.id);
-                                            if let Some(tags) = &item.image_tags {
-                                                if let Some(tag) = tags.get("Primary") {
-                                                    path_str.push_str(&format!(":{}", tag));
-                                                }
+                                if let Ok(items) = remote.get_playlist_items(&pid_clone).await {
+                                    let mut new_tracks = Vec::new();
+                                    for item in items {
+                                        let duration_secs =
+                                            item.run_time_ticks.unwrap_or(0) / 10_000_000;
+                                        let mut path_str = format!("jellyfin:{}", item.id);
+                                        if let Some(tags) = &item.image_tags {
+                                            if let Some(tag) = tags.get("Primary") {
+                                                path_str.push_str(&format!(":{}", tag));
                                             }
-                                            let bitrate_kbps = item.bitrate.unwrap_or(0) / 1000;
-                                            let bitrate_u16 =
-                                                bitrate_kbps.min(u16::MAX as u32) as u16;
-                                            let artist_str = item
-                                                .album_artist
-                                                .clone()
-                                                .or_else(|| {
-                                                    item.artists.as_ref().map(|a| a.join(", "))
-                                                })
-                                                .unwrap_or_default();
-                                            new_tracks.push(reader::models::Track {
-                                                path: PathBuf::from(path_str),
-                                                album_id: item
-                                                    .album_id
-                                                    .map(|id| format!("jellyfin:{}", id))
-                                                    .unwrap_or_default(),
-                                                title: item.name,
-                                                artist: artist_str,
-                                                album: item.album.unwrap_or_default(),
-                                                duration: duration_secs,
-                                                khz: item.sample_rate.unwrap_or(0),
-                                                bitrate: bitrate_u16,
-                                                track_number: item.index_number,
-                                                disc_number: item.parent_index_number,
-                                                musicbrainz_release_id: None,
-                                                playlist_item_id: item.playlist_item_id,
-                                                artists: item.artists.unwrap_or_default(),
-                                            });
                                         }
-                                        tracks.set(new_tracks);
-                                        has_loaded_jellyfin_tracks.set(true);
-                                    }
-                                }
-                                MusicService::Subsonic | MusicService::Custom => {
-                                    let remote = server::subsonic::SubsonicClient::new(
-                                        &url,
-                                        &user_id,
-                                        &token,
-                                    );
-                                    if let Ok(items) = remote.get_playlist_entries(&pid_clone).await
-                                    {
-                                        let mut new_tracks = Vec::new();
-                                        for item in items {
-                                            let cover_tag = item
-                                                .cover_art
-                                                .as_ref()
-                                                .and_then(|id| {
-                                                    remote.cover_art_url(id, Some(512)).ok()
-                                                })
-                                                .map(|url| {
-                                                    let mut hex =
-                                                        String::with_capacity(url.len() * 2);
-                                                    for b in url.as_bytes() {
-                                                        hex.push_str(&format!("{:02x}", b));
-                                                    }
-                                                    format!("urlhex_{}", hex)
-                                                });
-                                            let path = if let Some(tag) = &cover_tag {
-                                                PathBuf::from(format!(
-                                                    "jellyfin:{}:{}",
-                                                    item.id, tag
-                                                ))
-                                            } else {
-                                                PathBuf::from(format!("jellyfin:{}", item.id))
-                                            };
-                                            let album_id = item
+                                        let bitrate_kbps = item.bitrate.unwrap_or(0) / 1000;
+                                        let bitrate_u16 = bitrate_kbps.min(u16::MAX as u32) as u16;
+                                        let artist_str = item
+                                            .album_artist
+                                            .clone()
+                                            .or_else(|| item.artists.as_ref().map(|a| a.join(", ")))
+                                            .unwrap_or_default();
+                                        new_tracks.push(reader::models::Track {
+                                            path: PathBuf::from(path_str),
+                                            album_id: item
                                                 .album_id
-                                                .as_ref()
-                                                .map(|id| {
-                                                    if let Some(tag) = &cover_tag {
-                                                        format!("jellyfin:{}:{}", id, tag)
-                                                    } else {
-                                                        format!("jellyfin:{}:none", id)
-                                                    }
-                                                })
-                                                .unwrap_or_else(|| {
-                                                    format!("jellyfin:{}:none", item.id)
-                                                });
-                                            new_tracks.push(reader::models::Track {
-                                                path,
-                                                album_id,
-                                                title: item.title,
-                                                artist: item.artist.clone().unwrap_or_default(),
-                                                album: item.album.unwrap_or_default(),
-                                                duration: item.duration.unwrap_or(0),
-                                                khz: item.sampling_rate.unwrap_or(0),
-                                                bitrate: item
-                                                    .bit_rate
-                                                    .unwrap_or(0)
-                                                    .min(u16::MAX as u32)
-                                                    as u16,
-                                                track_number: item.track,
-                                                disc_number: item.disc_number,
-                                                musicbrainz_release_id: None,
-                                                playlist_item_id: None,
-                                                artists: vec![item.artist.unwrap_or_default()],
-                                            });
-                                        }
-                                        tracks.set(new_tracks);
-                                        has_loaded_jellyfin_tracks.set(true);
+                                                .map(|id| format!("jellyfin:{}", id))
+                                                .unwrap_or_default(),
+                                            title: item.name,
+                                            artist: artist_str,
+                                            album: item.album.unwrap_or_default(),
+                                            duration: duration_secs,
+                                            khz: item.sample_rate.unwrap_or(0),
+                                            bitrate: bitrate_u16,
+                                            track_number: item.index_number,
+                                            disc_number: item.parent_index_number,
+                                            musicbrainz_release_id: None,
+                                            musicbrainz_recording_id: None,
+                                            musicbrainz_track_id: None,
+                                            playlist_item_id: item.playlist_item_id,
+                                            artists: item.artists.unwrap_or_default(),
+                                        });
                                     }
+                                    tracks.set(new_tracks);
+                                    has_loaded_jellyfin_tracks.set(true);
+                                }
+                            }
+                            MusicService::Subsonic | MusicService::Custom => {
+                                let remote =
+                                    server::subsonic::SubsonicClient::new(&url, &user_id, &token);
+                                if let Ok(items) = remote.get_playlist_entries(&pid_clone).await {
+                                    let mut new_tracks = Vec::new();
+                                    for item in items {
+                                        let cover_tag = item
+                                            .cover_art
+                                            .as_ref()
+                                            .and_then(|id| remote.cover_art_url(id, Some(512)).ok())
+                                            .map(|url| {
+                                                let mut hex = String::with_capacity(url.len() * 2);
+                                                for b in url.as_bytes() {
+                                                    hex.push_str(&format!("{:02x}", b));
+                                                }
+                                                format!("urlhex_{}", hex)
+                                            });
+                                        let path = if let Some(tag) = &cover_tag {
+                                            PathBuf::from(format!("jellyfin:{}:{}", item.id, tag))
+                                        } else {
+                                            PathBuf::from(format!("jellyfin:{}", item.id))
+                                        };
+                                        let album_id = item
+                                            .album_id
+                                            .as_ref()
+                                            .map(|id| {
+                                                if let Some(tag) = &cover_tag {
+                                                    format!("jellyfin:{}:{}", id, tag)
+                                                } else {
+                                                    format!("jellyfin:{}:none", id)
+                                                }
+                                            })
+                                            .unwrap_or_else(|| {
+                                                format!("jellyfin:{}:none", item.id)
+                                            });
+                                        new_tracks.push(reader::models::Track {
+                                            path,
+                                            album_id,
+                                            title: item.title,
+                                            artist: item.artist.clone().unwrap_or_default(),
+                                            album: item.album.unwrap_or_default(),
+                                            duration: item.duration.unwrap_or(0),
+                                            khz: item.sampling_rate.unwrap_or(0),
+                                            bitrate: item.bit_rate.unwrap_or(0).min(u16::MAX as u32)
+                                                as u16,
+                                            track_number: item.track,
+                                            disc_number: item.disc_number,
+                                            musicbrainz_release_id: None,
+                                            musicbrainz_recording_id: None,
+                                            musicbrainz_track_id: None,
+                                            playlist_item_id: None,
+                                            artists: vec![item.artist.unwrap_or_default()],
+                                        });
+                                    }
+                                    tracks.set(new_tracks);
+                                    has_loaded_jellyfin_tracks.set(true);
                                 }
                             }
                         }
+                    }
                 });
             }
         });

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -5,6 +5,7 @@ use dioxus::{logger::tracing, prelude::*};
 use player::player::{NowPlayingMeta, Player};
 use reader::{Library, Track};
 use scrobble;
+use std::collections::HashMap;
 use std::time::Duration;
 use utils;
 
@@ -828,6 +829,7 @@ impl PlayerController {
                                                     &scrobble_track.artist,
                                                     &scrobble_track.title,
                                                     Some(&scrobble_track.album),
+                                                    None,
                                                 );
                                             if let Err(e) = scrobble::musicbrainz::submit_listens(
                                                 &auth,
@@ -938,6 +940,7 @@ impl PlayerController {
                                                 &scrobble_track.artist,
                                                 &scrobble_track.title,
                                                 Some(&scrobble_track.album),
+                                                None,
                                             );
                                             match scrobble::musicbrainz::submit_listens(
                                                 &auth,
@@ -1131,6 +1134,7 @@ impl PlayerController {
                                                     &scrobble_track.artist,
                                                     &scrobble_track.title,
                                                     Some(&scrobble_track.album),
+                                                    None,
                                                 );
                                             if let Err(e) = scrobble::musicbrainz::submit_listens(
                                                 &auth,
@@ -1237,6 +1241,7 @@ impl PlayerController {
                                                 &scrobble_track.artist,
                                                 &scrobble_track.title,
                                                 Some(&scrobble_track.album),
+                                                None,
                                             );
                                             match scrobble::musicbrainz::submit_listens(
                                                 &auth,
@@ -1351,6 +1356,17 @@ impl PlayerController {
                                     return;
                                 }
 
+                                let mut map: HashMap<&str, &str> = HashMap::new();
+                                if let Some(ref mbid) = scrobble_track.musicbrainz_release_id {
+                                    map.insert("release_mbid", mbid.as_str());
+                                }
+                                if let Some(ref mbid) = scrobble_track.musicbrainz_recording_id {
+                                    map.insert("recording_mbid", mbid.as_str());
+                                }
+                                if let Some(ref mbid) = scrobble_track.musicbrainz_track_id {
+                                    map.insert("track_mbid", mbid.as_str());
+                                }
+
                                 // Last.fm now-playing
                                 let lastfm_api_key = cfg_signal.read().lastfm_api_key.clone();
                                 let lastfm_api_secret = cfg_signal.read().lastfm_api_secret.clone();
@@ -1389,6 +1405,7 @@ impl PlayerController {
                                         &scrobble_track.artist,
                                         &scrobble_track.title,
                                         Some(&scrobble_track.album),
+                                        Some(map.clone()),
                                     );
                                     if let Err(e) = scrobble::musicbrainz::submit_listens(
                                         &auth,
@@ -1444,6 +1461,7 @@ impl PlayerController {
                                         &scrobble_track.artist,
                                         &scrobble_track.title,
                                         Some(&scrobble_track.album),
+                                        Some(map.clone()),
                                     );
                                     match scrobble::musicbrainz::submit_listens(
                                         &auth,
@@ -1701,6 +1719,8 @@ impl PlayerController {
             track_number: None,
             disc_number: None,
             musicbrainz_release_id: None,
+            musicbrainz_recording_id: None,
+            musicbrainz_track_id: None,
             playlist_item_id: None,
             artists: vec![],
         };

--- a/crates/pages/src/server/subsonic_sync.rs
+++ b/crates/pages/src/server/subsonic_sync.rs
@@ -11,7 +11,9 @@ use utils;
 
 fn normalize_album_id(id: &str) -> String {
     let parts: Vec<&str> = id.split(':').collect();
-    if parts.len() >= 2 && (parts[0] == "subsonic" || parts[0] == "custom" || parts[0] == "jellyfin") {
+    if parts.len() >= 2
+        && (parts[0] == "subsonic" || parts[0] == "custom" || parts[0] == "jellyfin")
+    {
         format!("{}:{}", parts[0], parts[1])
     } else {
         id.to_string()
@@ -156,6 +158,8 @@ pub async fn sync_server_library(
                             track_number: item.index_number,
                             disc_number: item.parent_index_number,
                             musicbrainz_release_id: None,
+                            musicbrainz_recording_id: None,
+                            musicbrainz_track_id: None,
                             playlist_item_id: None,
                             artists: item
                                 .artists
@@ -201,7 +205,10 @@ pub async fn sync_server_library(
                 info!("Cleared old jellyfin library data.");
                 for album in out_albums {
                     let mut merged = album;
-                    if let Some(old) = old_albums.iter().find(|a| normalize_album_id(&a.id) == normalize_album_id(&merged.id)) {
+                    if let Some(old) = old_albums
+                        .iter()
+                        .find(|a| normalize_album_id(&a.id) == normalize_album_id(&merged.id))
+                    {
                         if merged.cover_path.is_none() || old.manual_cover {
                             merged.cover_path = old.cover_path.clone();
                         }
@@ -213,7 +220,11 @@ pub async fn sync_server_library(
                 }
             } else {
                 for album in out_albums {
-                    if let Some(index) = lib_write.jellyfin_albums.iter().position(|a| normalize_album_id(&a.id) == normalize_album_id(&album.id)) {
+                    if let Some(index) = lib_write
+                        .jellyfin_albums
+                        .iter()
+                        .position(|a| normalize_album_id(&a.id) == normalize_album_id(&album.id))
+                    {
                         let mut new_album = album;
                         let existing = &lib_write.jellyfin_albums[index];
                         if new_album.cover_path.is_none() || existing.manual_cover {
@@ -270,7 +281,10 @@ pub async fn sync_server_library(
                 info!("Cleared old subsonic/custom library data.");
                 for album in albums {
                     let mut merged = album;
-                    if let Some(old) = old_albums.iter().find(|a| normalize_album_id(&a.id) == normalize_album_id(&merged.id)) {
+                    if let Some(old) = old_albums
+                        .iter()
+                        .find(|a| normalize_album_id(&a.id) == normalize_album_id(&merged.id))
+                    {
                         if merged.cover_path.is_none() || old.manual_cover {
                             merged.cover_path = old.cover_path.clone();
                         }
@@ -282,7 +296,11 @@ pub async fn sync_server_library(
                 }
             } else {
                 for album in albums {
-                    if let Some(index) = lib_write.jellyfin_albums.iter().position(|a| normalize_album_id(&a.id) == normalize_album_id(&album.id)) {
+                    if let Some(index) = lib_write
+                        .jellyfin_albums
+                        .iter()
+                        .position(|a| normalize_album_id(&a.id) == normalize_album_id(&album.id))
+                    {
                         let mut new_album = album;
                         let existing = &lib_write.jellyfin_albums[index];
                         if new_album.cover_path.is_none() || existing.manual_cover {
@@ -304,9 +322,13 @@ pub async fn sync_server_library(
                 }
                 lib_write.server_artist_images.extend(artist_images);
             }
-            
+
             for track in tracks {
-                if !lib_write.jellyfin_tracks.iter().any(|t| t.path == track.path) {
+                if !lib_write
+                    .jellyfin_tracks
+                    .iter()
+                    .any(|t| t.path == track.path)
+                {
                     lib_write.jellyfin_tracks.push(track);
                 }
             }
@@ -359,7 +381,11 @@ pub async fn fetch_subsonic_library(
         }
 
         let count = albums.len();
-        info!("Processing {} Subsonic/Custom albums (total {} so far)...", count, offset + count);
+        info!(
+            "Processing {} Subsonic/Custom albums (total {} so far)...",
+            count,
+            offset + count
+        );
 
         for album in albums {
             let album_cover_tag = album
@@ -435,6 +461,8 @@ pub async fn fetch_subsonic_library(
                     track_number: song.track,
                     disc_number: song.disc_number,
                     musicbrainz_release_id: None,
+                    musicbrainz_recording_id: None,
+                    musicbrainz_track_id: None,
                     playlist_item_id: None,
                     artists: vec![song.artist.unwrap_or_else(|| album_artist.clone())],
                 });

--- a/crates/reader/src/metadata.rs
+++ b/crates/reader/src/metadata.rs
@@ -115,6 +115,14 @@ pub fn extract_metadata(
         .and_then(|t| t.get_string(&ItemKey::MusicBrainzReleaseId))
         .map(|s| s.to_string());
 
+    let musicbrainz_recording_id = tag
+        .and_then(|t| t.get_string(&ItemKey::MusicBrainzRecordingId))
+        .map(|s| s.to_string());
+
+    let musicbrainz_track_id = tag
+        .and_then(|t| t.get_string(&ItemKey::MusicBrainzTrackId))
+        .map(|s| s.to_string());
+
     let sample_rate = properties.sample_rate().unwrap_or(0);
     let file_size = std::fs::metadata(track_path)
         .ok()
@@ -138,6 +146,8 @@ pub fn extract_metadata(
         track_number: tag.and_then(|t| t.track()),
         disc_number: tag.and_then(|t| t.disk()),
         musicbrainz_release_id,
+        musicbrainz_recording_id,
+        musicbrainz_track_id,
         playlist_item_id: None,
     }
 }
@@ -354,6 +364,18 @@ fn read_with_symphonia(
             &tags,
             StandardTagKey::MusicBrainzAlbumId,
             &["MUSICBRAINZ_ALBUMID"],
+        )
+        .and_then(symphonia_tag_to_string),
+        musicbrainz_recording_id: find_symphonia_tag(
+            &tags,
+            StandardTagKey::MusicBrainzRecordingId,
+            &["MUSICBRAINZ_TRACKID"],
+        )
+        .and_then(symphonia_tag_to_string),
+        musicbrainz_track_id: find_symphonia_tag(
+            &tags,
+            StandardTagKey::MusicBrainzTrackId,
+            &["MUSICBRAINZ_RELEASETRACKID"],
         )
         .and_then(symphonia_tag_to_string),
         playlist_item_id: None,

--- a/crates/reader/src/models.rs
+++ b/crates/reader/src/models.rs
@@ -30,6 +30,10 @@ pub struct Track {
     #[serde(default)]
     pub musicbrainz_release_id: Option<String>,
     #[serde(default)]
+    pub musicbrainz_recording_id: Option<String>,
+    #[serde(default)]
+    pub musicbrainz_track_id: Option<String>,
+    #[serde(default)]
     pub playlist_item_id: Option<String>,
     #[serde(default)]
     pub artists: Vec<String>,

--- a/crates/scrobble/src/musicbrainz.rs
+++ b/crates/scrobble/src/musicbrainz.rs
@@ -77,7 +77,12 @@ pub async fn submit_listens(
     Ok(resp)
 }
 
-pub fn make_listen<'a>(artist: &'a str, track: &'a str, release: Option<&'a str>) -> Listen<'a> {
+pub fn make_listen<'a>(
+    artist: &'a str,
+    track: &'a str,
+    release: Option<&'a str>,
+    additional_info: Option<HashMap<&'a str, &'a str>>,
+) -> Listen<'a> {
     let now_unix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap()
@@ -89,7 +94,7 @@ pub fn make_listen<'a>(artist: &'a str, track: &'a str, release: Option<&'a str>
             artist_name: artist,
             track_name: track,
             release_name: release.filter(|s| !s.is_empty()),
-            additional_info: None,
+            additional_info: additional_info,
         },
     }
 }
@@ -98,6 +103,7 @@ pub fn make_playing_now<'a>(
     artist: &'a str,
     track: &'a str,
     release: Option<&'a str>,
+    additional_info: Option<HashMap<&'a str, &'a str>>,
 ) -> Listen<'a> {
     Listen {
         listened_at: None,
@@ -105,7 +111,7 @@ pub fn make_playing_now<'a>(
             artist_name: artist,
             track_name: track,
             release_name: release.filter(|s| !s.is_empty()),
-            additional_info: None,
+            additional_info: additional_info,
         },
     }
 }


### PR DESCRIPTION
Some songs have different name than the one registered at musicbrainz db so it doesn't recognize it, asian music with english titles for example. so added musicbrainz metadata to the submit listen request payload

<img width="458" height="93" alt="image" src="https://github.com/user-attachments/assets/77447dfa-04c7-43fa-88a2-33f6173a7a19" />

<img width="458" height="93" alt="image" src="https://github.com/user-attachments/assets/63592032-2162-4a85-bff9-2b6c7655f039" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MusicBrainz recording and track identifiers to music metadata, enabling more accurate music tracking on scrobbling services.

* **Refactor**
  * Restructured playlist loading and metadata extraction for improved code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kopuz-org/kopuz/pull/333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->