### PR TITLE
fix: fetch jellyfin album covers properly to kopuz and discord

### DIFF
--- a/crates/components/src/playlist_detail.rs
+++ b/crates/components/src/playlist_detail.rs
@@ -230,8 +230,9 @@ pub fn PlaylistDetail(
         } else {
             tracks_val.first().and_then(|t| {
                 let path_str = t.path.to_string_lossy();
-                utils::jellyfin_image::jellyfin_image_url_from_path(
+                utils::jellyfin_image::track_cover_url_with_album_fallback(
                     &path_str,
+                    &t.album_id,
                     &server.url,
                     server.access_token.as_deref(),
                     512,

--- a/crates/components/src/queue_list_view.rs
+++ b/crates/components/src/queue_list_view.rs
@@ -393,8 +393,9 @@ pub fn QueueListView(
                 let path_str = track.path.to_string_lossy();
                 let url = match server.service {
                     config::MusicService::Jellyfin => {
-                        utils::jellyfin_image::jellyfin_image_url_from_path(
+                        utils::jellyfin_image::track_cover_url_with_album_fallback(
                             &path_str,
+                            &track.album_id,
                             &server.url,
                             server.access_token.as_deref(),
                             cover_max_width,

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -128,8 +128,9 @@ impl PlayerController {
                 .server
                 .as_ref()
                 .and_then(|server| {
-                    utils::jellyfin_image::jellyfin_image_url_from_path(
+                    utils::jellyfin_image::track_cover_url_with_album_fallback(
                         &path_str,
+                        &track.album_id,
                         &server.url,
                         server.access_token.as_deref(),
                         800,
@@ -541,8 +542,9 @@ impl PlayerController {
 
                                 let cover_url = {
                                     let path_str = track.path.to_string_lossy();
-                                    utils::jellyfin_image::jellyfin_image_url_from_path(
+                                    utils::jellyfin_image::track_cover_url_with_album_fallback(
                                         &path_str,
+                                        &track.album_id,
                                         &server.url,
                                         server.access_token.as_deref(),
                                         800,

--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -495,7 +495,6 @@ pub fn use_player_task(ctrl: PlayerController) {
                         } else {
                             pos.as_secs()
                         };
-                        let cover = ctrl.current_song_cover_url.read().clone();
 
                         let song_key = format!("{}|{}|{}", title, artist, album);
 
@@ -504,29 +503,26 @@ pub fn use_player_task(ctrl: PlayerController) {
                             discord_cover_url.set(None);
                             discord_cover_sent.set(false);
 
-                            if cover.starts_with("http") && !cover.contains("dioxus.localhost") {
-                                discord_cover_url.set(Some(cover.clone()));
-                            } else {
-                                let mbid = {
-                                    let idx = *ctrl.current_queue_index.read();
-                                    ctrl.get_track_at(idx)
-                                        .and_then(|t| t.musicbrainz_release_id.clone())
-                                };
-                                let artist_c = artist.clone();
-                                let album_c = album.clone();
-                                let song_key_for_spawn = song_key.clone();
-                                spawn(async move {
-                                    let resolved = cover_art::resolve_cover_art_url(
-                                        mbid.as_deref(),
-                                        &artist_c,
-                                        &album_c,
-                                    )
-                                    .await;
-                                    if *discord_cover_resolving_for.peek() == song_key_for_spawn {
-                                        discord_cover_url.set(resolved);
-                                    }
-                                });
-                            }
+                            let mbid = {
+                                let idx = *ctrl.current_queue_index.read();
+                                ctrl.get_track_at(idx)
+                                    .and_then(|t| t.musicbrainz_release_id.clone())
+                            };
+                            let artist_c = artist.clone();
+                            let album_c = album.clone();
+                            let song_key_for_spawn = song_key.clone();
+                            spawn(async move {
+                                let resolved = cover_art::resolve_cover_art_url(
+                                    mbid.as_deref(),
+                                    &artist_c,
+                                    &album_c,
+                                )
+                                .await;
+                                dbg!(&resolved);
+                                if *discord_cover_resolving_for.peek() == song_key_for_spawn {
+                                    discord_cover_url.set(resolved);
+                                }
+                            });
                         }
 
                         if discord_enabled {
@@ -542,10 +538,6 @@ pub fn use_player_task(ctrl: PlayerController) {
                                 let resolved = discord_cover_url.read().clone();
                                 let cover_ref = if let Some(ref url) = resolved {
                                     Some(url.as_str())
-                                } else if cover.starts_with("http")
-                                    && !cover.contains("dioxus.localhost")
-                                {
-                                    Some(cover.as_str())
                                 } else {
                                     None
                                 };

--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -518,7 +518,6 @@ pub fn use_player_task(ctrl: PlayerController) {
                                     &album_c,
                                 )
                                 .await;
-                                dbg!(&resolved);
                                 if *discord_cover_resolving_for.peek() == song_key_for_spawn {
                                     discord_cover_url.set(resolved);
                                 }

--- a/crates/hooks/src/use_search_data.rs
+++ b/crates/hooks/src/use_search_data.rs
@@ -84,8 +84,9 @@ fn search_server(
                 let path_str = t.path.to_string_lossy();
                 let url = match active_service {
                     Some(MusicService::Jellyfin) => {
-                        utils::jellyfin_image::jellyfin_image_url_from_path(
+                        utils::jellyfin_image::track_cover_url_with_album_fallback(
                             &path_str,
+                            &t.album_id,
                             &srv.url,
                             srv.access_token.as_deref(),
                             80,


### PR DESCRIPTION
jellyfin server doesnt save track images, it rather saves it under its album id. and discord rich presence cant access localhost to get those cover arts so now it fetches form coverartarchive/itunes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved track artwork display by adding album-cover fallback when individual track artwork is missing, yielding more consistent covers across playlists and queues.
  * Enhanced presence/remote artwork resolution to always resolve cover art from canonical metadata (artist/album/release) and avoid stale or incorrect images in Discord and other integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->