### PR TITLE
Convert runtime println/eprintln to tracing; fix pot-minter under WebKitGTK Trusted Types

### DIFF
--- a/crates/kopuz/src/pot_minter.rs
+++ b/crates/kopuz/src/pot_minter.rs
@@ -69,10 +69,14 @@ fn init_script() -> String {
     format!(
         r#"
 window.module = {{ exports: {{}} }}; window.exports = window.module.exports;
-// Chromium (WebView2) enforces Trusted Types on `new Function`/`eval`; the
-// BotGuard VM does unwrapped `new Function(...)` internally, so a permissive
-// `default` policy is needed to let those through. WebKit (Linux/macOS) ignores
-// this (no enforcement). Best-effort: a pre-existing default policy throws.
+// music.youtube.com serves `require-trusted-types-for 'script'`. Chromium
+// (WebView2) has always enforced it; WebKitGTK gained Trusted Types around
+// 2.46, so modern Linux webviews enforce it too. The permissive `default`
+// policy lets the BotGuard VM's internal string compilation through. The
+// outcome is recorded for the env diag: a pre-existing default policy makes
+// `createPolicy` throw, and every later compile check then consults *that*
+// policy instead.
+window.__kopuzDefaultPolicy = 'absent';
 try {{
   if (window.trustedTypes && window.trustedTypes.createPolicy) {{
     window.trustedTypes.createPolicy('default', {{
@@ -80,8 +84,9 @@ try {{
       createScript: function(s) {{ return s; }},
       createScriptURL: function(s) {{ return s; }}
     }});
+    window.__kopuzDefaultPolicy = 'installed';
   }}
-}} catch (e) {{}}
+}} catch (e) {{ window.__kopuzDefaultPolicy = 'failed: ' + e; }}
 {BGUTILS}
 window.__KOPUZ_BGX = (window.module && window.module.exports) || null;
 window.__kopuzMinter = null;
@@ -91,6 +96,15 @@ window.__kopuzMinting = null;
 // Rust side so a broken minter is debuggable from logs (issue: BotGuard VM
 // throwing "Function@[native code]" on some webview setups).
 window.__kopuzDiag = function(m) {{ try {{ window.ipc.postMessage(JSON.stringify({{diag: '' + m}})); }} catch(e) {{}} }};
+// JavaScriptCore stacks are frames only — no leading "Name: message" line
+// like V8 — so the name/message must be logged explicitly or the actual
+// error text is lost (all we'd see is "Function@[native code]").
+window.__kopuzErrStr = function(e) {{
+  if (!e) return '' + e;
+  var s = (e.name || 'Error') + ': ' + (e.message !== undefined ? e.message : ('' + e));
+  if (e.stack) s += ' :: ' + e.stack;
+  return s;
+}};
 
 window.__kopuzEnsureMinter = function() {{
   var now = Date.now();
@@ -114,10 +128,19 @@ window.__kopuzEnsureMinter = function() {{
     if (js) {{
       var src = js;
       if (window.trustedTypes && window.trustedTypes.createPolicy) {{
-        var pol = window.trustedTypes.createPolicy('kopuz-bg', {{ createScript: function(s){{ return s; }} }});
-        src = pol.createScript(js);
+        window.__kopuzBgPol = window.__kopuzBgPol ||
+          window.trustedTypes.createPolicy('kopuz-bg', {{ createScript: function(s) {{ return s; }} }});
+        src = window.__kopuzBgPol.createScript(js);
       }}
-      new Function(src)();
+      // Indirect eval first: the TT spec admits eval(TrustedScript) as-is,
+      // while `new Function(TrustedScript)` re-checks the assembled function
+      // source against the default policy — the path WebKitGTK rejects.
+      try {{
+        (0, eval)(src);
+      }} catch (evalErr) {{
+        window.__kopuzDiag('interpreter eval failed, retrying via Function :: ' + window.__kopuzErrStr(evalErr));
+        new Function(src)();
+      }}
     }}
     step = 'botguard_create';
     var botguard = await BG.BotGuardClient.create({{ program: ch.program, globalName: ch.globalName, globalObj: window }});
@@ -140,7 +163,7 @@ window.__kopuzEnsureMinter = function() {{
     window.__kopuzDiag('integrity token negotiated (ttl=' + ttl + 's)');
     return minter;
     }} catch (e) {{
-      window.__kopuzDiag('ensureMinter FAILED at step=' + step + ' :: ' + ((e && e.stack) ? e.stack : ('' + e)));
+      window.__kopuzDiag('ensureMinter FAILED at step=' + step + ' :: ' + window.__kopuzErrStr(e));
       throw e;
     }}
   }})();
@@ -159,18 +182,32 @@ window.__kopuzMint = async function(videoId, reqId) {{
     send({{pot: (pot || '') + ''}});
   }} catch (e) {{
     window.__kopuzMinter = null; window.__kopuzMinterExp = 0;
-    var stk = (e && e.stack) ? e.stack : ('' + e);
-    window.__kopuzDiag('mint FAILED in phase=' + phase + ' :: ' + stk);
-    send({{err: 'phase=' + phase + ': ' + stk}});
+    var msg = window.__kopuzErrStr(e);
+    window.__kopuzDiag('mint FAILED in phase=' + phase + ' :: ' + msg);
+    send({{err: 'phase=' + phase + ': ' + msg}});
   }}
 }};
 
 // One-shot environment snapshot: whether BgUtils captured BG, Trusted-Types
-// presence, the automation flag, and the UA — the usual culprits when the
-// BotGuard VM behaves differently across webview builds.
+// presence/enforcement, the automation flag, and the UA — the usual culprits
+// when the BotGuard VM behaves differently across webview builds. The three
+// compile probes pinpoint which dynamic-code path the engine blocks.
 setTimeout(function() {{
   var x = window.__KOPUZ_BGX;
-  window.__kopuzDiag('env: bgx=' + !!x + ' BG=' + !!(x && x.BG) + ' trustedTypes=' + !!(window.trustedTypes) + ' webdriver=' + navigator.webdriver + ' ua=' + navigator.userAgent);
+  var probe = function(fn) {{ try {{ fn(); return 'ok'; }} catch (e) {{ return ((e && e.name) || 'Error') + ':' + ((e && e.message) || e); }} }};
+  var fnRaw = probe(function() {{ new Function('return 1')(); }});
+  var fnTrusted = 'n/a', evalTrusted = 'n/a';
+  if (window.trustedTypes && window.trustedTypes.createPolicy) {{
+    try {{
+      var p = window.trustedTypes.createPolicy('kopuz-probe', {{ createScript: function(s) {{ return s; }} }});
+      fnTrusted = probe(function() {{ new Function(p.createScript('return 1'))(); }});
+      evalTrusted = probe(function() {{ (0, eval)(p.createScript('1')); }});
+    }} catch (e) {{ fnTrusted = 'policy-failed: ' + e; }}
+  }}
+  window.__kopuzDiag('env: bgx=' + !!x + ' BG=' + !!(x && x.BG) + ' trustedTypes=' + !!(window.trustedTypes)
+    + ' defaultPolicy=' + window.__kopuzDefaultPolicy
+    + ' newFunction=' + fnRaw + ' newFunctionTrusted=' + fnTrusted + ' evalTrusted=' + evalTrusted
+    + ' webdriver=' + navigator.webdriver + ' ua=' + navigator.userAgent);
 }}, 2000);
 
 // Pre-warm the integrity token as soon as the origin is live, so even the

--- a/crates/kopuz/src/pot_minter.rs
+++ b/crates/kopuz/src/pot_minter.rs
@@ -227,7 +227,7 @@ pub fn install_if_wanted<T: 'static>(target: &EventLoopWindowTarget<T>) {
             // the full JS stack, so a broken minter shows up in logs as more
             // than "Function@[native code]".
             if let Some(diag) = v.get("diag").and_then(|d| d.as_str()) {
-                eprintln!("[pot-minter] {diag}");
+                tracing::warn!("pot-minter: {diag}");
                 return;
             }
             let Some(id) = v.get("id").and_then(|i| i.as_u64()) else {
@@ -241,7 +241,7 @@ pub fn install_if_wanted<T: 'static>(target: &EventLoopWindowTarget<T>) {
                         .and_then(|e| e.as_str())
                         .unwrap_or("mint failed")
                         .to_string();
-                    eprintln!("[pot-minter] mint error: {err}");
+                    tracing::error!(error = %err, "pot-minter mint failed");
                     Err(err)
                 }
             };

--- a/crates/utils/src/lyrics.rs
+++ b/crates/utils/src/lyrics.rs
@@ -57,9 +57,7 @@ static MUSIXMATCH_TOKEN: OnceLock<Mutex<Option<MusixmatchToken>>> = OnceLock::ne
 
 macro_rules! lyrics_debug {
     ($($arg:tt)*) => {
-        if lyrics_terminal_debug_enabled() {
-            eprintln!("[lyrics] {}", format_args!($($arg)*));
-        }
+        tracing::debug!(target: "kopuz::lyrics", $($arg)*);
     };
 }
 
@@ -391,11 +389,6 @@ where
             log_lyrics_key_hash(&cache_key),
             lyrics_kind(cached.as_ref())
         );
-        lyrics_debug!(
-            "cache hit key_hash={} kind={}",
-            cache_key_hash,
-            lyrics_kind(cached.as_ref())
-        );
         return cached;
     }
 
@@ -475,11 +468,6 @@ where
             started.elapsed().as_millis(),
             lyrics_kind(local.as_ref())
         );
-        lyrics_debug!(
-            "provider=local_lrc elapsed_ms={} kind={}",
-            started.elapsed().as_millis(),
-            lyrics_kind(local.as_ref())
-        );
         if let Some(lyrics) = local {
             if has_word_timestamps(&lyrics) {
                 if let Ok(mut cache) = lyrics_cache().lock() {
@@ -489,12 +477,6 @@ where
                     target: "kopuz::lyrics",
                     "selected key_hash={} source=local_lrc kind={} total_ms={}",
                     log_lyrics_key_hash(&cache_key),
-                    lyrics_kind(Some(&lyrics)),
-                    total_start.elapsed().as_millis()
-                );
-                lyrics_debug!(
-                    "selected source=local_lrc key_hash={} kind={} total_ms={}",
-                    cache_key_hash,
                     lyrics_kind(Some(&lyrics)),
                     total_start.elapsed().as_millis()
                 );
@@ -512,12 +494,6 @@ where
             target: "kopuz::lyrics",
             "selected key_hash={} source=prefer_local kind={} total_ms={}",
             log_lyrics_key_hash(&cache_key),
-            lyrics_kind(fallback.as_ref()),
-            total_start.elapsed().as_millis()
-        );
-        lyrics_debug!(
-            "selected source=prefer_local key_hash={} kind={} total_ms={}",
-            cache_key_hash,
             lyrics_kind(fallback.as_ref()),
             total_start.elapsed().as_millis()
         );
@@ -539,11 +515,6 @@ where
                     started.elapsed().as_millis(),
                     lyrics_kind(server_lyrics.as_ref())
                 );
-                lyrics_debug!(
-                    "provider=jellyfin elapsed_ms={} kind={}",
-                    started.elapsed().as_millis(),
-                    lyrics_kind(server_lyrics.as_ref())
-                );
                 if let Some(lyrics) = server_lyrics {
                     if has_word_timestamps(&lyrics) {
                         if let Ok(mut cache) = lyrics_cache().lock() {
@@ -553,12 +524,6 @@ where
                             target: "kopuz::lyrics",
                             "selected key_hash={} source=jellyfin kind={} total_ms={}",
                             log_lyrics_key_hash(&cache_key),
-                            lyrics_kind(Some(&lyrics)),
-                            total_start.elapsed().as_millis()
-                        );
-                        lyrics_debug!(
-                            "selected source=jellyfin key_hash={} kind={} total_ms={}",
-                            cache_key_hash,
                             lyrics_kind(Some(&lyrics)),
                             total_start.elapsed().as_millis()
                         );
@@ -589,11 +554,6 @@ where
                     started.elapsed().as_millis(),
                     lyrics_kind(server_lyrics.as_ref())
                 );
-                lyrics_debug!(
-                    "provider=subsonic elapsed_ms={} kind={}",
-                    started.elapsed().as_millis(),
-                    lyrics_kind(server_lyrics.as_ref())
-                );
                 if let Some(lyrics) = server_lyrics {
                     if has_word_timestamps(&lyrics) {
                         if let Ok(mut cache) = lyrics_cache().lock() {
@@ -603,12 +563,6 @@ where
                             target: "kopuz::lyrics",
                             "selected key_hash={} source=subsonic kind={} total_ms={}",
                             log_lyrics_key_hash(&cache_key),
-                            lyrics_kind(Some(&lyrics)),
-                            total_start.elapsed().as_millis()
-                        );
-                        lyrics_debug!(
-                            "selected source=subsonic key_hash={} kind={} total_ms={}",
-                            cache_key_hash,
                             lyrics_kind(Some(&lyrics)),
                             total_start.elapsed().as_millis()
                         );
@@ -668,11 +622,6 @@ where
                     apple_started.elapsed().as_millis(),
                     lyrics_kind(result.as_ref())
                 );
-                lyrics_debug!(
-                    "provider=paxsenix_apple elapsed_ms={} kind={}",
-                    apple_started.elapsed().as_millis(),
-                    lyrics_kind(result.as_ref())
-                );
                 if let Some(lyrics) = result {
                     let should_replace = fallback
                         .as_ref()
@@ -698,11 +647,6 @@ where
                     target: "kopuz::lyrics",
                     "paxsenix_youtube key_hash={} elapsed_ms={} kind={}",
                     log_lyrics_key_hash(&cache_key),
-                    youtube_started.elapsed().as_millis(),
-                    lyrics_kind(result.as_ref())
-                );
-                lyrics_debug!(
-                    "provider=paxsenix_youtube elapsed_ms={} kind={}",
                     youtube_started.elapsed().as_millis(),
                     lyrics_kind(result.as_ref())
                 );
@@ -734,11 +678,6 @@ where
                     musixmatch_started.elapsed().as_millis(),
                     lyrics_kind(result.as_ref())
                 );
-                lyrics_debug!(
-                    "provider=musixmatch elapsed_ms={} kind={}",
-                    musixmatch_started.elapsed().as_millis(),
-                    lyrics_kind(result.as_ref())
-                );
                 if let Some(lyrics) = result
                 {
                     musixmatch_candidate = Some(lyrics);
@@ -750,11 +689,6 @@ where
                     target: "kopuz::lyrics",
                     "lrclib key_hash={} elapsed_ms={} kind={}",
                     log_lyrics_key_hash(&cache_key),
-                    lrclib_started.elapsed().as_millis(),
-                    lyrics_kind(result.as_ref())
-                );
-                lyrics_debug!(
-                    "provider=lrclib elapsed_ms={} kind={}",
                     lrclib_started.elapsed().as_millis(),
                     lyrics_kind(result.as_ref())
                 );
@@ -797,12 +731,6 @@ where
         target: "kopuz::lyrics",
         "selected key_hash={} source=final kind={} total_ms={}",
         log_lyrics_key_hash(&cache_key),
-        lyrics_kind(fetched.as_ref()),
-        total_start.elapsed().as_millis()
-    );
-    lyrics_debug!(
-        "selected source=final key_hash={} kind={} total_ms={}",
-        cache_key_hash,
         lyrics_kind(fetched.as_ref()),
         total_start.elapsed().as_millis()
     );
@@ -906,18 +834,6 @@ fn log_lyrics_key_hash(key: &str) -> String {
     let mut hasher = DefaultHasher::new();
     key.trim().hash(&mut hasher);
     format!("{:016x}", hasher.finish())
-}
-
-fn lyrics_terminal_debug_enabled() -> bool {
-    #[cfg(target_arch = "wasm32")]
-    {
-        false
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        std::env::var_os("KOPUZ_LYRICS_DEBUG").is_some()
-    }
 }
 
 fn lyrics_cache() -> &'static Mutex<LyricsCache> {
@@ -1317,7 +1233,6 @@ async fn fetch_from_musixmatch_enhanced(artist: &str, title: &str) -> Option<Lyr
             target: "kopuz::lyrics",
             "musixmatch track.search status={status}"
         );
-        lyrics_debug!("musixmatch track.search status={status}");
         return None;
     }
 
@@ -1327,11 +1242,6 @@ async fn fetch_from_musixmatch_enhanced(artist: &str, title: &str) -> Option<Lyr
             target: "kopuz::lyrics",
             "musixmatch no_match query={query:?} candidates={}",
             tracks.len()
-        );
-        lyrics_debug!(
-            "musixmatch no_match candidates={} query={:?}",
-            tracks.len(),
-            query
         );
         return None;
     };
@@ -1360,7 +1270,6 @@ async fn fetch_from_musixmatch_enhanced(artist: &str, title: &str) -> Option<Lyr
             target: "kopuz::lyrics",
             "musixmatch richsync status={status}"
         );
-        lyrics_debug!("musixmatch richsync status={status}");
         return None;
     }
 
@@ -1568,11 +1477,6 @@ async fn fetch_from_paxsenix_apple_music(
             target: "kopuz::lyrics",
             "paxsenix_apple no_match query={query:?} candidates={}",
             search.results.len()
-        );
-        lyrics_debug!(
-            "paxsenix_apple no_match candidates={} query={:?}",
-            search.results.len(),
-            query
         );
         return None;
     };


### PR DESCRIPTION
## Summary
- `lyrics_debug!` now emits `tracing::debug!(target: "kopuz::lyrics", ...)` instead of a `KOPUZ_LYRICS_DEBUG`-gated `eprintln!` — the standard `KOPUZ_LOG`/`KOPUZ_DEBUG` filter takes over and the output reaches the console sinks and `latest.log` instead of raw stderr. The env-var gate function is removed (on wasm32, events are no-ops without a subscriber, matching the old gate).
- Removed the 17 `lyrics_debug!` calls that sat next to a `tracing::info!(target: "kopuz::lyrics", ...)` logging the same event (cache-hit, per-provider timing, "selected" lines) — with both channels on tracing they would double-log at debug level. Calls with no info-level twin (inflight lifecycle, skip reasons, track selection, parse diagnostics) stay at debug.
- pot-minter: the BotGuard diag side-channel `eprintln!` becomes `tracing::warn!`, and the mint failure becomes `tracing::error!(error = %err, ...)`, matching the file's existing structured style.

Build scripts (cargo directives), the `duration_probe` example, and the ignored live test in `player.rs` keep their `#[expect(clippy::print_*)]` opt-outs per the workspace convention in `Cargo.toml`.

## pot-minter: WebKitGTK Trusted Types fix

A user report showed every mint failing at `step=run_interpreter` with only `Function@[native code]` for detail (free signed-in account → needs a content pot → deep seeks 403, fallback client hits `LOGIN_REQUIRED`). Two findings:

1. **The diag was discarding the real error.** JavaScriptCore stacks are frames only — no leading `Name: message` line like V8 — and the diag logged `e.stack`. All diag sites now log `name: message :: stack` via `__kopuzErrStr`.
2. **WebKitGTK ≥2.46 enforces Trusted Types.** `music.youtube.com` serves `require-trusted-types-for 'script'`; the init script's "WebKit ignores this (no enforcement)" assumption is stale. `new Function(TrustedScript)` re-checks the assembled function source against the default policy, while the TT spec admits `eval(TrustedScript)` as-is (and the page CSP carries `'unsafe-eval'`) — so the interpreter now runs through indirect `(0, eval)(src)` first, with `new Function` kept as fallback.

The env snapshot diag now also reports whether the permissive `default` policy install succeeded plus three compile probes (raw `new Function`, trusted `new Function`, trusted `eval`), so a single log line from any reporter's machine pinpoints the engine's enforcement mode. This part is not reproducible on a Premium account (itag 774 is pot-exempt, the minter is never exercised) — needs verification by an affected free/anon user on WebKitGTK ≥2.46.

## Testing
- `cargo clippy -p utils -p kopuz` — clean apart from pre-existing warnings; the workspace `print_stderr = "deny"` lint now passes on both crates.
- `cargo test -p utils`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More robust in-browser script evaluation under Trusted Types with a fallback retry to improve reliability and reduce runtime failures.
  * Improved capture of environment status so failures are diagnosed more accurately.

* **Chores**
  * Unified, structured logging for diagnostics and lyrics-related operations, emitting consistent warnings/errors and richer, single-line error summaries for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->