### PR TITLE
ci(windows): guarantee dx is installed (binstall + locked fallback + verify)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,13 +83,18 @@ jobs:
         uses: cargo-bins/cargo-binstall@30b5ca8b54e1dcffd9548bc87ede1531310fdc67 # v1.20.0
 
       - name: Install dioxus-cli
-        # Token lets binstall query the GitHub API for the prebuilt release
-        # asset without hitting the 60-req/hr unauthenticated limit. Disable the
-        # compile fallback so a missed prebuilt fails fast instead of building
-        # dioxus-cli from source (which breaks on auth-git2/git2 0.21).
-        run: cargo binstall dioxus-cli@0.7.9 -y --disable-strategies compile
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fast path: prebuilt via binstall (token avoids the unauthenticated
+          # GitHub API rate limit). Disable binstall's own compile fallback —
+          # its unlocked source build breaks on auth-git2/git2 0.21. If no
+          # prebuilt is available, fall back to a *locked* source build, which
+          # uses dioxus-cli's committed Cargo.lock and so avoids git2 0.21.
+          cargo binstall dioxus-cli@0.7.9 -y --disable-strategies compile || true
+          command -v dx >/dev/null 2>&1 || cargo install dioxus-cli@0.7.9 --locked
+          dx --version
 
       - name: Bundle Windows installer (.msi)
         run: dx bundle --release --platform desktop --package kopuz


### PR DESCRIPTION
## Problem
The Windows `dx bundle` step fails with **`dx: The term 'dx' is not recognized`**. The `Install dioxus-cli` step found no prebuilt for `dioxus-cli@0.7.9` via `cargo binstall` and — with `--disable-strategies compile` — installed nothing while still exiting 0, so the failure only surfaced (cryptically) at the bundle step.

## Fix
Make the install step resilient and self-verifying:
- Keep **binstall** as the prebuilt fast path (the `GITHUB_TOKEN` avoids the unauthenticated GitHub API rate limit).
- Keep binstall's own compile fallback disabled — its *unlocked* source build is what breaks on `auth-git2` calling the removed `git2 0.21` `Cred::credential_helper`.
- Fall back to **`cargo install dioxus-cli@0.7.9 --locked`** when `dx` is absent. `--locked` uses dioxus-cli's committed `Cargo.lock`, which pins a working `git2`, sidestepping the 0.21 break.
- End with **`dx --version`** so a missing `dx` fails *here* with a clear message instead of at bundle time.

If `dioxus-cli@0.7.9` has no Windows prebuilt, the `--locked` source path runs every time — correct, just a few minutes slower; the `dx --version` line makes which path ran obvious in the logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Windows build workflow reliability with an enhanced CLI tool installation process that includes a fallback mechanism and version verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->