### PR TITLE
feat(ci): add fmt and clippy linting

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -3,6 +3,6 @@ await-holding-invalid-types = [
   { path = "generational_box::GenerationalRef", reason = "Reads should not be held over an await point. This will cause any writes to fail while the await is pending since the read borrow is still active." },
   "generational_box::GenerationalRefMut",
   { path = "generational_box::GenerationalRefMut", reason = "Write should not be held over an await point. This will cause any reads or writes to fail while the await is pending since the write borrow is still active." },
-  "dioxus_signals::Write",
-  { path = "dioxus_signals::Write", reason = "Write should not be held over an await point. This will cause any reads or writes to fail while the await is pending since the write borrow is still active." },
+  "dioxus_signals::WriteLock",
+  { path = "dioxus_signals::WriteLock", reason = "Write should not be held over an await point. This will cause any reads or writes to fail while the await is pending since the write borrow is still active." },
 ]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,15 +2,21 @@ name: lint
 
 on:
   push:
-    branches: [master]
     paths:
       - 'README.md'
       - '.github/workflows/lint.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'crates/**'
   pull_request:
-    branches: [master]
     paths:
       - 'README.md'
       - '.github/workflows/lint.yml'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
+      - 'crates/**'
 
 jobs:
   deno-fmt:
@@ -24,3 +30,31 @@ jobs:
 
       - name: Check README.md formatting
         run: deno fmt --check README.md
+
+  rust-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential cmake pkg-config \
+            libopus-dev libasound2-dev libxdo-dev \
+            libwebkit2gtk-4.1-dev libgtk-3-dev \
+            libsoup-3.0-dev libssl-dev \
+            libglib2.0-dev libpango1.0-dev \
+            libcairo2-dev libgdk-pixbuf-2.0-dev
+
+      - uses: dtolnay/rust-toolchain@1.95.0
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check Rust formatting
+        run: cargo fmt --all --check
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,11 @@ jobs:
   deno-fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282
         with:
           deno-version: v2.x
 
@@ -34,7 +36,9 @@ jobs:
   rust-lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |
@@ -47,11 +51,11 @@ jobs:
             libglib2.0-dev libpango1.0-dev \
             libcairo2-dev libgdk-pixbuf-2.0-dev
 
-      - uses: dtolnay/rust-toolchain@1.95.0
+      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582
         with:
           components: rustfmt, clippy
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
 
       - name: Check Rust formatting
         run: cargo fmt --all --check

--- a/crates/components/src/album_details.rs
+++ b/crates/components/src/album_details.rs
@@ -3,6 +3,7 @@ use reader::Library;
 use std::path::PathBuf;
 
 #[component]
+#[allow(clippy::await_holding_invalid_type)]
 pub fn AlbumDetails(
     album_id: String,
     library: Signal<Library>,

--- a/crates/components/src/download_overlay.rs
+++ b/crates/components/src/download_overlay.rs
@@ -170,7 +170,11 @@ pub fn DownloadOverlay(mut queue: Signal<DownloadQueue>) -> Element {
                                             style: if item.bytes_total > 0 {
                                                 format!("width: {:.1}%", item.bytes_done as f64 / item.bytes_total as f64 * 100.0)
                                             } else {
-                                                format!("width: {:.1}%", (item.bytes_done as f64 / 8_000_000.0 * 100.0).max(5.0).min(95.0))
+                                                format!(
+                                                    "width: {:.1}%",
+                                                    (item.bytes_done as f64 / 8_000_000.0 * 100.0)
+                                                        .clamp(5.0, 95.0)
+                                                )
                                             }
                                         }
                                     }

--- a/crates/components/src/header.rs
+++ b/crates/components/src/header.rs
@@ -69,8 +69,8 @@ pub fn Header(
                 button {
                     class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
                     onclick: move |_| {
-                        if sort_state.is_some() {
-                            showcase::toggle_sort_state(sort_state.unwrap(), SortField::Title);
+                        if let Some(sort_state) = sort_state {
+                            showcase::toggle_sort_state(sort_state, SortField::Title);
                         }
                     },
                     "{i18n::t(\"title\")}"
@@ -79,8 +79,8 @@ pub fn Header(
                 button {
                     class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
                     onclick: move |_| {
-                        if sort_state.is_some() {
-                            showcase::toggle_sort_state(sort_state.unwrap(), SortField::Artist);
+                        if let Some(sort_state) = sort_state {
+                            showcase::toggle_sort_state(sort_state, SortField::Artist);
                         }
                     },
                     "{i18n::t(\"artist\")}"
@@ -90,8 +90,8 @@ pub fn Header(
                     button {
                         class: "flex items-center gap-1 uppercase tracking-widest text-left hover:text-white transition-colors",
                         onclick: move |_| {
-                            if sort_state.is_some() {
-                                showcase::toggle_sort_state(sort_state.unwrap(), SortField::Album);
+                            if let Some(sort_state) = sort_state {
+                                showcase::toggle_sort_state(sort_state, SortField::Album);
                             }
                         },
                         "{i18n::t(\"album\")}"
@@ -101,8 +101,8 @@ pub fn Header(
                 button {
                     class: "flex items-center justify-end gap-1 uppercase tracking-widest text-right hover:text-white transition-colors",
                     onclick: move |_| {
-                        if sort_state.is_some() {
-                            showcase::toggle_sort_state(sort_state.unwrap(), SortField::Duration);
+                        if let Some(sort_state) = sort_state {
+                            showcase::toggle_sort_state(sort_state, SortField::Duration);
                         }
                     },
                     i { class: "fa-regular fa-clock" }
@@ -142,8 +142,8 @@ pub fn Header(
                       button {
                           class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
                           onclick: move |_| {
-                              if sort_state.is_some() {
-                                  showcase::toggle_sort_state(sort_state.unwrap(), SortField::Title);
+                              if let Some(sort_state) = sort_state {
+                                  showcase::toggle_sort_state(sort_state, SortField::Title);
                               }
                           },
                           "{i18n::t(\"title\")}"
@@ -152,8 +152,8 @@ pub fn Header(
                       button {
                           class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
                           onclick: move |_| {
-                              if sort_state.is_some() {
-                                  showcase::toggle_sort_state(sort_state.unwrap(), SortField::Artist);
+                              if let Some(sort_state) = sort_state {
+                                  showcase::toggle_sort_state(sort_state, SortField::Artist);
                               }
                           },
                           "{i18n::t(\"artist\")}"
@@ -163,8 +163,8 @@ pub fn Header(
                           button {
                               class: "flex items-center gap-1 uppercase tracking-wider text-left hover:text-white transition-colors",
                               onclick: move |_| {
-                                  if sort_state.is_some() {
-                                      showcase::toggle_sort_state(sort_state.unwrap(), SortField::Album);
+                                  if let Some(sort_state) = sort_state {
+                                      showcase::toggle_sort_state(sort_state, SortField::Album);
                                   }
                               },
                               "{i18n::t(\"album\")}"
@@ -174,8 +174,8 @@ pub fn Header(
                       button {
                           class: "flex items-center justify-end gap-1 uppercase tracking-wider text-right hover:text-white transition-colors",
                           onclick: move |_| {
-                              if sort_state.is_some() {
-                                  showcase::toggle_sort_state(sort_state.unwrap(), SortField::Duration);
+                              if let Some(sort_state) = sort_state {
+                                  showcase::toggle_sort_state(sort_state, SortField::Duration);
                               }
                           },
                           i { class: "fa-regular fa-clock" }

--- a/crates/components/src/lyrics_view.rs
+++ b/crates/components/src/lyrics_view.rs
@@ -496,7 +496,7 @@ pub fn LyricsView(
                             .get(active_main_position.saturating_add(1))
                             .map(|&next_index| lines[next_index].start_time)
                             .map(|next_time| {
-                                ((next_time - current_time) * 1000.0).max(16.0).min(50.0) as u64
+                                ((next_time - current_time) * 1000.0).clamp(16.0, 50.0) as u64
                             })
                             .unwrap_or(50);
                     } else {

--- a/crates/components/src/metadata_modal.rs
+++ b/crates/components/src/metadata_modal.rs
@@ -37,10 +37,18 @@ pub fn MetadataModal(props: MetadataModalProps) -> Element {
     });
     let mut album = use_signal(|| props.track.album.clone());
     let mut track_no = use_signal(|| {
-        props.track.track_number.map(|n| n.to_string()).unwrap_or_default()
+        props
+            .track
+            .track_number
+            .map(|n| n.to_string())
+            .unwrap_or_default()
     });
     let mut disc_no = use_signal(|| {
-        props.track.disc_number.map(|n| n.to_string()).unwrap_or_default()
+        props
+            .track
+            .disc_number
+            .map(|n| n.to_string())
+            .unwrap_or_default()
     });
 
     let mut cover_preview = use_signal(|| None::<String>);
@@ -92,14 +100,26 @@ pub fn MetadataModal(props: MetadataModalProps) -> Element {
         push(&duration_text, fmt_dur(t.duration));
     }
     if t.khz > 0 {
-        push(&sample_rate_text, format!("{:.1} kHz", t.khz as f64 / 1000.0));
+        push(
+            &sample_rate_text,
+            format!("{:.1} kHz", t.khz as f64 / 1000.0),
+        );
     }
     if t.bitrate > 0 {
         push(&bitrate_text, format!("{} kbps", t.bitrate));
     }
-    push(&musicbrainz_release_text, t.musicbrainz_release_id.clone().unwrap_or_default());
-    push(&musicbrainz_recording_text, t.musicbrainz_recording_id.clone().unwrap_or_default());
-    push(&musicbrainz_track_text, t.musicbrainz_track_id.clone().unwrap_or_default());
+    push(
+        &musicbrainz_release_text,
+        t.musicbrainz_release_id.clone().unwrap_or_default(),
+    );
+    push(
+        &musicbrainz_recording_text,
+        t.musicbrainz_recording_id.clone().unwrap_or_default(),
+    );
+    push(
+        &musicbrainz_track_text,
+        t.musicbrainz_track_id.clone().unwrap_or_default(),
+    );
     push(&path_text, t.path.display().to_string());
 
     let input_class = "w-full bg-white/5 border border-white/10 rounded px-3 py-2 text-white text-sm focus:outline-none focus:border-white/20";

--- a/crates/components/src/playlist_detail.rs
+++ b/crates/components/src/playlist_detail.rs
@@ -87,7 +87,7 @@ pub fn PlaylistDetail(
                                     (&server.access_token, &server.user_id)
                                 {
                                     Some((
-                                        server.service.clone(),
+                                        server.service,
                                         server.url.clone(),
                                         token.clone(),
                                         conf.device_id.clone(),
@@ -127,10 +127,10 @@ pub fn PlaylistDetail(
                                             let duration_secs =
                                                 item.run_time_ticks.unwrap_or(0) / 10_000_000;
                                             let mut path_str = format!("jellyfin:{}", item.id);
-                                            if let Some(tags) = &item.image_tags {
-                                                if let Some(tag) = tags.get("Primary") {
-                                                    path_str.push_str(&format!(":{}", tag));
-                                                }
+                                            if let Some(tags) = &item.image_tags
+                                                && let Some(tag) = tags.get("Primary")
+                                            {
+                                                path_str.push_str(&format!(":{}", tag));
                                             }
                                             let bitrate_kbps = item.bitrate.unwrap_or(0) / 1000;
                                             let bitrate_u16 =
@@ -329,31 +329,42 @@ pub fn PlaylistDetail(
                         if let Some(file) = file {
                             let path = file.path().to_path_buf();
                             if is_jellyfin {
-                                let conf = config.peek();
-                                if let Some(server) = &conf.server {
-                                    if let (Some(token), Some(user_id)) =
-                                        (&server.access_token, &server.user_id)
-                                    {
-                                        if server.service == MusicService::Jellyfin {
-                                            if let Ok(bytes) = std::fs::read(&path) {
-                                                let ext = path
-                                                    .extension()
-                                                    .and_then(|e| e.to_str())
-                                                    .unwrap_or("")
-                                                    .to_lowercase();
-                                                let ct =
-                                                    if ext == "png" { "image/png" } else { "image/jpeg" };
-                                                let remote = server::jellyfin::JellyfinClient::new(
-                                                    &server.url,
-                                                    Some(token),
-                                                    &conf.device_id,
-                                                    Some(user_id),
-                                                );
-                                                let _ =
-                                                    remote.set_playlist_image(&pid, bytes, ct).await;
-                                            }
+                                let upload_info = {
+                                    let conf = config.peek();
+                                    conf.server.as_ref().and_then(|server| {
+                                        if let (MusicService::Jellyfin, Some(token), Some(user_id)) = (
+                                            server.service,
+                                            server.access_token.as_ref(),
+                                            server.user_id.as_ref(),
+                                        ) {
+                                            Some((
+                                                server.url.clone(),
+                                                token.clone(),
+                                                conf.device_id.clone(),
+                                                user_id.clone(),
+                                            ))
+                                        } else {
+                                            None
                                         }
-                                    }
+                                    })
+                                };
+                                if let Some((url, token, device_id, user_id)) = upload_info
+                                    && let Ok(bytes) = std::fs::read(&path)
+                                {
+                                    let ext = path
+                                        .extension()
+                                        .and_then(|e| e.to_str())
+                                        .unwrap_or("")
+                                        .to_lowercase();
+                                    let ct =
+                                        if ext == "png" { "image/png" } else { "image/jpeg" };
+                                    let remote = server::jellyfin::JellyfinClient::new(
+                                        &url,
+                                        Some(&token),
+                                        &device_id,
+                                        Some(&user_id),
+                                    );
+                                    let _ = remote.set_playlist_image(&pid, bytes, ct).await;
                                 }
                                 let mut store = playlist_store.write();
                                 if let Some(p) =
@@ -372,16 +383,14 @@ pub fn PlaylistDetail(
                 }
             },
             on_delete_track: move |idx: usize| {
-                if !is_jellyfin {
-                    if let Some(t) = tracks.read().get(idx).cloned() {
-                        #[cfg(not(target_arch = "wasm32"))]
-                        if std::fs::remove_file(&t.path).is_ok() {
-                            library.write().remove_track(&t.path);
-                            let lib_path = directories::ProjectDirs::from("com", "temidaradev", "kopuz")
-                                .map(|d| d.config_dir().join("library.json"))
-                                .unwrap_or_else(|| PathBuf::from("./config/library.json"));
-                            let _ = library.read().save(&lib_path);
-                        }
+                if !is_jellyfin && let Some(t) = tracks.read().get(idx).cloned() {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    if std::fs::remove_file(&t.path).is_ok() {
+                        library.write().remove_track(&t.path);
+                        let lib_path = directories::ProjectDirs::from("com", "temidaradev", "kopuz")
+                            .map(|d| d.config_dir().join("library.json"))
+                            .unwrap_or_else(|| PathBuf::from("./config/library.json"));
+                        let _ = library.read().save(&lib_path);
                     }
                 }
             },
@@ -415,59 +424,69 @@ pub fn PlaylistDetail(
                             .map(|s| s.to_string());
                         let remove_idx = idx;
                         spawn(async move {
-                            let conf = config.peek();
-                            if let Some(server) = &conf.server {
-                                if let (Some(token), Some(user_id)) =
-                                    (&server.access_token, &server.user_id)
-                                {
-                                    let removed = match server.service {
-                                        MusicService::YtMusic => {
-                                            if let Some(vid) = track_video_id.as_deref() {
-                                                let yt =
-                                                    server::ytmusic::YouTubeMusicClient::with_cookies(
-                                                        token.clone(),
-                                                    );
-                                                yt.remove_from_playlist(&pid_clone, vid)
-                                                    .await
-                                                    .is_ok()
-                                            } else {
-                                                false
-                                            }
-                                        }
-                                        MusicService::Jellyfin => {
-                                            if let Some(entry_id) = entry_id_opt {
-                                                let remote = server::jellyfin::JellyfinClient::new(
-                                                    &server.url,
-                                                    Some(token),
-                                                    &conf.device_id,
-                                                    Some(user_id),
+                            let server_info = {
+                                let conf = config.peek();
+                                conf.server.as_ref().and_then(|server| {
+                                    if let (Some(token), Some(user_id)) =
+                                        (&server.access_token, &server.user_id)
+                                    {
+                                        Some((
+                                            server.service,
+                                            server.url.clone(),
+                                            token.clone(),
+                                            conf.device_id.clone(),
+                                            user_id.clone(),
+                                        ))
+                                    } else {
+                                        None
+                                    }
+                                })
+                            };
+                            if let Some((service, url, token, device_id, user_id)) = server_info {
+                                let removed = match service {
+                                    MusicService::YtMusic => {
+                                        if let Some(vid) = track_video_id.as_deref() {
+                                            let yt =
+                                                server::ytmusic::YouTubeMusicClient::with_cookies(
+                                                    token.clone(),
                                                 );
-                                                remote
-                                                    .remove_from_playlist(&pid_clone, &entry_id)
-                                                    .await
-                                                    .is_ok()
-                                            } else {
-                                                false
-                                            }
-                                        }
-                                        MusicService::Subsonic | MusicService::Custom => {
-                                            let remote = server::subsonic::SubsonicClient::new(
-                                                &server.url,
-                                                user_id,
-                                                token,
-                                            );
-                                            remote
-                                                .remove_from_playlist(&pid_clone, remove_idx)
+                                            yt.remove_from_playlist(&pid_clone, vid)
                                                 .await
                                                 .is_ok()
-                                        }
-                                    };
-                                    if removed {
-                                        let mut tw = tracks.write();
-                                        if remove_idx < tw.len() {
-                                            tw.remove(remove_idx);
+                                        } else {
+                                            false
                                         }
                                     }
+                                    MusicService::Jellyfin => {
+                                        if let Some(entry_id) = entry_id_opt {
+                                            let remote = server::jellyfin::JellyfinClient::new(
+                                                &url,
+                                                Some(&token),
+                                                &device_id,
+                                                Some(&user_id),
+                                            );
+                                            remote
+                                                .remove_from_playlist(&pid_clone, &entry_id)
+                                                .await
+                                                .is_ok()
+                                        } else {
+                                            false
+                                        }
+                                    }
+                                    MusicService::Subsonic | MusicService::Custom => {
+                                        let remote = server::subsonic::SubsonicClient::new(
+                                            &url,
+                                            &user_id,
+                                            &token,
+                                        );
+                                        remote
+                                            .remove_from_playlist(&pid_clone, remove_idx)
+                                            .await
+                                            .is_ok()
+                                    }
+                                };
+                                if removed && remove_idx < tracks.read().len() {
+                                    tracks.write().remove(remove_idx);
                                 }
                             }
                         });
@@ -489,52 +508,65 @@ pub fn PlaylistDetail(
                     let track_list = tracks.read().clone();
                     let pid = pid_for_move_up.clone();
                     spawn(async move {
-                        let conf = config.peek();
-                        if let Some(server) = &conf.server {
-                            if let (Some(token), Some(user_id)) =
-                                (&server.access_token, &server.user_id)
-                            {
-                                let moved_item =
-                                    track_list.get(idx - 1).and_then(|t| t.playlist_item_id.clone());
-                                match server.service {
-                                    MusicService::YtMusic => {}
-                                    MusicService::Jellyfin => {
-                                        if let Some(item_id) = moved_item {
-                                            let remote = server::jellyfin::JellyfinClient::new(
-                                                &server.url,
-                                                Some(token),
-                                                &conf.device_id,
-                                                Some(user_id),
-                                            );
-                                            let _ = remote
-                                                .move_playlist_item(&pid, &item_id, idx - 1)
-                                                .await;
-                                        }
-                                    }
-                                    MusicService::Subsonic | MusicService::Custom => {
-                                        let remote = server::subsonic::SubsonicClient::new(
-                                            &server.url,
-                                            user_id,
-                                            token,
+                        let server_info = {
+                            let conf = config.peek();
+                            conf.server.as_ref().and_then(|server| {
+                                if let (Some(token), Some(user_id)) =
+                                    (&server.access_token, &server.user_id)
+                                {
+                                    Some((
+                                        server.service,
+                                        server.url.clone(),
+                                        token.clone(),
+                                        conf.device_id.clone(),
+                                        user_id.clone(),
+                                    ))
+                                } else {
+                                    None
+                                }
+                            })
+                        };
+                        if let Some((service, url, token, device_id, user_id)) = server_info {
+                            let moved_item =
+                                track_list.get(idx - 1).and_then(|t| t.playlist_item_id.clone());
+                            match service {
+                                MusicService::YtMusic => {}
+                                MusicService::Jellyfin => {
+                                    if let Some(item_id) = moved_item {
+                                        let remote = server::jellyfin::JellyfinClient::new(
+                                            &url,
+                                            Some(&token),
+                                            &device_id,
+                                            Some(&user_id),
                                         );
-                                        let ids: Vec<String> = track_list
-                                            .iter()
-                                            .filter_map(|t| {
-                                                let s = t.path.to_string_lossy();
-                                                let parts: Vec<&str> = s.split(':').collect();
-                                                if parts.len() >= 2 {
-                                                    Some(parts[1].to_string())
-                                                } else {
-                                                    None
-                                                }
-                                            })
-                                            .collect();
-                                        let id_refs: Vec<&str> =
-                                            ids.iter().map(|s| s.as_str()).collect();
                                         let _ = remote
-                                            .reorder_playlist(&pid, &id_refs, id_refs.len())
+                                            .move_playlist_item(&pid, &item_id, idx - 1)
                                             .await;
                                     }
+                                }
+                                MusicService::Subsonic | MusicService::Custom => {
+                                    let remote = server::subsonic::SubsonicClient::new(
+                                        &url,
+                                        &user_id,
+                                        &token,
+                                    );
+                                    let ids: Vec<String> = track_list
+                                        .iter()
+                                        .filter_map(|t| {
+                                            let s = t.path.to_string_lossy();
+                                            let parts: Vec<&str> = s.split(':').collect();
+                                            if parts.len() >= 2 {
+                                                Some(parts[1].to_string())
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .collect();
+                                    let id_refs: Vec<&str> =
+                                        ids.iter().map(|s| s.as_str()).collect();
+                                    let _ = remote
+                                        .reorder_playlist(&pid, &id_refs, id_refs.len())
+                                        .await;
                                 }
                             }
                         }
@@ -556,52 +588,65 @@ pub fn PlaylistDetail(
                     let track_list = tracks.read().clone();
                     let pid = pid_for_move_down.clone();
                     spawn(async move {
-                        let conf = config.peek();
-                        if let Some(server) = &conf.server {
-                            if let (Some(token), Some(user_id)) =
-                                (&server.access_token, &server.user_id)
-                            {
-                                let moved_item =
-                                    track_list.get(idx + 1).and_then(|t| t.playlist_item_id.clone());
-                                match server.service {
-                                    MusicService::YtMusic => {}
-                                    MusicService::Jellyfin => {
-                                        if let Some(item_id) = moved_item {
-                                            let remote = server::jellyfin::JellyfinClient::new(
-                                                &server.url,
-                                                Some(token),
-                                                &conf.device_id,
-                                                Some(user_id),
-                                            );
-                                            let _ = remote
-                                                .move_playlist_item(&pid, &item_id, idx + 1)
-                                                .await;
-                                        }
-                                    }
-                                    MusicService::Subsonic | MusicService::Custom => {
-                                        let remote = server::subsonic::SubsonicClient::new(
-                                            &server.url,
-                                            user_id,
-                                            token,
+                        let server_info = {
+                            let conf = config.peek();
+                            conf.server.as_ref().and_then(|server| {
+                                if let (Some(token), Some(user_id)) =
+                                    (&server.access_token, &server.user_id)
+                                {
+                                    Some((
+                                        server.service,
+                                        server.url.clone(),
+                                        token.clone(),
+                                        conf.device_id.clone(),
+                                        user_id.clone(),
+                                    ))
+                                } else {
+                                    None
+                                }
+                            })
+                        };
+                        if let Some((service, url, token, device_id, user_id)) = server_info {
+                            let moved_item =
+                                track_list.get(idx + 1).and_then(|t| t.playlist_item_id.clone());
+                            match service {
+                                MusicService::YtMusic => {}
+                                MusicService::Jellyfin => {
+                                    if let Some(item_id) = moved_item {
+                                        let remote = server::jellyfin::JellyfinClient::new(
+                                            &url,
+                                            Some(&token),
+                                            &device_id,
+                                            Some(&user_id),
                                         );
-                                        let ids: Vec<String> = track_list
-                                            .iter()
-                                            .filter_map(|t| {
-                                                let s = t.path.to_string_lossy();
-                                                let parts: Vec<&str> = s.split(':').collect();
-                                                if parts.len() >= 2 {
-                                                    Some(parts[1].to_string())
-                                                } else {
-                                                    None
-                                                }
-                                            })
-                                            .collect();
-                                        let id_refs: Vec<&str> =
-                                            ids.iter().map(|s| s.as_str()).collect();
                                         let _ = remote
-                                            .reorder_playlist(&pid, &id_refs, id_refs.len())
+                                            .move_playlist_item(&pid, &item_id, idx + 1)
                                             .await;
                                     }
+                                }
+                                MusicService::Subsonic | MusicService::Custom => {
+                                    let remote = server::subsonic::SubsonicClient::new(
+                                        &url,
+                                        &user_id,
+                                        &token,
+                                    );
+                                    let ids: Vec<String> = track_list
+                                        .iter()
+                                        .filter_map(|t| {
+                                            let s = t.path.to_string_lossy();
+                                            let parts: Vec<&str> = s.split(':').collect();
+                                            if parts.len() >= 2 {
+                                                Some(parts[1].to_string())
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .collect();
+                                    let id_refs: Vec<&str> =
+                                        ids.iter().map(|s| s.as_str()).collect();
+                                    let _ = remote
+                                        .reorder_playlist(&pid, &id_refs, id_refs.len())
+                                        .await;
                                 }
                             }
                         }

--- a/crates/components/src/playlist_detail.rs
+++ b/crates/components/src/playlist_detail.rs
@@ -77,153 +77,178 @@ pub fn PlaylistDetail(
                 let pid_clone = pid.clone();
                 let load_span =
                     tracing::info_span!("playlist.load_entries", playlist_id = %pid_clone);
-                spawn(async move {
-                    tracing::debug!("playlist entries load started");
-                    let server_info = {
-                        let conf = config.peek();
-                        conf.server.as_ref().and_then(|server| {
-                            if let (Some(token), Some(user_id)) =
-                                (&server.access_token, &server.user_id)
-                            {
-                                Some((
-                                    server.service.clone(),
-                                    server.url.clone(),
-                                    token.clone(),
-                                    conf.device_id.clone(),
-                                    user_id.clone(),
-                                ))
-                            } else {
-                                None
-                            }
-                        })
-                    };
-                    if let Some((service, url, token, device_id, user_id)) = server_info {
-                        match service {
-                            MusicService::YtMusic => {
-                                let yt = server::ytmusic::YouTubeMusicClient::with_cookies(
-                                    token.clone(),
-                                );
-                                if let Ok(yt_tracks) =
-                                    yt.get_playlist_entries(&pid_clone).await
+                spawn(
+                    async move {
+                        tracing::debug!("playlist entries load started");
+                        let server_info = {
+                            let conf = config.peek();
+                            conf.server.as_ref().and_then(|server| {
+                                if let (Some(token), Some(user_id)) =
+                                    (&server.access_token, &server.user_id)
                                 {
-                                    tracing::debug!(count = yt_tracks.len(), "playlist entries loaded, setting tracks");
-                                    tracks.set(yt_tracks);
-                                    has_loaded_jellyfin_tracks.set(true);
+                                    Some((
+                                        server.service.clone(),
+                                        server.url.clone(),
+                                        token.clone(),
+                                        conf.device_id.clone(),
+                                        user_id.clone(),
+                                    ))
+                                } else {
+                                    None
                                 }
-                            }
-                            MusicService::Jellyfin => {
-                                let remote = server::jellyfin::JellyfinClient::new(
-                                    &url,
-                                    Some(&token),
-                                    &device_id,
-                                    Some(&user_id),
-                                );
-                                if let Ok(items) = remote.get_playlist_items(&pid_clone).await {
-                                    let mut new_tracks = Vec::new();
-                                    for item in items {
-                                        let duration_secs =
-                                            item.run_time_ticks.unwrap_or(0) / 10_000_000;
-                                        let mut path_str = format!("jellyfin:{}", item.id);
-                                        if let Some(tags) = &item.image_tags {
-                                            if let Some(tag) = tags.get("Primary") {
-                                                path_str.push_str(&format!(":{}", tag));
+                            })
+                        };
+                        if let Some((service, url, token, device_id, user_id)) = server_info {
+                            match service {
+                                MusicService::YtMusic => {
+                                    let yt = server::ytmusic::YouTubeMusicClient::with_cookies(
+                                        token.clone(),
+                                    );
+                                    if let Ok(yt_tracks) = yt.get_playlist_entries(&pid_clone).await
+                                    {
+                                        tracing::debug!(
+                                            count = yt_tracks.len(),
+                                            "playlist entries loaded, setting tracks"
+                                        );
+                                        tracks.set(yt_tracks);
+                                        has_loaded_jellyfin_tracks.set(true);
+                                    }
+                                }
+                                MusicService::Jellyfin => {
+                                    let remote = server::jellyfin::JellyfinClient::new(
+                                        &url,
+                                        Some(&token),
+                                        &device_id,
+                                        Some(&user_id),
+                                    );
+                                    if let Ok(items) = remote.get_playlist_items(&pid_clone).await {
+                                        let mut new_tracks = Vec::new();
+                                        for item in items {
+                                            let duration_secs =
+                                                item.run_time_ticks.unwrap_or(0) / 10_000_000;
+                                            let mut path_str = format!("jellyfin:{}", item.id);
+                                            if let Some(tags) = &item.image_tags {
+                                                if let Some(tag) = tags.get("Primary") {
+                                                    path_str.push_str(&format!(":{}", tag));
+                                                }
                                             }
+                                            let bitrate_kbps = item.bitrate.unwrap_or(0) / 1000;
+                                            let bitrate_u16 =
+                                                bitrate_kbps.min(u16::MAX as u32) as u16;
+                                            let artist_str = item
+                                                .album_artist
+                                                .clone()
+                                                .or_else(|| {
+                                                    item.artists.as_ref().map(|a| a.join(", "))
+                                                })
+                                                .unwrap_or_default();
+                                            new_tracks.push(reader::models::Track {
+                                                path: PathBuf::from(path_str),
+                                                album_id: item
+                                                    .album_id
+                                                    .map(|id| format!("jellyfin:{}", id))
+                                                    .unwrap_or_default(),
+                                                title: item.name,
+                                                artist: artist_str,
+                                                album: item.album.unwrap_or_default(),
+                                                duration: duration_secs,
+                                                khz: item.sample_rate.unwrap_or(0),
+                                                bitrate: bitrate_u16,
+                                                track_number: item.index_number,
+                                                disc_number: item.parent_index_number,
+                                                musicbrainz_release_id: None,
+                                                musicbrainz_recording_id: None,
+                                                musicbrainz_track_id: None,
+                                                playlist_item_id: item.playlist_item_id,
+                                                artists: item.artists.unwrap_or_default(),
+                                            });
                                         }
-                                        let bitrate_kbps = item.bitrate.unwrap_or(0) / 1000;
-                                        let bitrate_u16 = bitrate_kbps.min(u16::MAX as u32) as u16;
-                                        let artist_str = item
-                                            .album_artist
-                                            .clone()
-                                            .or_else(|| item.artists.as_ref().map(|a| a.join(", ")))
-                                            .unwrap_or_default();
-                                        new_tracks.push(reader::models::Track {
-                                            path: PathBuf::from(path_str),
-                                            album_id: item
-                                                .album_id
-                                                .map(|id| format!("jellyfin:{}", id))
-                                                .unwrap_or_default(),
-                                            title: item.name,
-                                            artist: artist_str,
-                                            album: item.album.unwrap_or_default(),
-                                            duration: duration_secs,
-                                            khz: item.sample_rate.unwrap_or(0),
-                                            bitrate: bitrate_u16,
-                                            track_number: item.index_number,
-                                            disc_number: item.parent_index_number,
-                                            musicbrainz_release_id: None,
-                                            musicbrainz_recording_id: None,
-                                            musicbrainz_track_id: None,
-                                            playlist_item_id: item.playlist_item_id,
-                                            artists: item.artists.unwrap_or_default(),
-                                        });
+                                        tracing::debug!(
+                                            count = new_tracks.len(),
+                                            "playlist entries loaded, setting tracks"
+                                        );
+                                        tracks.set(new_tracks);
+                                        has_loaded_jellyfin_tracks.set(true);
                                     }
-                                    tracing::debug!(count = new_tracks.len(), "playlist entries loaded, setting tracks");
-                                    tracks.set(new_tracks);
-                                    has_loaded_jellyfin_tracks.set(true);
                                 }
-                            }
-                            MusicService::Subsonic | MusicService::Custom => {
-                                let remote =
-                                    server::subsonic::SubsonicClient::new(&url, &user_id, &token);
-                                if let Ok(items) = remote.get_playlist_entries(&pid_clone).await {
-                                    let mut new_tracks = Vec::new();
-                                    for item in items {
-                                        let cover_tag = item
-                                            .cover_art
-                                            .as_ref()
-                                            .and_then(|id| remote.cover_art_url(id, Some(512)).ok())
-                                            .map(|url| {
-                                                let mut hex = String::with_capacity(url.len() * 2);
-                                                for b in url.as_bytes() {
-                                                    hex.push_str(&format!("{:02x}", b));
-                                                }
-                                                format!("urlhex_{}", hex)
+                                MusicService::Subsonic | MusicService::Custom => {
+                                    let remote = server::subsonic::SubsonicClient::new(
+                                        &url, &user_id, &token,
+                                    );
+                                    if let Ok(items) = remote.get_playlist_entries(&pid_clone).await
+                                    {
+                                        let mut new_tracks = Vec::new();
+                                        for item in items {
+                                            let cover_tag = item
+                                                .cover_art
+                                                .as_ref()
+                                                .and_then(|id| {
+                                                    remote.cover_art_url(id, Some(512)).ok()
+                                                })
+                                                .map(|url| {
+                                                    let mut hex =
+                                                        String::with_capacity(url.len() * 2);
+                                                    for b in url.as_bytes() {
+                                                        hex.push_str(&format!("{:02x}", b));
+                                                    }
+                                                    format!("urlhex_{}", hex)
+                                                });
+                                            let path = if let Some(tag) = &cover_tag {
+                                                PathBuf::from(format!(
+                                                    "jellyfin:{}:{}",
+                                                    item.id, tag
+                                                ))
+                                            } else {
+                                                PathBuf::from(format!("jellyfin:{}", item.id))
+                                            };
+                                            let album_id = item
+                                                .album_id
+                                                .as_ref()
+                                                .map(|id| {
+                                                    if let Some(tag) = &cover_tag {
+                                                        format!("jellyfin:{}:{}", id, tag)
+                                                    } else {
+                                                        format!("jellyfin:{}:none", id)
+                                                    }
+                                                })
+                                                .unwrap_or_else(|| {
+                                                    format!("jellyfin:{}:none", item.id)
+                                                });
+                                            new_tracks.push(reader::models::Track {
+                                                path,
+                                                album_id,
+                                                title: item.title,
+                                                artist: item.artist.clone().unwrap_or_default(),
+                                                album: item.album.unwrap_or_default(),
+                                                duration: item.duration.unwrap_or(0),
+                                                khz: item.sampling_rate.unwrap_or(0),
+                                                bitrate: item
+                                                    .bit_rate
+                                                    .unwrap_or(0)
+                                                    .min(u16::MAX as u32)
+                                                    as u16,
+                                                track_number: item.track,
+                                                disc_number: item.disc_number,
+                                                musicbrainz_release_id: None,
+                                                musicbrainz_recording_id: None,
+                                                musicbrainz_track_id: None,
+                                                playlist_item_id: None,
+                                                artists: vec![item.artist.unwrap_or_default()],
                                             });
-                                        let path = if let Some(tag) = &cover_tag {
-                                            PathBuf::from(format!("jellyfin:{}:{}", item.id, tag))
-                                        } else {
-                                            PathBuf::from(format!("jellyfin:{}", item.id))
-                                        };
-                                        let album_id = item
-                                            .album_id
-                                            .as_ref()
-                                            .map(|id| {
-                                                if let Some(tag) = &cover_tag {
-                                                    format!("jellyfin:{}:{}", id, tag)
-                                                } else {
-                                                    format!("jellyfin:{}:none", id)
-                                                }
-                                            })
-                                            .unwrap_or_else(|| {
-                                                format!("jellyfin:{}:none", item.id)
-                                            });
-                                        new_tracks.push(reader::models::Track {
-                                            path,
-                                            album_id,
-                                            title: item.title,
-                                            artist: item.artist.clone().unwrap_or_default(),
-                                            album: item.album.unwrap_or_default(),
-                                            duration: item.duration.unwrap_or(0),
-                                            khz: item.sampling_rate.unwrap_or(0),
-                                            bitrate: item.bit_rate.unwrap_or(0).min(u16::MAX as u32)
-                                                as u16,
-                                            track_number: item.track,
-                                            disc_number: item.disc_number,
-                                            musicbrainz_release_id: None,
-                                            musicbrainz_recording_id: None,
-                                            musicbrainz_track_id: None,
-                                            playlist_item_id: None,
-                                            artists: vec![item.artist.unwrap_or_default()],
-                                        });
+                                        }
+                                        tracing::debug!(
+                                            count = new_tracks.len(),
+                                            "playlist entries loaded, setting tracks"
+                                        );
+                                        tracks.set(new_tracks);
+                                        has_loaded_jellyfin_tracks.set(true);
                                     }
-                                    tracing::debug!(count = new_tracks.len(), "playlist entries loaded, setting tracks");
-                                    tracks.set(new_tracks);
-                                    has_loaded_jellyfin_tracks.set(true);
                                 }
                             }
                         }
                     }
-                }.instrument(load_span));
+                    .instrument(load_span),
+                );
             }
         });
     }

--- a/crates/components/src/queue_drag.rs
+++ b/crates/components/src/queue_drag.rs
@@ -157,10 +157,8 @@ pub fn handle_select_click(
     is_selection_mode: bool,
     on_select: Option<EventHandler<bool>>,
 ) {
-    if is_selection_mode {
-        if let Some(handler) = on_select {
-            handler.call(!is_selected);
-        }
+    if is_selection_mode && let Some(handler) = on_select {
+        handler.call(!is_selected);
     }
 }
 

--- a/crates/components/src/queue_list_view.rs
+++ b/crates/components/src/queue_list_view.rs
@@ -618,7 +618,7 @@ pub fn QueueListView(
                 queue_count,
                 queue_duration,
                 current_queue_index,
-                layout: layout.clone(),
+                layout,
             }
 
             VirtualScrollView {
@@ -806,39 +806,42 @@ pub fn QueueListView(
                                             if queue_reorder_from.read().is_some() {
                                                 is_queue_drag_over.set(true);
                                                 queue_drop_index.set(Some(row_drop_index));
-                                                if let Some(from) = *queue_reorder_from.read() {
-                                                    if rightbar_reorder_move_target(from, row_drop_index, queue_count)
-                                                        .is_some()
-                                                    {
-                                                        queue_reorder_did_move.set(true);
-                                                    }
+                                                if let Some(from) = *queue_reorder_from.read()
+                                                    && rightbar_reorder_move_target(
+                                                        from,
+                                                        row_drop_index,
+                                                        queue_count,
+                                                    )
+                                                    .is_some()
+                                                {
+                                                    queue_reorder_did_move.set(true);
                                                 }
                                                 return;
                                             }
                                             let pending = *pending_queue_reorder.read();
-                                            if let Some((from_idx, start_x, start_y)) = pending {
-                                                if from_idx == queue_idx {
-                                                    let coords = evt.client_coordinates();
-                                                    let dx = coords.x - start_x;
-                                                    let dy = coords.y - start_y;
-                                                    if dx.hypot(dy) >= QUEUE_REORDER_THRESHOLD_PX {
-                                                        pending_queue_reorder.set(None);
-                                                        start_rightbar_reorder(
-                                                            queue_idx,
-                                                            queue_drop_index,
-                                                            queue_reorder_from,
-                                                            queue_reorder_did_move,
-                                                        );
-                                                        queue_drop_index.set(Some(row_drop_index));
-                                                        if rightbar_reorder_move_target(
-                                                                queue_idx,
-                                                                row_drop_index,
-                                                                queue_count,
-                                                            )
-                                                            .is_some()
-                                                        {
-                                                            queue_reorder_did_move.set(true);
-                                                        }
+                                            if let Some((from_idx, start_x, start_y)) = pending
+                                                && from_idx == queue_idx
+                                            {
+                                                let coords = evt.client_coordinates();
+                                                let dx = coords.x - start_x;
+                                                let dy = coords.y - start_y;
+                                                if dx.hypot(dy) >= QUEUE_REORDER_THRESHOLD_PX {
+                                                    pending_queue_reorder.set(None);
+                                                    start_rightbar_reorder(
+                                                        queue_idx,
+                                                        queue_drop_index,
+                                                        queue_reorder_from,
+                                                        queue_reorder_did_move,
+                                                    );
+                                                    queue_drop_index.set(Some(row_drop_index));
+                                                    if rightbar_reorder_move_target(
+                                                        queue_idx,
+                                                        row_drop_index,
+                                                        queue_count,
+                                                    )
+                                                    .is_some()
+                                                    {
+                                                        queue_reorder_did_move.set(true);
                                                     }
                                                 }
                                             }

--- a/crates/components/src/rightbar.rs
+++ b/crates/components/src/rightbar.rs
@@ -160,7 +160,7 @@ pub fn Rightbar(
 
                 while let Ok(val) = eval.recv::<Value>().await {
                     if let Some(w) = val.as_f64() {
-                        let new_width = w.max(280.0).min(600.0);
+                        let new_width = w.clamp(280.0, 600.0);
                         width.set(new_width as usize);
                     } else if val.as_str() == Some("stop") {
                         is_resizing.set(false);
@@ -182,11 +182,11 @@ pub fn Rightbar(
             ctrl.shuffle_order
                 .read()
                 .iter()
-                .filter_map(|&qi| q.get(qi).cloned().map(|t| t))
+                .filter_map(|&qi| q.get(qi).cloned())
                 .collect::<Vec<_>>()
         } else {
             (0..q.len())
-                .filter_map(|qi| q.get(qi).cloned().map(|t| t))
+                .filter_map(|qi| q.get(qi).cloned())
                 .collect::<Vec<_>>()
         }
     };

--- a/crates/components/src/settings_items.rs
+++ b/crates/components/src/settings_items.rs
@@ -3,12 +3,12 @@ use config::{
     MusicServer, SavedServer,
 };
 use dioxus::prelude::*;
-use tracing::Instrument;
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
 use rfd::AsyncFileDialog;
 use scrobble::lastfm;
 use scrobble::librefm;
+use tracing::Instrument;
 
 #[component]
 pub fn SettingItem(title: String, control: Element) -> Element {
@@ -526,10 +526,7 @@ pub fn LastFmSettings(
 }
 
 #[component]
-pub fn LibreFmSettings(
-    session_key: String,
-    on_session_key_save: EventHandler<String>,
-) -> Element {
+pub fn LibreFmSettings(session_key: String, on_session_key_save: EventHandler<String>) -> Element {
     rsx! {
         div {
             class: "flex flex-col gap-3 w-full max-w-xl",

--- a/crates/components/src/settings_popups.rs
+++ b/crates/components/src/settings_popups.rs
@@ -300,7 +300,7 @@ fn ServerServiceFields(
                     }
                 }
             }
-        },
+        }
         _ => rsx! {
             input {
                 placeholder: "{server_url_placeholder}",

--- a/crates/components/src/track_row.rs
+++ b/crates/components/src/track_row.rs
@@ -1,16 +1,16 @@
+use crate::NavigationController;
 use crate::constants::*;
 use crate::dots_menu::{DotsMenu, MenuAction};
 use crate::queue_drag::{
     clear_dragged_queue_track, handle_select_click, is_queue_drag_enabled, set_dragged_queue_track,
     set_dragged_queue_tracks,
 };
-use crate::NavigationController;
+use config::MusicSource;
 use config::{AppConfig, UiStyle};
 use dioxus::prelude::*;
 use hooks::PlayerController;
-use tracing::Instrument;
 use reader::models::Track;
-use config::MusicSource;
+use tracing::Instrument;
 
 pub(crate) fn copy_to_clipboard(text: &str) {
     let value = serde_json::to_string(text).unwrap_or_else(|_| "\"\"".to_string());
@@ -21,16 +21,19 @@ pub(crate) fn copy_to_clipboard(text: &str) {
 }
 
 pub(crate) fn share_to_musicbrainz(release_id: Option<String>, artist: String, title: String) {
-    spawn(async move {
-        if let Some(url) =
-            utils::musicbrainz::track_page_url(release_id.as_deref(), &artist, &title).await
-        {
-            copy_to_clipboard(&url);
-            toast("Copied MusicBrainz link");
-        } else {
-            toast("Couldn't find this track on MusicBrainz");
+    spawn(
+        async move {
+            if let Some(url) =
+                utils::musicbrainz::track_page_url(release_id.as_deref(), &artist, &title).await
+            {
+                copy_to_clipboard(&url);
+                toast("Copied MusicBrainz link");
+            } else {
+                toast("Couldn't find this track on MusicBrainz");
+            }
         }
-    }.instrument(tracing::info_span!("musicbrainz.fetch")));
+        .instrument(tracing::info_span!("musicbrainz.fetch")),
+    );
 }
 
 pub(crate) fn share_youtube_url(video_id: &str) {
@@ -171,8 +174,7 @@ pub fn TrackRow(
 
     let delete_action_idx = if !hide_delete {
         let idx = actions.len();
-        actions
-            .push(MenuAction::new(delete_song_text.as_str(), "fa-solid fa-trash").destructive());
+        actions.push(MenuAction::new(delete_song_text.as_str(), "fa-solid fa-trash").destructive());
         Some(idx)
     } else {
         None
@@ -187,7 +189,10 @@ pub fn TrackRow(
     let is_ytmusic_track = track.path.to_string_lossy().starts_with("ytmusic:");
     let mix_idx = if is_ytmusic_track {
         let idx = actions.len();
-        actions.push(MenuAction::new("Start radio", "fa-solid fa-tower-broadcast"));
+        actions.push(MenuAction::new(
+            "Start radio",
+            "fa-solid fa-tower-broadcast",
+        ));
         Some(idx)
     } else {
         None
@@ -485,11 +490,10 @@ pub fn TrackRow(
                                 }
                                 if let Some(queue_idx) = add_to_queue_idx
                                     && idx == queue_idx
+                                    && let Some(handler) = on_queue
                                 {
-                                    if let Some(handler) = on_queue {
-                                        handler.call(());
-                                        return;
-                                    }
+                                    handler.call(());
+                                    return;
                                 }
                                 if idx == add_to_playlist_idx {
                                     on_add_to_playlist.call(());
@@ -750,13 +754,13 @@ pub fn TrackRow(
                                 on_close_menu.call(());
                                 return;
                             }
-                            if let Some(queue_idx) = add_to_queue_idx {
-                                if idx == queue_idx {
-                                    if let Some(handler) = on_queue {
-                                        handler.call(());
-                                    }
-                                    return;
+                            if let Some(queue_idx) = add_to_queue_idx
+                                && idx == queue_idx
+                            {
+                                if let Some(handler) = on_queue {
+                                    handler.call(());
                                 }
+                                return;
                             }
 
                             if idx == add_to_playlist_idx {
@@ -821,14 +825,17 @@ fn start_radio_from(
         .as_ref()
         .and_then(|s| s.access_token.clone())
         .unwrap_or_default();
-    spawn(async move {
-        let yt = server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
-        match yt.start_mix(&video_id).await {
-            Ok(tracks) if !tracks.is_empty() => {
-                ctrl.play_queue_linear(tracks);
+    spawn(
+        async move {
+            let yt = server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
+            match yt.start_mix(&video_id).await {
+                Ok(tracks) if !tracks.is_empty() => {
+                    ctrl.play_queue_linear(tracks);
+                }
+                Ok(_) => tracing::debug!(seed = %video_id, "YT mix returned empty queue"),
+                Err(e) => tracing::warn!(seed = %video_id, error = %e, "YT mix failed"),
             }
-            Ok(_) => tracing::debug!(seed = %video_id, "YT mix returned empty queue"),
-            Err(e) => tracing::warn!(seed = %video_id, error = %e, "YT mix failed"),
         }
-    }.instrument(tracing::info_span!("mix.start")));
+        .instrument(tracing::info_span!("mix.start")),
+    );
 }

--- a/crates/discord-presence/src/lib.rs
+++ b/crates/discord-presence/src/lib.rs
@@ -51,7 +51,7 @@ impl Presence {
             Timestamps::new().start(start_time).end(end_time)
         };
 
-        let state = format!("{artist}");
+        let state = artist.to_string();
 
         let mut activity = activity::Activity::new()
             .details(title)

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -360,9 +360,7 @@ impl PlayerController {
             _ => {
                 if shuffle && queue_len > 1 {
                     !self.shuffle_order.peek().is_empty() || loop_mode == LoopMode::Queue
-                } else if shuffle && queue_len == 1 {
-                    true
-                } else if idx + 1 < queue_len {
+                } else if (shuffle && queue_len == 1) || idx + 1 < queue_len {
                     true
                 } else {
                     loop_mode == LoopMode::Queue
@@ -2153,6 +2151,7 @@ impl PlayerController {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn use_player_controller(
     player: Signal<Player>,
     is_playing: Signal<bool>,

--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -545,11 +545,7 @@ pub fn use_player_task(ctrl: PlayerController) {
                                 last_title.set(title.clone());
 
                                 let resolved = discord_cover_url.read().clone();
-                                let cover_ref = if let Some(ref url) = resolved {
-                                    Some(url.as_str())
-                                } else {
-                                    None
-                                };
+                                let cover_ref = resolved.as_deref();
 
                                 let _ = p.set_now_playing(
                                     &title, &artist, &album, progress, duration, cover_ref,

--- a/crates/hooks/src/use_search_data.rs
+++ b/crates/hooks/src/use_search_data.rs
@@ -214,16 +214,15 @@ async fn search_ytmusic(query: &str, cookies: Option<String>) -> Option<(TrackRe
         .into_iter()
         .map(|t| {
             let path_str = t.path.to_string_lossy();
-            let cover_url = utils::map_cover_url(
-                utils::jellyfin_image::track_cover_url_with_album_fallback(
+            let cover_url =
+                utils::map_cover_url(utils::jellyfin_image::track_cover_url_with_album_fallback(
                     &path_str,
                     &t.album_id,
                     "",
                     None,
                     80,
                     80,
-                ),
-            );
+                ));
             (t, cover_url)
         })
         .collect();
@@ -252,7 +251,7 @@ pub fn use_search_data(
 ) -> SearchData {
     let genres = use_memo(move || {
         let conf = config.read();
-        let active_source = conf.active_source.clone();
+        let active_source = conf.active_source;
         let active_service = conf.active_service();
         let server = conf.server.clone();
         let lib = library.read();
@@ -341,7 +340,7 @@ pub fn use_search_data(
         let (active_source, active_service, server) = {
             let conf = config.read();
             (
-                conf.active_source.clone(),
+                conf.active_source,
                 conf.active_service(),
                 conf.server.clone(),
             )

--- a/crates/kopuz/build.rs
+++ b/crates/kopuz/build.rs
@@ -216,10 +216,10 @@ fn copy_kt_dir(src: &Path, dst: &Path) {
     }
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().and_then(|e| e.to_str()) == Some("kt") {
-            if let Some(name) = path.file_name() {
-                copy_file(&path, &dst.join(name));
-            }
+        if path.extension().and_then(|e| e.to_str()) == Some("kt")
+            && let Some(name) = path.file_name()
+        {
+            copy_file(&path, &dst.join(name));
         }
     }
 }
@@ -291,9 +291,9 @@ fn patch_manifest(path: &Path) {
         );
     }
 
-    if content != original {
-        if let Err(e) = fs::write(path, &content) {
-            warn(&format!("cannot write {}: {e}", path.display()));
-        }
+    if content != original
+        && let Err(e) = fs::write(path, &content)
+    {
+        warn(&format!("cannot write {}: {e}", path.display()));
     }
 }

--- a/crates/kopuz/src/logging.rs
+++ b/crates/kopuz/src/logging.rs
@@ -221,16 +221,16 @@ fn install_panic_hook() {
                 .unwrap_or_else(|| "unknown".to_string());
             let backtrace = std::backtrace::Backtrace::force_capture().to_string();
 
-            if let Some(dir) = utils::logs::log_dir() {
-                if let Some(path) = utils::logs::write_crash_report(
+            if let Some(dir) = utils::logs::log_dir()
+                && let Some(path) = utils::logs::write_crash_report(
                     &dir,
                     env!("CARGO_PKG_VERSION"),
                     &message,
                     &location,
                     &backtrace,
-                ) {
-                    tracing::error!(crash_report = %path.display(), panic = %message, %location, "panic — crash report written");
-                }
+                )
+            {
+                tracing::error!(crash_report = %path.display(), panic = %message, %location, "panic — crash report written");
             }
         }
         default(info);

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -20,7 +20,6 @@ use dioxus::desktop::tao::platform::windows::WindowExtWindows;
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
 use dioxus::desktop::tao::window::Icon;
 use dioxus::prelude::*;
-use tracing::Instrument;
 #[cfg(not(target_arch = "wasm32"))]
 use discord_presence::Presence;
 use kopuz_route::Route;
@@ -32,6 +31,7 @@ use reader::FavoritesStore;
 use std::path::PathBuf;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
+use tracing::Instrument;
 #[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
 use windows::Win32::Foundation::HWND;
 
@@ -197,14 +197,17 @@ async fn fetch_available_update() -> Option<AvailableUpdate> {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn persist_config_snapshot(config_snapshot: config::AppConfig, path: std::path::PathBuf) {
-    spawn(async move {
-        let result = tokio::task::spawn_blocking(move || config_snapshot.save(&path)).await;
-        match result {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => tracing::error!("Failed to save config: {}", e),
-            Err(e) => tracing::error!("Failed to join config save task: {}", e),
+    spawn(
+        async move {
+            let result = tokio::task::spawn_blocking(move || config_snapshot.save(&path)).await;
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::error!("Failed to save config: {}", e),
+                Err(e) => tracing::error!("Failed to join config save task: {}", e),
+            }
         }
-    }.instrument(tracing::info_span!("config.persist")));
+        .instrument(tracing::info_span!("config.persist")),
+    );
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -503,7 +506,9 @@ fn main() {
         // so the setting is applied at startup. Same path the settings UI
         // writes to. Missing/unreadable config defaults to off.
         let config_tracing_enabled = directories::ProjectDirs::from("com", "temidaradev", "kopuz")
-            .map(|dirs| config::AppConfig::load(&dirs.config_dir().join("config.json")).tracing_enabled)
+            .map(|dirs| {
+                config::AppConfig::load(&dirs.config_dir().join("config.json")).tracing_enabled
+            })
             .unwrap_or(false);
 
         // Guards live in a global inside `logging`; flushed by
@@ -577,184 +582,190 @@ fn main() {
                 |_id, request, responder: RequestAsyncResponder| {
                     let uri = request.uri().clone();
 
-                    tokio::spawn(async move {
-                        let query = uri.query().unwrap_or_default();
-                        let file_path: String = query
-                            .split('&')
-                            .find_map(|kv| kv.strip_prefix("p="))
-                            .map(|encoded| {
-                                percent_encoding::percent_decode_str(encoded)
-                                    .decode_utf8_lossy()
-                                    .into_owned()
-                            })
-                            .unwrap_or_default();
-                        let high_quality = query.split('&').any(|kv| kv == "hq=1");
+                    tokio::spawn(
+                        async move {
+                            let query = uri.query().unwrap_or_default();
+                            let file_path: String = query
+                                .split('&')
+                                .find_map(|kv| kv.strip_prefix("p="))
+                                .map(|encoded| {
+                                    percent_encoding::percent_decode_str(encoded)
+                                        .decode_utf8_lossy()
+                                        .into_owned()
+                                })
+                                .unwrap_or_default();
+                            let high_quality = query.split('&').any(|kv| kv == "hq=1");
 
-                        if file_path.is_empty() {
-                            responder.respond(
-                                http::Response::builder()
-                                    .status(400)
-                                    .body(std::borrow::Cow::from(Vec::new()))
-                                    .unwrap(),
-                            );
-                            return;
-                        }
-
-                        #[cfg(target_os = "windows")]
-                        let file_path = file_path.replace('/', "\\");
-
-                        #[cfg(not(target_os = "windows"))]
-                        let file_path = if file_path.starts_with('~') {
-                            if let Ok(home) = std::env::var("HOME") {
-                                file_path.replacen('~', &home, 1)
-                            } else {
-                                file_path
-                            }
-                        } else {
-                            file_path
-                        };
-
-                        if high_quality {
-                            let hq_path = hq_cache_path(&file_path);
-                            if hq_path.exists()
-                                && let Ok(b) = tokio::fs::read(&hq_path).await
-                            {
+                            if file_path.is_empty() {
                                 responder.respond(
                                     http::Response::builder()
-                                        .header("Content-Type", "image/jpeg")
-                                        .header("Access-Control-Allow-Origin", "*")
-                                        .header("Cache-Control", "public, max-age=31536000")
-                                        .body(std::borrow::Cow::from(b))
+                                        .status(400)
+                                        .body(std::borrow::Cow::from(Vec::new()))
                                         .unwrap(),
                                 );
                                 return;
                             }
-                            match tokio::fs::read(&file_path).await {
-                                Ok(raw) => {
-                                    let file_path_clone = file_path.clone();
-                                    let result = tokio::task::spawn_blocking(move || {
-                                        make_hq_image(&raw, &hq_path)
-                                            .map(|b| (b, "image/jpeg"))
-                                            .unwrap_or_else(|| {
-                                                let mime = if file_path_clone.ends_with(".png") {
-                                                    "image/png"
-                                                } else {
-                                                    "image/jpeg"
-                                                };
-                                                (raw, mime)
-                                            })
-                                    })
-                                    .await;
-                                    match result {
-                                        Ok((bytes, mime)) => responder.respond(
-                                            http::Response::builder()
-                                                .header("Content-Type", mime)
-                                                .header("Access-Control-Allow-Origin", "*")
-                                                .header("Cache-Control", "public, max-age=31536000")
-                                                .body(std::borrow::Cow::from(bytes))
-                                                .unwrap(),
-                                        ),
-                                        Err(_) => responder.respond(
-                                            http::Response::builder()
-                                                .status(500)
-                                                .body(std::borrow::Cow::from(Vec::new()))
-                                                .unwrap(),
-                                        ),
-                                    }
-                                }
-                                Err(_) => responder.respond(
-                                    http::Response::builder()
-                                        .status(404)
-                                        .body(std::borrow::Cow::from(Vec::new()))
-                                        .unwrap(),
-                                ),
-                            }
-                            return;
-                        }
 
-                        let thumb_path = thumb_cache_path(&file_path);
+                            #[cfg(target_os = "windows")]
+                            let file_path = file_path.replace('/', "\\");
 
-                        let (bytes, mime) = if thumb_path.exists() {
-                            match tokio::fs::read(&thumb_path).await {
-                                Ok(b) => (b, "image/jpeg"),
-                                Err(_) => {
-                                    let _ = std::fs::remove_file(&thumb_path);
-                                    match tokio::fs::read(&file_path).await {
-                                        Ok(b) => (
-                                            b,
-                                            if file_path.ends_with(".png") {
-                                                "image/png"
-                                            } else {
-                                                "image/jpeg"
-                                            },
-                                        ),
-                                        Err(_) => {
-                                            responder.respond(
-                                                http::Response::builder()
-                                                    .status(404)
-                                                    .body(std::borrow::Cow::from(Vec::new()))
-                                                    .unwrap(),
-                                            );
-                                            return;
-                                        }
-                                    }
+                            #[cfg(not(target_os = "windows"))]
+                            let file_path = if file_path.starts_with('~') {
+                                if let Ok(home) = std::env::var("HOME") {
+                                    file_path.replacen('~', &home, 1)
+                                } else {
+                                    file_path
                                 }
-                            }
-                        } else {
-                            match tokio::fs::read(&file_path).await {
-                                Ok(raw) => {
-                                    let thumb_path_clone = thumb_path.clone();
-                                    match tokio::task::spawn_blocking(move || match make_thumbnail(
-                                        &raw,
-                                        &thumb_path_clone,
-                                    ) {
-                                        Some(b) => Ok(b),
-                                        None => Err(raw),
-                                    })
-                                    .await
-                                    {
-                                        Ok(Ok(b)) => (b, "image/jpeg"),
-                                        Ok(Err(raw)) => (
-                                            raw,
-                                            if file_path.ends_with(".png") {
-                                                "image/png"
-                                            } else {
-                                                "image/jpeg"
-                                            },
-                                        ),
-                                        Err(_) => {
-                                            responder.respond(
-                                                http::Response::builder()
-                                                    .status(500)
-                                                    .body(std::borrow::Cow::from(Vec::new()))
-                                                    .unwrap(),
-                                            );
-                                            return;
-                                        }
-                                    }
-                                }
-                                Err(e) => {
-                                    tracing::warn!("[artwork] not found {}: {}", file_path, e);
+                            } else {
+                                file_path
+                            };
+
+                            if high_quality {
+                                let hq_path = hq_cache_path(&file_path);
+                                if hq_path.exists()
+                                    && let Ok(b) = tokio::fs::read(&hq_path).await
+                                {
                                     responder.respond(
                                         http::Response::builder()
-                                            .status(404)
-                                            .body(std::borrow::Cow::from(Vec::new()))
+                                            .header("Content-Type", "image/jpeg")
+                                            .header("Access-Control-Allow-Origin", "*")
+                                            .header("Cache-Control", "public, max-age=31536000")
+                                            .body(std::borrow::Cow::from(b))
                                             .unwrap(),
                                     );
                                     return;
                                 }
+                                match tokio::fs::read(&file_path).await {
+                                    Ok(raw) => {
+                                        let file_path_clone = file_path.clone();
+                                        let result = tokio::task::spawn_blocking(move || {
+                                            make_hq_image(&raw, &hq_path)
+                                                .map(|b| (b, "image/jpeg"))
+                                                .unwrap_or_else(|| {
+                                                    let mime = if file_path_clone.ends_with(".png")
+                                                    {
+                                                        "image/png"
+                                                    } else {
+                                                        "image/jpeg"
+                                                    };
+                                                    (raw, mime)
+                                                })
+                                        })
+                                        .await;
+                                        match result {
+                                            Ok((bytes, mime)) => responder.respond(
+                                                http::Response::builder()
+                                                    .header("Content-Type", mime)
+                                                    .header("Access-Control-Allow-Origin", "*")
+                                                    .header(
+                                                        "Cache-Control",
+                                                        "public, max-age=31536000",
+                                                    )
+                                                    .body(std::borrow::Cow::from(bytes))
+                                                    .unwrap(),
+                                            ),
+                                            Err(_) => responder.respond(
+                                                http::Response::builder()
+                                                    .status(500)
+                                                    .body(std::borrow::Cow::from(Vec::new()))
+                                                    .unwrap(),
+                                            ),
+                                        }
+                                    }
+                                    Err(_) => responder.respond(
+                                        http::Response::builder()
+                                            .status(404)
+                                            .body(std::borrow::Cow::from(Vec::new()))
+                                            .unwrap(),
+                                    ),
+                                }
+                                return;
                             }
-                        };
 
-                        responder.respond(
-                            http::Response::builder()
-                                .header("Content-Type", mime)
-                                .header("Access-Control-Allow-Origin", "*")
-                                .header("Cache-Control", "public, max-age=31536000")
-                                .body(std::borrow::Cow::from(bytes))
-                                .unwrap(),
-                        );
-                    }.instrument(tracing::info_span!("artwork.serve")));
+                            let thumb_path = thumb_cache_path(&file_path);
+
+                            let (bytes, mime) = if thumb_path.exists() {
+                                match tokio::fs::read(&thumb_path).await {
+                                    Ok(b) => (b, "image/jpeg"),
+                                    Err(_) => {
+                                        let _ = std::fs::remove_file(&thumb_path);
+                                        match tokio::fs::read(&file_path).await {
+                                            Ok(b) => (
+                                                b,
+                                                if file_path.ends_with(".png") {
+                                                    "image/png"
+                                                } else {
+                                                    "image/jpeg"
+                                                },
+                                            ),
+                                            Err(_) => {
+                                                responder.respond(
+                                                    http::Response::builder()
+                                                        .status(404)
+                                                        .body(std::borrow::Cow::from(Vec::new()))
+                                                        .unwrap(),
+                                                );
+                                                return;
+                                            }
+                                        }
+                                    }
+                                }
+                            } else {
+                                match tokio::fs::read(&file_path).await {
+                                    Ok(raw) => {
+                                        let thumb_path_clone = thumb_path.clone();
+                                        match tokio::task::spawn_blocking(move || {
+                                            match make_thumbnail(&raw, &thumb_path_clone) {
+                                                Some(b) => Ok(b),
+                                                None => Err(raw),
+                                            }
+                                        })
+                                        .await
+                                        {
+                                            Ok(Ok(b)) => (b, "image/jpeg"),
+                                            Ok(Err(raw)) => (
+                                                raw,
+                                                if file_path.ends_with(".png") {
+                                                    "image/png"
+                                                } else {
+                                                    "image/jpeg"
+                                                },
+                                            ),
+                                            Err(_) => {
+                                                responder.respond(
+                                                    http::Response::builder()
+                                                        .status(500)
+                                                        .body(std::borrow::Cow::from(Vec::new()))
+                                                        .unwrap(),
+                                                );
+                                                return;
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!("[artwork] not found {}: {}", file_path, e);
+                                        responder.respond(
+                                            http::Response::builder()
+                                                .status(404)
+                                                .body(std::borrow::Cow::from(Vec::new()))
+                                                .unwrap(),
+                                        );
+                                        return;
+                                    }
+                                }
+                            };
+
+                            responder.respond(
+                                http::Response::builder()
+                                    .header("Content-Type", mime)
+                                    .header("Access-Control-Allow-Origin", "*")
+                                    .header("Cache-Control", "public, max-age=31536000")
+                                    .body(std::borrow::Cow::from(bytes))
+                                    .unwrap(),
+                            );
+                        }
+                        .instrument(tracing::info_span!("artwork.serve")),
+                    );
                 },
             );
 
@@ -1083,11 +1094,14 @@ fn App() -> Element {
     use_effect(move || {
         let url = current_song_cover_url.read().clone();
         if !url.is_empty() {
-            spawn(async move {
-                if let Some(colors) = utils::color::get_palette_from_url(&url).await {
-                    palette.set(Some(colors));
+            spawn(
+                async move {
+                    if let Some(colors) = utils::color::get_palette_from_url(&url).await {
+                        palette.set(Some(colors));
+                    }
                 }
-            }.instrument(tracing::info_span!("ui.palette_fetch")));
+                .instrument(tracing::info_span!("ui.palette_fetch")),
+            );
         } else {
             palette.set(None);
         }
@@ -1129,23 +1143,26 @@ fn App() -> Element {
         }
         last_radio_registry_key.set(Some(key));
 
-        spawn(async move {
-            let mut new_registry = radio::registry::StationRegistry::new();
-            let mut import_count = 0;
+        spawn(
+            async move {
+                let mut new_registry = radio::registry::StationRegistry::new();
+                let mut import_count = 0;
 
-            for path in registry_paths {
-                match new_registry.import_registry(&path).await {
-                    Ok(_) => import_count += 1,
-                    Err(e) => tracing::warn!("Failed to import registry from {}: {}", path, e),
+                for path in registry_paths {
+                    match new_registry.import_registry(&path).await {
+                        Ok(_) => import_count += 1,
+                        Err(e) => tracing::warn!("Failed to import registry from {}: {}", path, e),
+                    }
+                }
+
+                station_registry.set(new_registry);
+
+                if import_count > 0 {
+                    tracing::info!("Imported {} external radio registries", import_count);
                 }
             }
-
-            station_registry.set(new_registry);
-
-            if import_count > 0 {
-                tracing::info!("Imported {} external radio registries", import_count);
-            }
-        }.instrument(tracing::info_span!("radio.registry_load")));
+            .instrument(tracing::info_span!("radio.registry_load")),
+        );
     });
 
     let mut selected_album_id = use_signal(String::new);
@@ -1249,11 +1266,14 @@ fn App() -> Element {
         }
 
         did_check_updates.set(true);
-        spawn(async move {
-            if let Some(update) = fetch_available_update().await {
-                update_banner.set(Some(update));
+        spawn(
+            async move {
+                if let Some(update) = fetch_available_update().await {
+                    update_banner.set(Some(update));
+                }
             }
-        }.instrument(tracing::info_span!("app.update_check")));
+            .instrument(tracing::info_span!("app.update_check")),
+        );
     });
 
     use_effect(move || {
@@ -1318,11 +1338,7 @@ fn App() -> Element {
             run_rotation(config).await;
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(300)).await;
-                if yt_keepalive_identity
-                    .peek()
-                    .as_deref()
-                    != Some(my_identity.as_str())
-                {
+                if yt_keepalive_identity.peek().as_deref() != Some(my_identity.as_str()) {
                     return;
                 }
                 run_rotation(config).await;
@@ -1357,12 +1373,16 @@ fn App() -> Element {
         {
             let store_snapshot = playlist_store.read().clone();
             let path = playlist_path();
-            spawn(async move {
-                let result = tokio::task::spawn_blocking(move || store_snapshot.save(&path)).await;
-                if let Ok(Err(e)) = result {
-                    tracing::error!("Failed to save playlists: {}", e);
+            spawn(
+                async move {
+                    let result =
+                        tokio::task::spawn_blocking(move || store_snapshot.save(&path)).await;
+                    if let Ok(Err(e)) = result {
+                        tracing::error!("Failed to save playlists: {}", e);
+                    }
                 }
-            }.instrument(tracing::info_span!("playlists.persist")));
+                .instrument(tracing::info_span!("playlists.persist")),
+            );
         }
         #[cfg(target_arch = "wasm32")]
         {
@@ -1379,12 +1399,16 @@ fn App() -> Element {
         {
             let lib_snapshot = library.read().clone();
             let path = lib_path();
-            spawn(async move {
-                let result = tokio::task::spawn_blocking(move || lib_snapshot.save(&path)).await;
-                if let Ok(Err(e)) = result {
-                    tracing::error!("Failed to save library: {}", e);
+            spawn(
+                async move {
+                    let result =
+                        tokio::task::spawn_blocking(move || lib_snapshot.save(&path)).await;
+                    if let Ok(Err(e)) = result {
+                        tracing::error!("Failed to save library: {}", e);
+                    }
                 }
-            }.instrument(tracing::info_span!("library.persist")));
+                .instrument(tracing::info_span!("library.persist")),
+            );
         }
         #[cfg(target_arch = "wasm32")]
         {
@@ -1401,12 +1425,16 @@ fn App() -> Element {
         {
             let store_snapshot = favorites_store.read().clone();
             let path = favorites_path();
-            spawn(async move {
-                let result = tokio::task::spawn_blocking(move || store_snapshot.save(&path)).await;
-                if let Ok(Err(e)) = result {
-                    tracing::error!("Failed to save favorites: {}", e);
+            spawn(
+                async move {
+                    let result =
+                        tokio::task::spawn_blocking(move || store_snapshot.save(&path)).await;
+                    if let Ok(Err(e)) = result {
+                        tracing::error!("Failed to save favorites: {}", e);
+                    }
                 }
-            }.instrument(tracing::info_span!("favorites.persist")));
+                .instrument(tracing::info_span!("favorites.persist")),
+            );
         }
         #[cfg(target_arch = "wasm32")]
         {
@@ -1554,74 +1582,81 @@ fn App() -> Element {
             let queue_state_path = queue_state_path();
             let mut ctrl = ctrl;
 
-            spawn(async move {
-                let lib_path_c = lib_path.clone();
-                let config_path_c = config_path.clone();
-                let playlist_path_c = playlist_path.clone();
-                let favorites_path_c = favorites_path.clone();
-                let queue_state_path_c = queue_state_path.clone();
+            spawn(
+                async move {
+                    let lib_path_c = lib_path.clone();
+                    let config_path_c = config_path.clone();
+                    let playlist_path_c = playlist_path.clone();
+                    let favorites_path_c = favorites_path.clone();
+                    let queue_state_path_c = queue_state_path.clone();
 
-                let (lib_res, cfg_res, pl_res, fav_res, queue_res) = tokio::join!(
-                    tokio::task::spawn_blocking(move || reader::Library::load(&lib_path_c)),
-                    tokio::task::spawn_blocking(move || config::AppConfig::load(&config_path_c)),
-                    tokio::task::spawn_blocking(move || reader::PlaylistStore::load(
-                        &playlist_path_c
-                    )),
-                    tokio::task::spawn_blocking(move || FavoritesStore::load(&favorites_path_c)),
-                    tokio::task::spawn_blocking(move || {
-                        PersistedQueueState::load(&queue_state_path_c)
-                    }),
-                );
-
-                if let Ok(Ok(loaded)) = lib_res {
-                    library.set(loaded.clone());
-                }
-                if let Ok(loaded) = cfg_res {
-                    config.set(loaded.clone());
-                    configured_music_dirs.set(loaded.music_directory.clone());
-                    volume.set(loaded.volume);
-                    persisted_volume.set(loaded.volume);
-                    player.write().set_volume(loaded.volume);
-                    player.write().set_channel_mode(loaded.channel_mode);
-                    player.write().set_equalizer(loaded.equalizer.clone());
-                    i18n::set_locale(&loaded.language);
-                }
-                if let Ok(Ok(loaded)) = pl_res {
-                    playlist_store.set(loaded);
-                }
-                if let Ok(Ok(loaded)) = fav_res {
-                    favorites_store.set(loaded);
-                }
-
-                {
-                    let cfg = config.peek();
-                    let no_local_tracks = library.peek().tracks.is_empty();
-                    let server_connected = cfg
-                        .server
-                        .as_ref()
-                        .and_then(|s| s.access_token.as_ref())
-                        .is_some();
-                    let not_explicitly_set = !cfg.source_explicitly_set;
-                    drop(cfg);
-                    if no_local_tracks && server_connected && not_explicitly_set {
-                        config.write().active_source = config::MusicSource::Server;
-                    }
-                }
-
-                if let Ok(Ok(loaded_queue_state)) = queue_res
-                    && let Some(queue_state) = sanitize_queue_state(loaded_queue_state)
-                {
-                    ctrl.restore_queue_state(
-                        queue_state.queue,
-                        queue_state.current_queue_index,
-                        queue_state.progress_secs,
-                        queue_state.shuffle_order,
-                        queue_state.shuffle_enabled,
+                    let (lib_res, cfg_res, pl_res, fav_res, queue_res) = tokio::join!(
+                        tokio::task::spawn_blocking(move || reader::Library::load(&lib_path_c)),
+                        tokio::task::spawn_blocking(move || config::AppConfig::load(
+                            &config_path_c
+                        )),
+                        tokio::task::spawn_blocking(move || reader::PlaylistStore::load(
+                            &playlist_path_c
+                        )),
+                        tokio::task::spawn_blocking(move || FavoritesStore::load(
+                            &favorites_path_c
+                        )),
+                        tokio::task::spawn_blocking(move || {
+                            PersistedQueueState::load(&queue_state_path_c)
+                        }),
                     );
-                }
 
-                initial_load_done.set(true);
-            }.instrument(tracing::info_span!("startup.load")));
+                    if let Ok(Ok(loaded)) = lib_res {
+                        library.set(loaded.clone());
+                    }
+                    if let Ok(loaded) = cfg_res {
+                        config.set(loaded.clone());
+                        configured_music_dirs.set(loaded.music_directory.clone());
+                        volume.set(loaded.volume);
+                        persisted_volume.set(loaded.volume);
+                        player.write().set_volume(loaded.volume);
+                        player.write().set_channel_mode(loaded.channel_mode);
+                        player.write().set_equalizer(loaded.equalizer.clone());
+                        i18n::set_locale(&loaded.language);
+                    }
+                    if let Ok(Ok(loaded)) = pl_res {
+                        playlist_store.set(loaded);
+                    }
+                    if let Ok(Ok(loaded)) = fav_res {
+                        favorites_store.set(loaded);
+                    }
+
+                    {
+                        let cfg = config.peek();
+                        let no_local_tracks = library.peek().tracks.is_empty();
+                        let server_connected = cfg
+                            .server
+                            .as_ref()
+                            .and_then(|s| s.access_token.as_ref())
+                            .is_some();
+                        let not_explicitly_set = !cfg.source_explicitly_set;
+                        drop(cfg);
+                        if no_local_tracks && server_connected && not_explicitly_set {
+                            config.write().active_source = config::MusicSource::Server;
+                        }
+                    }
+
+                    if let Ok(Ok(loaded_queue_state)) = queue_res
+                        && let Some(queue_state) = sanitize_queue_state(loaded_queue_state)
+                    {
+                        ctrl.restore_queue_state(
+                            queue_state.queue,
+                            queue_state.current_queue_index,
+                            queue_state.progress_secs,
+                            queue_state.shuffle_order,
+                            queue_state.shuffle_enabled,
+                        );
+                    }
+
+                    initial_load_done.set(true);
+                }
+                .instrument(tracing::info_span!("startup.load")),
+            );
         }
         #[cfg(target_arch = "wasm32")]
         {
@@ -1730,133 +1765,146 @@ fn App() -> Element {
         last_scan_key.set(Some(scan_key));
 
         #[cfg(not(target_arch = "wasm32"))]
-        spawn(async move {
-            let configured_dirs = configured_dirs;
-            let scannable_dirs: Vec<PathBuf> = configured_dirs
-                .iter()
-                .filter(|d| d.exists())
-                .cloned()
-                .collect();
-            let mut current_lib = library.peek().clone();
+        spawn(
+            async move {
+                let configured_dirs = configured_dirs;
+                let scannable_dirs: Vec<PathBuf> = configured_dirs
+                    .iter()
+                    .filter(|d| d.exists())
+                    .cloned()
+                    .collect();
+                let mut current_lib = library.peek().clone();
 
-            let current_roots: std::collections::HashSet<_> =
-                current_lib.root_paths.iter().cloned().collect();
-            let new_roots: std::collections::HashSet<_> = configured_dirs.iter().cloned().collect();
+                let current_roots: std::collections::HashSet<_> =
+                    current_lib.root_paths.iter().cloned().collect();
+                let new_roots: std::collections::HashSet<_> =
+                    configured_dirs.iter().cloned().collect();
 
-            if current_roots != new_roots {
-                current_lib.root_paths = configured_dirs.clone();
-                current_lib.tracks.clear();
-                current_lib.albums.clear();
-                library.set(current_lib.clone());
-            }
-
-            if !configured_dirs.is_empty() {
-                current_lib.local_artist_images.clear();
-                scan_current_file.set(Some(String::new()));
-
-                let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-                spawn(async move {
-                    while let Some(file) = rx.recv().await {
-                        scan_current_file.set(Some(file));
-                    }
-                    scan_current_file.set(None);
-                });
-
-                let progress_cb: std::sync::Arc<dyn Fn(String) + Send + Sync> =
-                    std::sync::Arc::new(move |file: String| {
-                        let _ = tx.send(file);
-                    });
-                for dir in &scannable_dirs {
-                    let _ = reader::scan_directory(
-                        dir.clone(),
-                        cover_cache(),
-                        &mut current_lib,
-                        progress_cb.clone(),
-                    )
-                    .await;
+                if current_roots != new_roots {
+                    current_lib.root_paths = configured_dirs.clone();
+                    current_lib.tracks.clear();
+                    current_lib.albums.clear();
+                    library.set(current_lib.clone());
                 }
 
-                current_lib.tracks.retain(|t| {
-                    let in_configured_root = configured_dirs.iter().any(|d| t.path.starts_with(d));
-                    let in_scannable_root = scannable_dirs.iter().any(|d| t.path.starts_with(d));
+                if !configured_dirs.is_empty() {
+                    current_lib.local_artist_images.clear();
+                    scan_current_file.set(Some(String::new()));
 
-                    in_configured_root && (!in_scannable_root || t.path.exists())
-                });
-
-                let valid_album_ids: std::collections::HashSet<_> = current_lib
-                    .tracks
-                    .iter()
-                    .map(|t| t.album_id.clone())
-                    .collect();
-                current_lib
-                    .albums
-                    .retain(|a| valid_album_ids.contains(&a.id));
-
-                // Show the library immediately — before any cover fetching.
-                library.set(current_lib.clone());
-                let _ = current_lib.save(&lib_path());
-
-                if fetch_covers {
-                    // Fetch missing covers in the background so the UI stays responsive.
-                    // Passing `progress_cb` into the task keeps the scan-progress bar
-                    // alive during fetching; it disappears automatically when the task ends.
-                    let lib_for_fetch = current_lib;
+                    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
                     spawn(async move {
-                        let fetcher = reader::cover_fetcher::CoverFetcher::new(
+                        while let Some(file) = rx.recv().await {
+                            scan_current_file.set(Some(file));
+                        }
+                        scan_current_file.set(None);
+                    });
+
+                    let progress_cb: std::sync::Arc<dyn Fn(String) + Send + Sync> =
+                        std::sync::Arc::new(move |file: String| {
+                            let _ = tx.send(file);
+                        });
+                    for dir in &scannable_dirs {
+                        let _ = reader::scan_directory(
+                            dir.clone(),
                             cover_cache(),
-                            fetch_strategy,
-                            lastfm_key,
-                            progress_cb,
-                        );
-                        let mut lib = lib_for_fetch;
-                        let report = fetcher.fetch_missing_covers(&mut lib).await;
-                        tracing::info!(
-                            "Cover auto-fetch: {} found, {} missing, {} errors",
-                            report.found,
-                            report.missing,
-                            report.errors,
-                        );
-                        let merged_lib = {
-                            let mut current = library.write();
-                            let mut changed = false;
+                            &mut current_lib,
+                            progress_cb.clone(),
+                        )
+                        .await;
+                    }
 
-                            for fetched_album in lib.albums.iter() {
-                                let Some(fetched_cover) = fetched_album.cover_path.clone() else {
-                                    continue;
+                    current_lib.tracks.retain(|t| {
+                        let in_configured_root =
+                            configured_dirs.iter().any(|d| t.path.starts_with(d));
+                        let in_scannable_root =
+                            scannable_dirs.iter().any(|d| t.path.starts_with(d));
+
+                        in_configured_root && (!in_scannable_root || t.path.exists())
+                    });
+
+                    let valid_album_ids: std::collections::HashSet<_> = current_lib
+                        .tracks
+                        .iter()
+                        .map(|t| t.album_id.clone())
+                        .collect();
+                    current_lib
+                        .albums
+                        .retain(|a| valid_album_ids.contains(&a.id));
+
+                    // Show the library immediately — before any cover fetching.
+                    library.set(current_lib.clone());
+                    let _ = current_lib.save(&lib_path());
+
+                    if fetch_covers {
+                        // Fetch missing covers in the background so the UI stays responsive.
+                        // Passing `progress_cb` into the task keeps the scan-progress bar
+                        // alive during fetching; it disappears automatically when the task ends.
+                        let lib_for_fetch = current_lib;
+                        spawn(
+                            async move {
+                                let fetcher = reader::cover_fetcher::CoverFetcher::new(
+                                    cover_cache(),
+                                    fetch_strategy,
+                                    lastfm_key,
+                                    progress_cb,
+                                );
+                                let mut lib = lib_for_fetch;
+                                let report = fetcher.fetch_missing_covers(&mut lib).await;
+                                tracing::info!(
+                                    "Cover auto-fetch: {} found, {} missing, {} errors",
+                                    report.found,
+                                    report.missing,
+                                    report.errors,
+                                );
+                                let merged_lib = {
+                                    let mut current = library.write();
+                                    let mut changed = false;
+
+                                    for fetched_album in lib.albums.iter() {
+                                        let Some(fetched_cover) = fetched_album.cover_path.clone()
+                                        else {
+                                            continue;
+                                        };
+
+                                        let Some(current_album) = current
+                                            .albums
+                                            .iter_mut()
+                                            .find(|a| a.id == fetched_album.id)
+                                        else {
+                                            continue;
+                                        };
+
+                                        if current_album.cover_path.is_none()
+                                            && !current_album.manual_cover
+                                        {
+                                            current_album.cover_path = Some(fetched_cover);
+                                            changed = true;
+                                        }
+                                    }
+
+                                    changed.then(|| current.clone())
                                 };
 
-                                let Some(current_album) =
-                                    current.albums.iter_mut().find(|a| a.id == fetched_album.id)
-                                else {
-                                    continue;
-                                };
-
-                                if current_album.cover_path.is_none() && !current_album.manual_cover
-                                {
-                                    current_album.cover_path = Some(fetched_cover);
-                                    changed = true;
+                                if let Some(merged_lib) = merged_lib {
+                                    let _ = merged_lib.save(&lib_path());
                                 }
                             }
-
-                            changed.then(|| current.clone())
-                        };
-
-                        if let Some(merged_lib) = merged_lib {
-                            let _ = merged_lib.save(&lib_path());
-                        }
-                    }.instrument(tracing::info_span!("library.fetch_covers")));
+                            .instrument(tracing::info_span!("library.fetch_covers")),
+                        );
+                    } else {
+                        // No cover fetching — drop the callback so the progress bar closes.
+                        drop(progress_cb);
+                    }
                 } else {
-                    // No cover fetching — drop the callback so the progress bar closes.
-                    drop(progress_cb);
+                    current_lib.tracks.clear();
+                    current_lib.albums.clear();
+                    current_lib.root_paths.clear();
+                    library.set(current_lib.clone());
+                    let _ = current_lib.save(&lib_path());
                 }
-            } else {
-                current_lib.tracks.clear();
-                current_lib.albums.clear();
-                current_lib.root_paths.clear();
-                library.set(current_lib.clone());
-                let _ = current_lib.save(&lib_path());
             }
-        }.instrument(tracing::info_span!("library.rescan")));
+            .instrument(tracing::info_span!("library.rescan")),
+        );
     });
 
     use_effect(move || {

--- a/crates/kopuz/src/pot_minter.rs
+++ b/crates/kopuz/src/pot_minter.rs
@@ -219,7 +219,7 @@ pub fn install_if_wanted<T: 'static>(target: &EventLoopWindowTarget<T>) {
     let builder = WebViewBuilder::new()
         .with_url("https://music.youtube.com/")
         .with_user_agent(UA)
-        .with_initialization_script(&init_script())
+        .with_initialization_script(init_script())
         .with_ipc_handler(move |req| {
             let body = req.into_body();
             let v: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
@@ -227,7 +227,7 @@ pub fn install_if_wanted<T: 'static>(target: &EventLoopWindowTarget<T>) {
             // the full JS stack, so a broken minter shows up in logs as more
             // than "Function@[native code]".
             if let Some(diag) = v.get("diag").and_then(|d| d.as_str()) {
-                eprintln!("[pot-minter] {diag}");
+                tracing::warn!("[pot-minter] {diag}");
                 return;
             }
             let Some(id) = v.get("id").and_then(|i| i.as_u64()) else {
@@ -241,7 +241,7 @@ pub fn install_if_wanted<T: 'static>(target: &EventLoopWindowTarget<T>) {
                         .and_then(|e| e.as_str())
                         .unwrap_or("mint failed")
                         .to_string();
-                    eprintln!("[pot-minter] mint error: {err}");
+                    tracing::warn!("[pot-minter] mint error: {err}");
                     Err(err)
                 }
             };

--- a/crates/pages/src/local/artist.rs
+++ b/crates/pages/src/local/artist.rs
@@ -39,7 +39,7 @@ pub fn LocalArtist(
 
     // Multi-selection state
     let mut is_selection_mode = use_signal(|| false);
-    let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
+    let mut selected_tracks = use_signal(HashSet::<PathBuf>::new);
 
     let mut open_album_menu = use_signal(|| None::<String>);
     let mut show_album_playlist_modal = use_signal(|| false);
@@ -86,7 +86,7 @@ pub fn LocalArtist(
             artist_map.insert(normalized, (display_name, Some(image_path.clone())));
         }
         let mut artists: Vec<_> = artist_map.into_values().collect();
-        artists.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+        artists.sort_by_key(|a| a.0.to_lowercase());
         artists
     });
 
@@ -636,11 +636,10 @@ pub fn LocalArtist(
                                     }
                                 },
                                 on_delete_track: move |idx: usize| {
-                                    if let Some(track) = artist_tracks().get(idx) {
-                                        if std::fs::remove_file(&track.path).is_ok() {
+                                    if let Some(track) = artist_tracks().get(idx)
+                                        && std::fs::remove_file(&track.path).is_ok() {
                                             library.write().remove_track(&track.path);
                                         }
-                                    }
                                     active_menu_track.set(None);
                                 },
                                 actions: Some(rsx! {

--- a/crates/pages/src/local/favorites.rs
+++ b/crates/pages/src/local/favorites.rs
@@ -1,9 +1,8 @@
-use components::constants::{COLUMNS_MODERN, COLUMNS_NORMAL};
 use components::header::Header;
 use components::metadata_modal::MetadataModal;
 use components::playlist_modal::PlaylistModal;
 use components::selection_bar::SelectionBar;
-use components::showcase::{self, SortField};
+use components::showcase::{self};
 use components::track_row::TrackRow;
 use config::{AppConfig, UiStyle};
 use dioxus::prelude::*;
@@ -28,7 +27,7 @@ pub fn LocalFavorites(
 
     // Multi-selection state
     let mut is_selection_mode = use_signal(|| false);
-    let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
+    let mut selected_tracks = use_signal(HashSet::<PathBuf>::new);
     let sort_state = use_signal(|| None);
 
     let displayed_tracks: Vec<(reader::models::Track, Option<utils::CoverUrl>)> = {
@@ -199,11 +198,10 @@ pub fn LocalFavorites(
                                         playlist.tracks.push(path.clone());
                                     }
                                 }
-                            } else if let Some(path) = selected_track_for_playlist.read().clone() {
-                                if !playlist.tracks.contains(&path) {
+                            } else if let Some(path) = selected_track_for_playlist.read().clone()
+                                && !playlist.tracks.contains(&path) {
                                     playlist.tracks.push(path);
                                 }
-                            }
                         }
                         show_playlist_modal.set(false);
                         active_menu_track.set(None);

--- a/crates/pages/src/local/home.rs
+++ b/crates/pages/src/local/home.rs
@@ -67,7 +67,7 @@ pub fn LocalHome(
     let new_release_albums = use_memo(move || {
         let lib = library.read();
         let mut albums = lib.albums.clone();
-        albums.sort_by(|a, b| b.year.cmp(&a.year));
+        albums.sort_by_key(|b| std::cmp::Reverse(b.year));
         let mut unique_albums = Vec::new();
         let mut seen_titles = std::collections::HashSet::new();
         for album in albums {
@@ -193,10 +193,10 @@ pub fn LocalHome(
                 } else if is_unknown_artist(&track.artist) {
                     continue;
                 }
-                if let Some(ref a) = album {
-                    if !seen_albums.insert(a.id.clone()) {
-                        continue;
-                    }
+                if let Some(ref a) = album
+                    && !seen_albums.insert(a.id.clone())
+                {
+                    continue;
                 }
                 out.push(((*track).clone(), album));
                 if out.len() >= 10 {
@@ -356,9 +356,8 @@ pub fn LocalHome(
                                                 disabled: idx == 0,
                                                 onclick: move |_| {
                                                     let mut conf = config.write();
-                                                    if let Some(i) = conf.home_sections.iter().position(|s| s.key == key_up) {
-                                                        if i > 0 { conf.home_sections.swap(i, i - 1); }
-                                                    }
+                                                    if let Some(i) = conf.home_sections.iter().position(|s| s.key == key_up)
+                                                        && i > 0 { conf.home_sections.swap(i, i - 1); }
                                                 },
                                                 i { class: "fa-solid fa-chevron-up text-xs" }
                                             }
@@ -368,9 +367,8 @@ pub fn LocalHome(
                                                 disabled: idx + 1 >= total,
                                                 onclick: move |_| {
                                                     let mut conf = config.write();
-                                                    if let Some(i) = conf.home_sections.iter().position(|s| s.key == key_down) {
-                                                        if i + 1 < conf.home_sections.len() { conf.home_sections.swap(i, i + 1); }
-                                                    }
+                                                    if let Some(i) = conf.home_sections.iter().position(|s| s.key == key_down)
+                                                        && i + 1 < conf.home_sections.len() { conf.home_sections.swap(i, i + 1); }
                                                 },
                                                 i { class: "fa-solid fa-chevron-down text-xs" }
                                             }
@@ -574,10 +572,10 @@ fn LocalHeroBanner(
             if !track.title.trim().is_empty() {
                 return track.title.clone();
             }
-            if let Some(album) = album_opt.as_ref() {
-                if !is_unknown_album(&album.title) {
-                    return album.title.clone();
-                }
+            if let Some(album) = album_opt.as_ref()
+                && !is_unknown_album(&album.title)
+            {
+                return album.title.clone();
             }
             track.title.clone()
         })
@@ -664,9 +662,7 @@ fn LocalHeroBanner(
                                             let new_fav = !local_hero_fav;
                                             for track in tracks {
                                                 let currently = favorites_store.read().is_local_favorite(&track.path);
-                                                if new_fav && !currently {
-                                                    favorites_store.write().toggle_local(track.path);
-                                                } else if !new_fav && currently {
+                                                if currently != new_fav {
                                                     favorites_store.write().toggle_local(track.path);
                                                 }
                                             }
@@ -950,6 +946,7 @@ fn render_top_artists(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_albums_row(
     scroll_id: &'static str,
     title: String,

--- a/crates/pages/src/local/library.rs
+++ b/crates/pages/src/local/library.rs
@@ -46,7 +46,7 @@ pub fn LocalLibrary(
     let mut selected_track_for_playlist = use_signal(|| None::<PathBuf>);
     let mut metadata_track = use_signal(|| None::<reader::models::Track>);
     let mut is_selection_mode = use_signal(|| false);
-    let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
+    let mut selected_tracks = use_signal(HashSet::<PathBuf>::new);
     let displayed_tracks = use_memo(move || (items.all_tracks)());
     let album_covers = use_memo(move || (items.album_covers)());
     let cover_urls_memo = use_memo(move || std::sync::Arc::new(album_covers()));
@@ -193,11 +193,10 @@ pub fn LocalLibrary(
                                         playlist.tracks.push(path.clone());
                                     }
                                 }
-                            } else if let Some(path) = selected_track_for_playlist.read().clone() {
-                                if !playlist.tracks.contains(&path) {
+                            } else if let Some(path) = selected_track_for_playlist.read().clone()
+                                && !playlist.tracks.contains(&path) {
                                     playlist.tracks.push(path);
                                 }
-                            }
                         }
                         show_playlist_modal.set(false);
                         active_menu_track.set(None);

--- a/crates/pages/src/local/search.rs
+++ b/crates/pages/src/local/search.rs
@@ -80,11 +80,10 @@ pub fn LocalSearch(
                     on_add_to_playlist: move |playlist_id: String| {
                         if let Some(path) = selected_track_for_playlist.read().clone() {
                             let mut store = playlist_store.write();
-                            if let Some(playlist) = store.playlists.iter_mut().find(|p| p.id == playlist_id) {
-                                if !playlist.tracks.contains(&path) {
+                            if let Some(playlist) = store.playlists.iter_mut().find(|p| p.id == playlist_id)
+                                && !playlist.tracks.contains(&path) {
                                     playlist.tracks.push(path);
                                 }
-                            }
                         }
                         show_playlist_modal.set(false);
                         active_menu_track.set(None);

--- a/crates/pages/src/playlists.rs
+++ b/crates/pages/src/playlists.rs
@@ -21,7 +21,7 @@ pub fn PlaylistsPage(
 
     let mut selected_folder = use_signal(|| Option::<String>::None);
     let mut show_add_playlist = use_signal(|| false);
-    let mut playlist_name = use_signal(|| String::new());
+    let mut playlist_name = use_signal(String::new);
     let mut error = use_signal(|| Option::<String>::None);
     let mut saving = use_signal(|| false);
     let mut playlist_refresh_trigger = use_signal(|| 0u64);
@@ -91,10 +91,10 @@ pub fn PlaylistsPage(
 
     let download_queue = use_context::<Signal<DownloadQueue>>();
 
-    let mut last_source = use_signal(|| config.read().active_source.clone());
+    let mut last_source = use_signal(|| config.read().active_source);
     if *last_source.read() != config.read().active_source {
         selected_playlist_id.set(None);
-        last_source.set(config.read().active_source.clone());
+        last_source.set(config.read().active_source);
     }
 
     let is_modern = config.read().ui_style == UiStyle::Modern;
@@ -210,8 +210,7 @@ pub fn PlaylistsPage(
                                         .jellyfin_playlists
                                         .iter()
                                         .find(|p| p.id == pid_for_dl_track)
-                                    {
-                                        if let Some(tid) = p.tracks.get(idx) {
+                                        && let Some(tid) = p.tracks.get(idx) {
                                             track_id = tid.clone();
                                             if let Some(meta) = lib
                                                 .jellyfin_tracks
@@ -222,7 +221,6 @@ pub fn PlaylistsPage(
                                                 track_artist = meta.artist.clone();
                                             }
                                         }
-                                    }
                                     if !track_id.is_empty() {
                                         let is_downloaded = if let Some(path_str) = config
                                             .read()

--- a/crates/pages/src/radio.rs
+++ b/crates/pages/src/radio.rs
@@ -15,7 +15,7 @@ pub struct RadioProps {
 #[component]
 pub fn Radio(props: RadioProps) -> Element {
     let mut ctrl = use_context::<PlayerController>();
-    let config = use_context::<Signal<config::AppConfig>>();
+    let config = props.config;
     let is_modern = config.read().ui_style == UiStyle::Modern;
 
     let registry = use_context::<Signal<radio::registry::StationRegistry>>();
@@ -28,11 +28,11 @@ pub fn Radio(props: RadioProps) -> Element {
         .collect();
 
     // Search / filter
-    let mut filter = use_signal(|| String::new());
+    let mut filter = use_signal(String::new);
     let debounce_gen = use_hook(|| Arc::new(AtomicU64::new(0))).clone();
 
     // Expanded stations set for stream overflow
-    let mut expanded_stations = use_signal(|| std::collections::HashSet::<String>::new());
+    let mut expanded_stations = use_signal(std::collections::HashSet::<String>::new);
 
     let query = filter.read().to_lowercase();
     let filtered: Vec<&radio::manifest::StationManifest> = stations

--- a/crates/pages/src/server/activity.rs
+++ b/crates/pages/src/server/activity.rs
@@ -258,7 +258,10 @@ pub fn ServerLogs(library: Signal<Library>, config: Signal<AppConfig>) -> Elemen
         .unwrap_or(MusicService::Jellyfin);
 
     match service {
-        MusicService::Jellyfin | MusicService::Subsonic | MusicService::Custom | MusicService::YtMusic => rsx! {
+        MusicService::Jellyfin
+        | MusicService::Subsonic
+        | MusicService::Custom
+        | MusicService::YtMusic => rsx! {
             JellyfinLogs { library, config }
         },
     }

--- a/crates/pages/src/server/album.rs
+++ b/crates/pages/src/server/album.rs
@@ -233,7 +233,7 @@ pub fn JellyfinAlbumDetails(
 
     // Multi-selection state
     let mut is_selection_mode = use_signal(|| false);
-    let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
+    let mut selected_tracks = use_signal(HashSet::<PathBuf>::new);
     let download_queue = use_context::<Signal<DownloadQueue>>();
 
     let mut album_id_sig = use_signal(|| album_jellyfin_id.clone());

--- a/crates/pages/src/server/artist.rs
+++ b/crates/pages/src/server/artist.rs
@@ -28,7 +28,7 @@ pub fn JellyfinArtist(
     let mut selected_track_for_playlist = use_signal(|| None::<PathBuf>);
 
     let mut is_selection_mode = use_signal(|| false);
-    let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
+    let mut selected_tracks = use_signal(HashSet::<PathBuf>::new);
     let download_queue = use_context::<Signal<DownloadQueue>>();
 
     let sort_order = use_signal(move || config.read().artist_view_order.clone());
@@ -80,19 +80,21 @@ pub fn JellyfinArtist(
 
         is_fetching_images.set(true);
 
-        spawn(async move {
-            let (service, url, token, user_id, device_id) = snapshot;
-            let mut images: std::collections::HashMap<String, String> = Default::default();
+        spawn(
+            async move {
+                let (service, url, token, user_id, device_id) = snapshot;
+                let mut images: std::collections::HashMap<String, String> = Default::default();
 
-            match service {
-                config::MusicService::Jellyfin => {
-                    let client =
-                        JellyfinClient::new(&url, Some(&token), &device_id, Some(&user_id));
-                    match client.get_artists().await {
-                        Ok(artists) => {
-                            for artist in artists {
-                                if let Some(tags) = &artist.image_tags {
-                                    if let Some(tag) = tags.get("Primary") {
+                match service {
+                    config::MusicService::Jellyfin => {
+                        let client =
+                            JellyfinClient::new(&url, Some(&token), &device_id, Some(&user_id));
+                        match client.get_artists().await {
+                            Ok(artists) => {
+                                for artist in artists {
+                                    if let Some(tags) = &artist.image_tags
+                                        && let Some(tag) = tags.get("Primary")
+                                    {
                                         let img_url = utils::jellyfin_image::jellyfin_image_url(
                                             &url,
                                             &artist.id,
@@ -105,37 +107,43 @@ pub fn JellyfinArtist(
                                     }
                                 }
                             }
-                        }
-                        Err(e) => {
-                            dioxus::logger::tracing::warn!("Failed to fetch artist images: {}", e);
+                            Err(e) => {
+                                dioxus::logger::tracing::warn!(
+                                    "Failed to fetch artist images: {}",
+                                    e
+                                );
+                            }
                         }
                     }
-                }
-                config::MusicService::Subsonic | config::MusicService::Custom => {
-                    let client = SubsonicClient::new(&url, &user_id, &token);
-                    match client.get_artists().await {
-                        Ok(artists) => {
-                            for artist in artists {
-                                if let Some(cover_art_id) = &artist.cover_art {
-                                    if let Ok(img_url) =
-                                        client.cover_art_url(cover_art_id, Some(512))
+                    config::MusicService::Subsonic | config::MusicService::Custom => {
+                        let client = SubsonicClient::new(&url, &user_id, &token);
+                        match client.get_artists().await {
+                            Ok(artists) => {
+                                for artist in artists {
+                                    if let Some(cover_art_id) = &artist.cover_art
+                                        && let Ok(img_url) =
+                                            client.cover_art_url(cover_art_id, Some(512))
                                     {
                                         images.insert(artist.name.clone(), img_url);
                                     }
                                 }
                             }
-                        }
-                        Err(e) => {
-                            dioxus::logger::tracing::warn!("Failed to fetch artist images: {}", e);
+                            Err(e) => {
+                                dioxus::logger::tracing::warn!(
+                                    "Failed to fetch artist images: {}",
+                                    e
+                                );
+                            }
                         }
                     }
+                    config::MusicService::YtMusic => {}
                 }
-                config::MusicService::YtMusic => {}
-            }
 
-            fetched_artist_images.set(images);
-            is_fetching_images.set(false);
-        }.instrument(tracing::info_span!("artist.fetch_images")));
+                fetched_artist_images.set(images);
+                is_fetching_images.set(false);
+            }
+            .instrument(tracing::info_span!("artist.fetch_images")),
+        );
     });
 
     let jellyfin_artists = use_memo(move || {
@@ -159,10 +167,10 @@ pub fn JellyfinArtist(
         // Custom artist photos override album cover and server-fetched images.
         for name in artist_map.keys().cloned().collect::<Vec<_>>() {
             let norm = name.trim().to_lowercase();
-            if let Some(path) = lib.custom_artist_images.get(&norm) {
-                if let Some(url) = utils::format_artwork_url(Some(path)) {
-                    artist_map.insert(name, Some(PathBuf::from(format!("directurl:{}", url))));
-                }
+            if let Some(path) = lib.custom_artist_images.get(&norm)
+                && let Some(url) = utils::format_artwork_url(Some(path))
+            {
+                artist_map.insert(name, Some(PathBuf::from(format!("directurl:{}", url))));
             }
         }
         let offline = *is_offline.read();
@@ -187,7 +195,7 @@ pub fn JellyfinArtist(
                 })
             })
             .collect();
-        artists.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+        artists.sort_by_key(|a| a.0.to_lowercase());
         artists
     });
 
@@ -226,10 +234,10 @@ pub fn JellyfinArtist(
             return None;
         }
         // Custom artist photo overrides every other source, regardless of config.
-        if let Some(path) = lib.custom_artist_images.get(&artist.trim().to_lowercase()) {
-            if let Some(url) = utils::format_artwork_url(Some(path)) {
-                return Some(url);
-            }
+        if let Some(path) = lib.custom_artist_images.get(&artist.trim().to_lowercase())
+            && let Some(url) = utils::format_artwork_url(Some(path))
+        {
+            return Some(url);
         }
         if conf.artist_photo_source == ArtistPhotoSource::ArtistPhoto {
             let fetched = fetched_artist_images.read();

--- a/crates/pages/src/server/discover.rs
+++ b/crates/pages/src/server/discover.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use components::track_row::TrackRow;
 use config::{AppConfig, MusicService};
 use dioxus::prelude::*;
 use reader::models::{Library, Track};
 use server::ytmusic::discover::{DiscoverHome, DiscoverItem, DiscoverShelf, YtArtist};
-use components::track_row::TrackRow;
 use std::path::PathBuf;
 use tracing::Instrument;
 
@@ -60,27 +60,30 @@ pub fn DiscoverPage(
             return;
         }
         let home_span = tracing::info_span!("discover.load_home");
-        spawn(async move {
-            let token = config
-                .peek()
-                .server
-                .as_ref()
-                .and_then(|s| s.access_token.clone());
-            let Some(token) = token else {
-                error.set(Some("not signed in".to_string()));
-                initial_loading.set(false);
-                return;
-            };
-            let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(token);
-            match yt.discover_home().await {
-                Ok(home) => {
-                    apply_home(home, &mut shelves, &mut continuation);
-                    error.set(None);
+        spawn(
+            async move {
+                let token = config
+                    .peek()
+                    .server
+                    .as_ref()
+                    .and_then(|s| s.access_token.clone());
+                let Some(token) = token else {
+                    error.set(Some("not signed in".to_string()));
+                    initial_loading.set(false);
+                    return;
+                };
+                let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(token);
+                match yt.discover_home().await {
+                    Ok(home) => {
+                        apply_home(home, &mut shelves, &mut continuation);
+                        error.set(None);
+                    }
+                    Err(e) => error.set(Some(e)),
                 }
-                Err(e) => error.set(Some(e)),
+                initial_loading.set(false);
             }
-            initial_loading.set(false);
-        }.instrument(home_span));
+            .instrument(home_span),
+        );
     });
 
     if !is_ytmusic {
@@ -100,21 +103,24 @@ pub fn DiscoverPage(
         }
         loading_more.set(true);
         let more_span = tracing::info_span!("discover.load_more");
-        spawn(async move {
-            let cookies = config
-                .peek()
-                .server
-                .as_ref()
-                .and_then(|s| s.access_token.clone());
-            if let Some(cookies) = cookies {
-                let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
-                match yt.discover_continuation(&token).await {
-                    Ok(home) => apply_home(home, &mut shelves, &mut continuation),
-                    Err(e) => error.set(Some(e)),
+        spawn(
+            async move {
+                let cookies = config
+                    .peek()
+                    .server
+                    .as_ref()
+                    .and_then(|s| s.access_token.clone());
+                if let Some(cookies) = cookies {
+                    let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
+                    match yt.discover_continuation(&token).await {
+                        Ok(home) => apply_home(home, &mut shelves, &mut continuation),
+                        Err(e) => error.set(Some(e)),
+                    }
                 }
+                loading_more.set(false);
             }
-            loading_more.set(false);
-        }.instrument(more_span));
+            .instrument(more_span),
+        );
     };
 
     use_effect(move || {
@@ -385,8 +391,13 @@ fn DiscoverTile(
     match item {
         DiscoverItem::Song(track) => {
             rsx! { SongCard { track: track.clone() } }
-        },
-        DiscoverItem::Playlist { playlist_id, title, subtitle, thumbnail } => {
+        }
+        DiscoverItem::Playlist {
+            playlist_id,
+            title,
+            subtitle,
+            thumbnail,
+        } => {
             let title_for_click = title.clone();
             let pid_for_play = playlist_id.clone();
             let pid_for_source = playlist_id.clone();
@@ -405,8 +416,13 @@ fn DiscoverTile(
                     source_id: Some(pid_for_source),
                 }
             }
-        },
-        DiscoverItem::Album { browse_id, title, subtitle, thumbnail } => {
+        }
+        DiscoverItem::Album {
+            browse_id,
+            title,
+            subtitle,
+            thumbnail,
+        } => {
             let title_for_click = title.clone();
             let bid_for_play = browse_id.clone();
             let bid_for_source = browse_id.clone();
@@ -425,8 +441,12 @@ fn DiscoverTile(
                     source_id: Some(bid_for_source),
                 }
             }
-        },
-        DiscoverItem::Artist { channel_id, name, thumbnail } => {
+        }
+        DiscoverItem::Artist {
+            channel_id,
+            name,
+            thumbnail,
+        } => {
             let cid = channel_id.clone();
             let name_for_click = name.clone();
             rsx! {
@@ -440,8 +460,10 @@ fn DiscoverTile(
                     source_id: None,
                 }
             }
-        },
-        DiscoverItem::Mood { title, thumbnail, .. } => rsx! {
+        }
+        DiscoverItem::Mood {
+            title, thumbnail, ..
+        } => rsx! {
             Card {
                 title: title,
                 subtitle: String::new(),
@@ -484,85 +506,87 @@ fn play_playlist_async(
         return;
     }
     let play_span = tracing::info_span!("discover.play_playlist", playlist_id = %id);
-    spawn(async move {
-        let mut cache_writer = cache;
-        // Shared failure path: release is_loading AND let go of the
-        // now_playing tag so the tile drops out of phantom-pause state
-        // and a subsequent click can retry through the normal play path
-        // rather than landing on ctrl.toggle() against an unrelated
-        // currently-playing track.
-        let fail = |ctrl: &mut hooks::use_player_controller::PlayerController,
-                    now_playing: &mut Signal<Option<String>>| {
-            ctrl.is_loading.set(false);
-            now_playing.set(None);
-        };
-        let Some(cookies) = config
-            .peek()
-            .server
-            .as_ref()
-            .and_then(|s| s.access_token.clone())
-        else {
-            fail(&mut ctrl, &mut now_playing);
-            return;
-        };
-        let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
+    spawn(
+        async move {
+            let mut cache_writer = cache;
+            // Shared failure path: release is_loading AND let go of the
+            // now_playing tag so the tile drops out of phantom-pause state
+            // and a subsequent click can retry through the normal play path
+            // rather than landing on ctrl.toggle() against an unrelated
+            // currently-playing track.
+            let fail = |ctrl: &mut hooks::use_player_controller::PlayerController,
+                        now_playing: &mut Signal<Option<String>>| {
+                ctrl.is_loading.set(false);
+                now_playing.set(None);
+            };
+            let Some(cookies) = config
+                .peek()
+                .server
+                .as_ref()
+                .and_then(|s| s.access_token.clone())
+            else {
+                fail(&mut ctrl, &mut now_playing);
+                return;
+            };
+            let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
 
-        // Albums come back in a single browse hit. Playlists give the
-        // first ~100 rows on the initial browse and paginate the rest
-        // via continuation tokens — stream them so the first batch can
-        // start playing instantly while the tail fills in.
-        if id.starts_with("MPRE") {
-            match yt.fetch_album_tracks(&id).await {
-                Ok(tracks) if !tracks.is_empty() => {
-                    // Warm the cache for the next click on the same
-                    // tile — without this the MPRE branch repaid full
-                    // network roundtrip for every cold click.
-                    cache_writer.write().insert(id, tracks.clone());
-                    ctrl.play_queue_linear(tracks);
+            // Albums come back in a single browse hit. Playlists give the
+            // first ~100 rows on the initial browse and paginate the rest
+            // via continuation tokens — stream them so the first batch can
+            // start playing instantly while the tail fills in.
+            if id.starts_with("MPRE") {
+                match yt.fetch_album_tracks(&id).await {
+                    Ok(tracks) if !tracks.is_empty() => {
+                        // Warm the cache for the next click on the same
+                        // tile — without this the MPRE branch repaid full
+                        // network roundtrip for every cold click.
+                        cache_writer.write().insert(id, tracks.clone());
+                        ctrl.play_queue_linear(tracks);
+                    }
+                    _ => fail(&mut ctrl, &mut now_playing),
                 }
-                _ => fail(&mut ctrl, &mut now_playing),
+                return;
             }
-            return;
-        }
 
-        let mut started = false;
-        let mut accumulated = Vec::<Track>::new();
-        let result = yt
-            .stream_playlist_entries(&id, |batch| {
-                if batch.is_empty() {
-                    return;
-                }
-                accumulated.extend(batch.iter().cloned());
-                if started {
-                    ctrl.add_to_queue(batch);
-                } else {
-                    ctrl.play_queue_linear(batch);
-                    started = true;
-                }
-            })
-            .await;
-        if !started {
-            fail(&mut ctrl, &mut now_playing);
-            return;
-        }
-        // Only cache when the WHOLE playlist successfully streamed. A
-        // mid-stream failure (continuation 5xx, network blip) yields a
-        // truncated `accumulated` — caching it would poison every
-        // future click on this tile with the partial copy, with no UI
-        // affordance to refresh. Surface the failure to the user so
-        // they can retry from the playlist viewer.
-        match result {
-            Ok(()) => {
-                cache_writer.write().insert(id, accumulated);
+            let mut started = false;
+            let mut accumulated = Vec::<Track>::new();
+            let result = yt
+                .stream_playlist_entries(&id, |batch| {
+                    if batch.is_empty() {
+                        return;
+                    }
+                    accumulated.extend(batch.iter().cloned());
+                    if started {
+                        ctrl.add_to_queue(batch);
+                    } else {
+                        ctrl.play_queue_linear(batch);
+                        started = true;
+                    }
+                })
+                .await;
+            if !started {
+                fail(&mut ctrl, &mut now_playing);
+                return;
             }
-            Err(e) => {
-                tracing::warn!(error = %e, "discover playlist stream errored mid-flight");
-                ctrl.playback_error.set(Some(format!(
-                    "Discover playlist failed mid-load:\n{e}"
-                )));
+            // Only cache when the WHOLE playlist successfully streamed. A
+            // mid-stream failure (continuation 5xx, network blip) yields a
+            // truncated `accumulated` — caching it would poison every
+            // future click on this tile with the partial copy, with no UI
+            // affordance to refresh. Surface the failure to the user so
+            // they can retry from the playlist viewer.
+            match result {
+                Ok(()) => {
+                    cache_writer.write().insert(id, accumulated);
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "discover playlist stream errored mid-flight");
+                    ctrl.playback_error
+                        .set(Some(format!("Discover playlist failed mid-load:\n{e}")));
+                }
             }
         }
-    }.instrument(play_span));
+        .instrument(play_span),
+    );
 }
 
 #[component]
@@ -588,7 +612,11 @@ fn Card(
     } else {
         "w-44 h-44 rounded-lg bg-white/5"
     };
-    let cover_radius = if rounded_full { "rounded-full" } else { "rounded-lg" };
+    let cover_radius = if rounded_full {
+        "rounded-full"
+    } else {
+        "rounded-lg"
+    };
     let now_playing = use_context::<DiscoverNowPlaying>().0;
     let mut cache = use_context::<DiscoverPrefetchCache>().0;
     let config_ctx = use_context::<Signal<AppConfig>>();
@@ -865,34 +893,37 @@ fn play_song_with_mix(
         return;
     }
     let song_span = tracing::info_span!("discover.play_song", video_id = %video_id);
-    spawn(async move {
-        let Some(cookies) = config
-            .peek()
-            .server
-            .as_ref()
-            .and_then(|s| s.access_token.clone())
-        else {
-            ctrl.is_loading.set(false);
-            now_playing.set(None);
-            return;
-        };
-        let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
-        match yt.start_mix(&video_id).await {
-            Ok(mix) if !mix.is_empty() => {
-                let mut cache_writer = cache;
-                cache_writer.write().insert(video_id, mix.clone());
-                let queue = build_song_queue(&seed, mix);
-                ctrl.play_queue_linear(queue);
-            }
-            _ => {
-                // Mix failed → at least play the seed alone so the user
-                // gets the song they clicked, even if "next" won't work.
-                // now_playing stays as the video_id so the tile shows
-                // pause overlay for the seed song that IS now playing.
-                ctrl.play_queue_linear(vec![seed]);
+    spawn(
+        async move {
+            let Some(cookies) = config
+                .peek()
+                .server
+                .as_ref()
+                .and_then(|s| s.access_token.clone())
+            else {
+                ctrl.is_loading.set(false);
+                now_playing.set(None);
+                return;
+            };
+            let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
+            match yt.start_mix(&video_id).await {
+                Ok(mix) if !mix.is_empty() => {
+                    let mut cache_writer = cache;
+                    cache_writer.write().insert(video_id, mix.clone());
+                    let queue = build_song_queue(&seed, mix);
+                    ctrl.play_queue_linear(queue);
+                }
+                _ => {
+                    // Mix failed → at least play the seed alone so the user
+                    // gets the song they clicked, even if "next" won't work.
+                    // now_playing stays as the video_id so the tile shows
+                    // pause overlay for the seed song that IS now playing.
+                    ctrl.play_queue_linear(vec![seed]);
+                }
             }
         }
-    }.instrument(song_span));
+        .instrument(song_span),
+    );
 }
 
 /// Put the seed at index 0 and append the rest of the mix. The seed
@@ -908,7 +939,12 @@ fn build_song_queue(seed: &Track, mix: Vec<Track>) -> Vec<Track> {
         .into_iter()
         .partition(|t| seed_vid.is_some() && track_video_id(t) == seed_vid);
     let mut out = Vec::with_capacity(rest.len() + 1);
-    out.push(seed_in_queue.into_iter().next().unwrap_or_else(|| seed.clone()));
+    out.push(
+        seed_in_queue
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| seed.clone()),
+    );
     out.extend(rest);
     out
 }
@@ -1166,60 +1202,63 @@ pub fn DiscoverArtistPage(
         loading.set(true);
         error.set(None);
         let artist_span = tracing::info_span!("artist.load", artist = %name);
-        spawn(async move {
-            let cookies = config
-                .peek()
-                .server
-                .as_ref()
-                .and_then(|s| s.access_token.clone());
-            let Some(cookies) = cookies else {
-                if *fetch_gen.peek() == my_gen {
-                    error.set(Some("not signed in".to_string()));
-                    loading.set(false);
+        spawn(
+            async move {
+                let cookies = config
+                    .peek()
+                    .server
+                    .as_ref()
+                    .and_then(|s| s.access_token.clone());
+                let Some(cookies) = cookies else {
+                    if *fetch_gen.peek() == my_gen {
+                        error.set(Some("not signed in".to_string()));
+                        loading.set(false);
+                    }
+                    return;
+                };
+                let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
+                // Resolve cid from name if we didn't get one with the
+                // click. Top YT search hit for the artist filter is the
+                // first UC… browseId in the response — see
+                // search::resolve_artist_channel_id.
+                let cid = match cid_opt {
+                    Some(c) => c,
+                    None => match yt.resolve_artist_channel_id(name.trim()).await {
+                        Ok(Some(c)) => c,
+                        Ok(None) => {
+                            if *fetch_gen.peek() == my_gen {
+                                error.set(Some(format!(
+                                    "No YouTube Music artist found for \"{}\"",
+                                    name.trim()
+                                )));
+                                loading.set(false);
+                            }
+                            return;
+                        }
+                        Err(e) => {
+                            if *fetch_gen.peek() == my_gen {
+                                error.set(Some(e));
+                                loading.set(false);
+                            }
+                            return;
+                        }
+                    },
+                };
+                if *fetch_gen.peek() != my_gen {
+                    return;
                 }
-                return;
-            };
-            let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(cookies);
-            // Resolve cid from name if we didn't get one with the
-            // click. Top YT search hit for the artist filter is the
-            // first UC… browseId in the response — see
-            // search::resolve_artist_channel_id.
-            let cid = match cid_opt {
-                Some(c) => c,
-                None => match yt.resolve_artist_channel_id(name.trim()).await {
-                    Ok(Some(c)) => c,
-                    Ok(None) => {
-                        if *fetch_gen.peek() == my_gen {
-                            error.set(Some(format!(
-                                "No YouTube Music artist found for \"{}\"",
-                                name.trim()
-                            )));
-                            loading.set(false);
-                        }
-                        return;
-                    }
-                    Err(e) => {
-                        if *fetch_gen.peek() == my_gen {
-                            error.set(Some(e));
-                            loading.set(false);
-                        }
-                        return;
-                    }
-                },
-            };
-            if *fetch_gen.peek() != my_gen {
-                return;
+                let result = yt.fetch_artist(&cid).await;
+                if *fetch_gen.peek() != my_gen {
+                    return;
+                }
+                match result {
+                    Ok(a) => artist.set(Some(a)),
+                    Err(e) => error.set(Some(e)),
+                }
+                loading.set(false);
             }
-            let result = yt.fetch_artist(&cid).await;
-            if *fetch_gen.peek() != my_gen {
-                return;
-            }
-            match result {
-                Ok(a) => artist.set(Some(a)),
-                Err(e) => error.set(Some(e)),
-            }
-            loading.set(false);
-        }.instrument(artist_span));
+            .instrument(artist_span),
+        );
     });
 
     if selected_artist_id.read().is_none() && selected_artist_name.read().trim().is_empty() {
@@ -1300,4 +1339,3 @@ pub fn DiscoverArtistPage(
         }
     }
 }
-

--- a/crates/pages/src/server/download_manager.rs
+++ b/crates/pages/src/server/download_manager.rs
@@ -96,18 +96,21 @@ pub fn queue_downloads(
 
     let session_start = Instant::now();
     let session_span = tracing::info_span!("downloads.session");
-    spawn(async move {
-        tokio::join!(
-            download_worker(queue, config, session_start, cancel_flag.clone()),
-            download_worker(queue, config, session_start, cancel_flag.clone()),
-            download_worker(queue, config, session_start, cancel_flag.clone()),
-            download_worker(queue, config, session_start, cancel_flag.clone()),
-        );
+    spawn(
+        async move {
+            tokio::join!(
+                download_worker(queue, config, session_start, cancel_flag.clone()),
+                download_worker(queue, config, session_start, cancel_flag.clone()),
+                download_worker(queue, config, session_start, cancel_flag.clone()),
+                download_worker(queue, config, session_start, cancel_flag.clone()),
+            );
 
-        let mut q = queue.write();
-        q.is_running = false;
-        q.cancel_requested = false;
-    }.instrument(session_span));
+            let mut q = queue.write();
+            q.is_running = false;
+            q.cancel_requested = false;
+        }
+        .instrument(session_span),
+    );
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -152,10 +155,7 @@ async fn download_worker(
         let (service, yt_cookies) = {
             let conf = config.read();
             let s = conf.server.as_ref();
-            (
-                s.map(|x| x.service),
-                s.and_then(|x| x.access_token.clone()),
-            )
+            (s.map(|x| x.service), s.and_then(|x| x.access_token.clone()))
         };
 
         let resolved: Option<(String, &'static str, Option<String>, Option<u64>)> =
@@ -248,6 +248,7 @@ pub fn delete_downloads(
     skip(url, user_agent, queue, session_start, cancel_flag),
     fields(item_id = %item_id, content_length)
 )]
+#[allow(clippy::too_many_arguments)]
 async fn download_with_progress(
     item_id: &str,
     url: &str,
@@ -370,12 +371,14 @@ async fn download_with_progress(
             }
         }
 
-        writer
-            .flush()
-            .await
-            .map_err(|e| format!("Flush: {e}"))?;
+        writer.flush().await.map_err(|e| format!("Flush: {e}"))?;
         let trailing = bytes_done.saturating_sub(last_update_bytes);
-        publish_progress(item_id, bytes_done, trailing, session_start.elapsed().as_secs_f64());
+        publish_progress(
+            item_id,
+            bytes_done,
+            trailing,
+            session_start.elapsed().as_secs_f64(),
+        );
         return Ok(file_path);
     }
 
@@ -465,11 +468,13 @@ async fn download_with_progress(
         }
     }
 
-    writer
-        .flush()
-        .await
-        .map_err(|e| format!("Flush: {e}"))?;
+    writer.flush().await.map_err(|e| format!("Flush: {e}"))?;
     let trailing = bytes_done.saturating_sub(last_update_bytes);
-    publish_progress(item_id, bytes_done, trailing, session_start.elapsed().as_secs_f64());
+    publish_progress(
+        item_id,
+        bytes_done,
+        trailing,
+        session_start.elapsed().as_secs_f64(),
+    );
     Ok(file_path)
 }

--- a/crates/pages/src/server/favorites.rs
+++ b/crates/pages/src/server/favorites.rs
@@ -34,7 +34,7 @@ pub fn JellyfinFavorites(
 
     // Multi-selection state
     let mut is_selection_mode = use_signal(|| false);
-    let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
+    let mut selected_tracks = use_signal(HashSet::<PathBuf>::new);
     let sort_state = use_signal(|| None);
     let mut show_playlist_modal = use_signal(|| false);
     let mut selected_track_for_playlist = use_signal(|| None::<PathBuf>);
@@ -43,7 +43,12 @@ pub fn JellyfinFavorites(
     use_effect(move || {
         let nonce = *refresh_nonce.read();
 
-        let token = match config.peek().server.as_ref().and_then(|s| s.access_token.clone()) {
+        let token = match config
+            .peek()
+            .server
+            .as_ref()
+            .and_then(|s| s.access_token.clone())
+        {
             Some(t) => t,
             None => return,
         };
@@ -56,74 +61,72 @@ pub fn JellyfinFavorites(
 
         is_syncing.set(true);
         synced_so_far.set(0);
-        spawn(async move {
-            let device_id = config.peek().device_id.clone();
-            let server_snapshot = config.peek().server.clone();
-            let Some(server) = server_snapshot else {
-                is_syncing.set(false);
-                return;
-            };
-            let user_id = server.user_id.clone().unwrap_or_default();
-            let url = server.url.clone();
+        spawn(
+            async move {
+                let device_id = config.peek().device_id.clone();
+                let server_snapshot = config.peek().server.clone();
+                let Some(server) = server_snapshot else {
+                    is_syncing.set(false);
+                    return;
+                };
+                let user_id = server.user_id.clone().unwrap_or_default();
+                let url = server.url.clone();
 
-            let ids: Vec<String> = match server.service {
-                MusicService::Jellyfin => {
-                    let remote =
-                        JellyfinClient::new(&url, Some(&token), &device_id, Some(&user_id));
-                    remote
-                        .get_favorite_items()
-                        .await
-                        .map(|items| items.into_iter().map(|i| i.id).collect())
-                        .unwrap_or_default()
-                }
-                MusicService::Subsonic | MusicService::Custom => {
-                    let remote = SubsonicClient::new(&url, &user_id, &token);
-                    remote.get_starred_song_ids().await.unwrap_or_default()
-                }
-                MusicService::YtMusic => {
-                    let yt =
-                        ::server::ytmusic::YouTubeMusicClient::with_cookies(token);
-
-                    {
-                        let mut lib = library.write();
-                        lib.jellyfin_tracks.clear();
-                        lib.jellyfin_albums.clear();
+                let ids: Vec<String> = match server.service {
+                    MusicService::Jellyfin => {
+                        let remote =
+                            JellyfinClient::new(&url, Some(&token), &device_id, Some(&user_id));
+                        remote
+                            .get_favorite_items()
+                            .await
+                            .map(|items| items.into_iter().map(|i| i.id).collect())
+                            .unwrap_or_default()
                     }
+                    MusicService::Subsonic | MusicService::Custom => {
+                        let remote = SubsonicClient::new(&url, &user_id, &token);
+                        remote.get_starred_song_ids().await.unwrap_or_default()
+                    }
+                    MusicService::YtMusic => {
+                        let yt = ::server::ytmusic::YouTubeMusicClient::with_cookies(token);
 
-                    let mut accumulated: Vec<reader::models::Track> = Vec::new();
-                    let result = yt
-                        .stream_liked_songs(|page| {
-                            accumulated.extend(page.iter().cloned());
-                            let albums = synthesize_albums(&accumulated);
-                            {
-                                let mut lib = library.write();
-                                lib.jellyfin_tracks.extend(page);
-                                lib.jellyfin_albums = albums;
-                            }
-                            synced_so_far.set(accumulated.len());
-                        })
-                        .await;
+                        {
+                            let mut lib = library.write();
+                            lib.jellyfin_tracks.clear();
+                            lib.jellyfin_albums.clear();
+                        }
 
-                    match result {
-                        Ok(()) => {
-                            let ids: Vec<String> = accumulated
-                                .iter()
-                                .filter_map(|t| {
-                                    t.path
-                                        .to_string_lossy()
-                                        .split(':')
-                                        .nth(1)
-                                        .map(|s| s.to_string())
-                                })
-                                .collect();
-                            let now = std::time::SystemTime::now()
-                                .duration_since(std::time::UNIX_EPOCH)
-                                .map(|d| d.as_secs())
-                                .unwrap_or(0);
-                            library.write().last_yt_sync_at = Some(now);
-                            let liked_cover = accumulated
-                                .first()
-                                .and_then(|t| {
+                        let mut accumulated: Vec<reader::models::Track> = Vec::new();
+                        let result = yt
+                            .stream_liked_songs(|page| {
+                                accumulated.extend(page.iter().cloned());
+                                let albums = synthesize_albums(&accumulated);
+                                {
+                                    let mut lib = library.write();
+                                    lib.jellyfin_tracks.extend(page);
+                                    lib.jellyfin_albums = albums;
+                                }
+                                synced_so_far.set(accumulated.len());
+                            })
+                            .await;
+
+                        match result {
+                            Ok(()) => {
+                                let ids: Vec<String> = accumulated
+                                    .iter()
+                                    .filter_map(|t| {
+                                        t.path
+                                            .to_string_lossy()
+                                            .split(':')
+                                            .nth(1)
+                                            .map(|s| s.to_string())
+                                    })
+                                    .collect();
+                                let now = std::time::SystemTime::now()
+                                    .duration_since(std::time::UNIX_EPOCH)
+                                    .map(|d| d.as_secs())
+                                    .unwrap_or(0);
+                                library.write().last_yt_sync_at = Some(now);
+                                let liked_cover = accumulated.first().and_then(|t| {
                                     t.path
                                         .to_string_lossy()
                                         .split(':')
@@ -131,38 +134,38 @@ pub fn JellyfinFavorites(
                                         .filter(|s| s.starts_with("urlhex_"))
                                         .map(|s| s.to_string())
                                 });
-                            let liked_entry = reader::models::JellyfinPlaylist {
-                                id: "LM".to_string(),
-                                name: "Liked Songs".to_string(),
-                                tracks: ids.clone(),
-                                image_tag: liked_cover,
-                                cover_path: None,
-                            };
-                            {
-                                let mut ps = playlist_store.write();
-                                if let Some(existing) = ps
-                                    .jellyfin_playlists
-                                    .iter_mut()
-                                    .find(|p| p.id == "LM")
+                                let liked_entry = reader::models::JellyfinPlaylist {
+                                    id: "LM".to_string(),
+                                    name: "Liked Songs".to_string(),
+                                    tracks: ids.clone(),
+                                    image_tag: liked_cover,
+                                    cover_path: None,
+                                };
                                 {
-                                    *existing = liked_entry;
-                                } else {
-                                    ps.jellyfin_playlists.insert(0, liked_entry);
+                                    let mut ps = playlist_store.write();
+                                    if let Some(existing) =
+                                        ps.jellyfin_playlists.iter_mut().find(|p| p.id == "LM")
+                                    {
+                                        *existing = liked_entry;
+                                    } else {
+                                        ps.jellyfin_playlists.insert(0, liked_entry);
+                                    }
                                 }
+                                ids
                             }
-                            ids
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = %e, "YT favorites sync failed");
-                            Vec::new()
+                            Err(e) => {
+                                tracing::warn!(error = %e, "YT favorites sync failed");
+                                Vec::new()
+                            }
                         }
                     }
-                }
-            };
+                };
 
-            favorites_store.write().jellyfin_favorites = ids;
-            is_syncing.set(false);
-        }.instrument(tracing::info_span!("favorites.sync")));
+                favorites_store.write().jellyfin_favorites = ids;
+                is_syncing.set(false);
+            }
+            .instrument(tracing::info_span!("favorites.sync")),
+        );
     });
 
     let displayed_tracks: Vec<(reader::models::Track, Option<utils::CoverUrl>)> = {

--- a/crates/pages/src/server/home.rs
+++ b/crates/pages/src/server/home.rs
@@ -177,7 +177,7 @@ pub fn JellyfinHome(
         let lib = library.read();
         let conf = config.read();
         let mut albums = lib.jellyfin_albums.clone();
-        albums.sort_by(|a, b| b.year.cmp(&a.year));
+        albums.sort_by_key(|b| std::cmp::Reverse(b.year));
         let mut unique = Vec::new();
         let mut seen = std::collections::HashSet::new();
         for album in albums {
@@ -263,10 +263,10 @@ pub fn JellyfinHome(
                 } else if is_unknown_artist(&track.artist) {
                     continue;
                 }
-                if let Some(ref a) = album {
-                    if !seen_albums.insert(a.id.clone()) {
-                        continue;
-                    }
+                if let Some(ref a) = album
+                    && !seen_albums.insert(a.id.clone())
+                {
+                    continue;
                 }
                 let cover = track_cover_url(&conf, track);
                 out.push(((*track).clone(), album, cover));
@@ -426,12 +426,8 @@ pub fn JellyfinHome(
             return None;
         };
         let entry = hero_entry.read();
-        let Some((_, album_opt, _)) = entry.as_ref() else {
-            return None;
-        };
-        let Some(album) = album_opt.as_ref() else {
-            return None;
-        };
+        let (_, album_opt, _) = entry.as_ref()?;
+        let album = album_opt.as_ref()?;
         album.cover_path.as_ref().and_then(|cover_path| {
             utils::jellyfin_image::jellyfin_image_url_from_path(
                 &cover_path.to_string_lossy(),
@@ -508,9 +504,8 @@ pub fn JellyfinHome(
                                                 disabled: idx == 0,
                                                 onclick: move |_| {
                                                     let mut conf = config.write();
-                                                    if let Some(i) = conf.home_sections.iter().position(|s| s.key == key_up) {
-                                                        if i > 0 { conf.home_sections.swap(i, i - 1); }
-                                                    }
+                                                    if let Some(i) = conf.home_sections.iter().position(|s| s.key == key_up)
+                                                        && i > 0 { conf.home_sections.swap(i, i - 1); }
                                                 },
                                                 i { class: "fa-solid fa-chevron-up text-xs" }
                                             }
@@ -520,9 +515,8 @@ pub fn JellyfinHome(
                                                 disabled: idx + 1 >= total,
                                                 onclick: move |_| {
                                                     let mut conf = config.write();
-                                                    if let Some(i) = conf.home_sections.iter().position(|s| s.key == key_down) {
-                                                        if i + 1 < conf.home_sections.len() { conf.home_sections.swap(i, i + 1); }
-                                                    }
+                                                    if let Some(i) = conf.home_sections.iter().position(|s| s.key == key_down)
+                                                        && i + 1 < conf.home_sections.len() { conf.home_sections.swap(i, i + 1); }
                                                 },
                                                 i { class: "fa-solid fa-chevron-down text-xs" }
                                             }
@@ -1113,6 +1107,7 @@ fn render_top_artists(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_albums_row(
     scroll_id: &'static str,
     title: String,

--- a/crates/pages/src/server/library.rs
+++ b/crates/pages/src/server/library.rs
@@ -32,7 +32,7 @@ pub fn JellyfinLibrary(
         .get(&Route::Library)
         .copied()
         .unwrap_or(0.0);
-    let mut scroll_stat = use_signal(move || saved_scroll);
+    let scroll_stat = use_signal(move || saved_scroll);
     use_effect(move || {
         let curr = sort_order.read().clone();
         if config.peek().sort_order != curr {
@@ -45,7 +45,7 @@ pub fn JellyfinLibrary(
     let mut selected_track_for_playlist = use_signal(|| None::<PathBuf>);
 
     let mut is_selection_mode = use_signal(|| false);
-    let mut selected_tracks = use_signal(|| HashSet::<PathBuf>::new());
+    let mut selected_tracks = use_signal(HashSet::<PathBuf>::new);
     let download_queue = use_context::<Signal<DownloadQueue>>();
 
     let mut fetch_jellyfin = move || {

--- a/crates/pages/src/server/playlists.rs
+++ b/crates/pages/src/server/playlists.rs
@@ -80,7 +80,7 @@ pub fn JellyfinPlaylists(
         let last_server_key = last_key.as_ref().and_then(|k| {
             let parts: Vec<&str> = k.splitn(5, '|').collect();
             if parts.len() >= 3 {
-                Some(format!("{}", &parts[..3].join("|")))
+                Some(parts[..3].join("|"))
             } else {
                 None
             }

--- a/crates/pages/src/server/subsonic_sync.rs
+++ b/crates/pages/src/server/subsonic_sync.rs
@@ -131,10 +131,10 @@ pub async fn sync_server_library(
 
                     for item in items {
                         let mut path_str = format!("jellyfin:{}", item.id);
-                        if let Some(tags) = &item.image_tags {
-                            if let Some(tag) = tags.get("Primary") {
-                                path_str.push_str(&format!(":{}", tag));
-                            }
+                        if let Some(tags) = &item.image_tags
+                            && let Some(tag) = tags.get("Primary")
+                        {
+                            path_str.push_str(&format!(":{}", tag));
                         }
 
                         let bitrate_kbps = item.bitrate.unwrap_or(0) / 1000;
@@ -182,18 +182,18 @@ pub async fn sync_server_library(
             let mut artist_images = std::collections::HashMap::new();
             if let Ok(artists) = remote.get_artists().await {
                 for artist in artists {
-                    if let Some(tags) = &artist.image_tags {
-                        if let Some(tag) = tags.get("Primary") {
-                            let url = utils::jellyfin_image::jellyfin_image_url(
-                                &server_url,
-                                &artist.id,
-                                Some(tag.as_str()),
-                                Some(&token),
-                                512,
-                                90,
-                            );
-                            artist_images.insert(artist.name, url);
-                        }
+                    if let Some(tags) = &artist.image_tags
+                        && let Some(tag) = tags.get("Primary")
+                    {
+                        let url = utils::jellyfin_image::jellyfin_image_url(
+                            &server_url,
+                            &artist.id,
+                            Some(tag.as_str()),
+                            Some(&token),
+                            512,
+                            90,
+                        );
+                        artist_images.insert(artist.name, url);
                     }
                 }
             }
@@ -366,10 +366,10 @@ pub async fn fetch_subsonic_library(
     let mut artist_images = std::collections::HashMap::new();
     if let Ok(artists) = remote.get_artists().await {
         for artist in artists {
-            if let Some(cover_art_id) = &artist.cover_art {
-                if let Ok(url) = remote.cover_art_url(cover_art_id, Some(512)) {
-                    artist_images.insert(artist.name, url);
-                }
+            if let Some(cover_art_id) = &artist.cover_art
+                && let Ok(url) = remote.cover_art_url(cover_art_id, Some(512))
+            {
+                artist_images.insert(artist.name, url);
             }
         }
     }
@@ -432,10 +432,10 @@ pub async fn fetch_subsonic_library(
                     continue;
                 }
 
-                if let Some(genre) = &song.genre {
-                    if !genre.is_empty() {
-                        genres.insert(genre.clone());
-                    }
+                if let Some(genre) = &song.genre
+                    && !genre.is_empty()
+                {
+                    genres.insert(genre.clone());
                 }
 
                 let bitrate_u16 = song.bit_rate.unwrap_or(0).min(u16::MAX as u32) as u16;
@@ -482,7 +482,7 @@ pub async fn fetch_subsonic_library(
         .into_iter()
         .map(|genre| (genre.clone(), genre))
         .collect();
-    genres_out.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+    genres_out.sort_by_key(|a| a.0.to_lowercase());
 
     Ok(SubsonicLibraryData {
         albums: albums_out,

--- a/crates/pages/src/settings.rs
+++ b/crates/pages/src/settings.rs
@@ -76,11 +76,9 @@ fn logs_section(mut config: Signal<AppConfig>) -> Element {
                                 .set_file_name("kopuz-logs.txt")
                                 .save_file()
                                 .await
-                            {
-                                if let Err(e) = utils::logs::export_logs(file.path()) {
+                                && let Err(e) = utils::logs::export_logs(file.path()) {
                                     tracing::warn!(error = %e, "failed to export logs");
                                 }
-                            }
                         });
                     },
                     i { class: "fa-solid fa-file-export" }
@@ -181,8 +179,8 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
     let mut show_add_server = use_signal(|| false);
     let mut show_login = use_signal(|| false);
 
-    let mut server_name = use_signal(|| String::new());
-    let mut server_url = use_signal(|| String::new());
+    let mut server_name = use_signal(String::new);
+    let mut server_url = use_signal(String::new);
     let mut server_service = use_signal(|| MusicService::Jellyfin);
     let yt_browser = use_signal(|| {
         config
@@ -197,15 +195,15 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
     // popup opens on the only working method.
     let yt_anonymous = use_signal(|| cfg!(target_os = "windows"));
 
-    let mut username = use_signal(|| String::new());
-    let mut password = use_signal(|| String::new());
+    let mut username = use_signal(String::new);
+    let mut password = use_signal(String::new);
 
     let mut error = use_signal(|| Option::<String>::None);
     let mut login_error = use_signal(|| Option::<String>::None);
     let mut is_loading = use_signal(|| false);
 
     let mut show_add_registry = use_signal(|| false);
-    let mut registry_url = use_signal(|| String::new());
+    let mut registry_url = use_signal(String::new);
     let mut registry_error = use_signal(|| Option::<String>::None);
     let mut registry_loading = use_signal(|| false);
     let mut registry_toggle_error = use_signal(|| Option::<String>::None);
@@ -225,31 +223,34 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
         registry_loading.set(true);
         registry_error.set(None);
 
-        spawn(async move {
-            let mut temp_registry = radio::registry::StationRegistry::new();
-            match temp_registry.import_registry(&url).await {
-                Ok(_) => {
-                    let mut current_config = config.write();
-                    if !current_config.radio_registries.iter().any(|r| r.url == url) {
-                        current_config.radio_registries.push(config::RegistryEntry {
-                            url,
-                            enabled: true,
-                            is_default: false,
-                        });
+        spawn(
+            async move {
+                let mut temp_registry = radio::registry::StationRegistry::new();
+                match temp_registry.import_registry(&url).await {
+                    Ok(_) => {
+                        let mut current_config = config.write();
+                        if !current_config.radio_registries.iter().any(|r| r.url == url) {
+                            current_config.radio_registries.push(config::RegistryEntry {
+                                url,
+                                enabled: true,
+                                is_default: false,
+                            });
+                        }
+                        registry_url.set(String::new());
+                        registry_error.set(None);
+                        show_add_registry.set(false);
                     }
-                    registry_url.set(String::new());
-                    registry_error.set(None);
-                    show_add_registry.set(false);
+                    Err(e) => {
+                        registry_error.set(Some(i18n::t_with(
+                            "radio_registry_import_failed",
+                            &[("error", e.to_string())],
+                        )));
+                    }
                 }
-                Err(e) => {
-                    registry_error.set(Some(i18n::t_with(
-                        "radio_registry_import_failed",
-                        &[("error", e.to_string())],
-                    )));
-                }
+                registry_loading.set(false);
             }
-            registry_loading.set(false);
-        }.instrument(tracing::info_span!("radio.import_registry")));
+            .instrument(tracing::info_span!("radio.import_registry")),
+        );
     };
 
     let ytmusic_auto_login = move || {
@@ -314,65 +315,68 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
         let name_input = server_name();
         let url_input = server_url();
 
-        spawn(async move {
-            let display_name = if name_input.is_empty() {
-                format!("Local {}", selected_service.display_name())
-            } else {
-                name_input
-            };
+        spawn(
+            async move {
+                let display_name = if name_input.is_empty() {
+                    format!("Local {}", selected_service.display_name())
+                } else {
+                    name_input
+                };
 
-            let effective_url = if is_ytmusic {
-                "https://music.youtube.com".to_string()
-            } else {
-                url_input
-            };
+                let effective_url = if is_ytmusic {
+                    "https://music.youtube.com".to_string()
+                } else {
+                    url_input
+                };
 
-            let mut new_server = config::MusicServer::new_with_service(
-                display_name,
-                effective_url,
-                selected_service,
-            );
-            let is_anon = is_ytmusic && *yt_anonymous.peek();
-            new_server.yt_anonymous = is_anon;
-            if is_anon {
-                // Mark anonymous mode at the server level. Empty access
-                // token + yt_anonymous=true is what get_stream /
-                // discover etc. read as "no cookies, public surfaces
-                // only".
-                new_server.access_token = Some(String::new());
+                let mut new_server = config::MusicServer::new_with_service(
+                    display_name,
+                    effective_url,
+                    selected_service,
+                );
+                let is_anon = is_ytmusic && *yt_anonymous.peek();
+                new_server.yt_anonymous = is_anon;
+                if is_anon {
+                    // Mark anonymous mode at the server level. Empty access
+                    // token + yt_anonymous=true is what get_stream /
+                    // discover etc. read as "no cookies, public surfaces
+                    // only".
+                    new_server.access_token = Some(String::new());
+                }
+                // Persist the chosen browser on the active server too (not just the
+                // saved-list entry), so the sign-in flow knows which browser to use.
+                new_server.yt_browser = (is_ytmusic && !is_anon).then(|| *yt_browser.peek());
+
+                let saved = config::SavedServer {
+                    id: new_server.id.clone().unwrap_or_default(),
+                    name: new_server.name.clone(),
+                    url: new_server.url.clone(),
+                    service: new_server.service,
+                    yt_browser: (is_ytmusic && !is_anon).then(|| *yt_browser.peek()),
+                    yt_anonymous: is_anon,
+                };
+                {
+                    let mut cfg = config.write();
+                    cfg.add_saved_server(saved);
+                    cfg.server = Some(new_server);
+                }
+
+                server_name.set(String::new());
+                server_url.set(String::new());
+                server_service.set(MusicService::Jellyfin);
+                error.set(None);
+                show_add_server.set(false);
+
+                if is_ytmusic && !is_anon {
+                    ytmusic_auto_login();
+                } else if !is_ytmusic {
+                    show_login.set(true);
+                }
+                // Anonymous YT needs no further setup — the server entry
+                // is already active and playable.
             }
-            // Persist the chosen browser on the active server too (not just the
-            // saved-list entry), so the sign-in flow knows which browser to use.
-            new_server.yt_browser = (is_ytmusic && !is_anon).then(|| *yt_browser.peek());
-
-            let saved = config::SavedServer {
-                id: new_server.id.clone().unwrap_or_default(),
-                name: new_server.name.clone(),
-                url: new_server.url.clone(),
-                service: new_server.service,
-                yt_browser: (is_ytmusic && !is_anon).then(|| *yt_browser.peek()),
-                yt_anonymous: is_anon,
-            };
-            {
-                let mut cfg = config.write();
-                cfg.add_saved_server(saved);
-                cfg.server = Some(new_server);
-            }
-
-            server_name.set(String::new());
-            server_url.set(String::new());
-            server_service.set(MusicService::Jellyfin);
-            error.set(None);
-            show_add_server.set(false);
-
-            if is_ytmusic && !is_anon {
-                ytmusic_auto_login();
-            } else if !is_ytmusic {
-                show_login.set(true);
-            }
-            // Anonymous YT needs no further setup — the server entry
-            // is already active and playable.
-        }.instrument(tracing::info_span!("yt.anon_setup")));
+            .instrument(tracing::info_span!("yt.anon_setup")),
+        );
     };
 
     let handle_switch_server = move |id: String| {

--- a/crates/pages/src/ytdlp.rs
+++ b/crates/pages/src/ytdlp.rs
@@ -86,19 +86,17 @@ fn search_dirs() -> &'static [PathBuf] {
         let mut dirs: Vec<PathBuf> =
             std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()).collect();
 
-        if let Some(shell) = std::env::var_os("SHELL") {
-            if let Ok(out) = std::process::Command::new(shell)
+        if let Some(shell) = std::env::var_os("SHELL")
+            && let Ok(out) = std::process::Command::new(shell)
                 .arg("-lc")
                 .arg("printf %s \"$PATH\"")
                 .output()
-            {
-                if out.status.success() {
-                    let path = String::from_utf8_lossy(&out.stdout);
-                    for dir in std::env::split_paths(path.trim()) {
-                        if !dirs.contains(&dir) {
-                            dirs.push(dir);
-                        }
-                    }
+            && out.status.success()
+        {
+            let path = String::from_utf8_lossy(&out.stdout);
+            for dir in std::env::split_paths(path.trim()) {
+                if !dirs.contains(&dir) {
+                    dirs.push(dir);
                 }
             }
         }
@@ -398,7 +396,7 @@ fn parse_line(line: &str) -> Option<LineInfo> {
 pub fn YtdlpPage(config: Signal<AppConfig>, mut trigger_rescan: Signal<usize>) -> Element {
     let mut url_input = use_signal(String::new);
     let mut format = use_signal(|| AudioFormat::BestAudio);
-    let mut jobs = use_signal(|| Vec::<DownloadJob>::new());
+    let mut jobs = use_signal(Vec::<DownloadJob>::new);
     let mut out_dir = use_signal(|| config.peek().ytdlp_output_dir.clone());
     let mut show_opts = use_signal(|| false);
     let mut preflight_error = use_signal(|| Option::<String>::None);
@@ -483,7 +481,10 @@ pub fn YtdlpPage(config: Signal<AppConfig>, mut trigger_rescan: Signal<usize>) -
                 };
 
                 if let Some(stdout) = child.stdout.take() {
-                    for line in std::io::BufReader::new(stdout).lines().flatten() {
+                    for line in std::io::BufReader::new(stdout)
+                        .lines()
+                        .map_while(Result::ok)
+                    {
                         if let Some(info) = parse_line(&line) {
                             let _ = tx.send(info);
                         }
@@ -492,7 +493,7 @@ pub fn YtdlpPage(config: Signal<AppConfig>, mut trigger_rescan: Signal<usize>) -
                 if let Some(stderr) = child.stderr.take() {
                     let errs: Vec<String> = std::io::BufReader::new(stderr)
                         .lines()
-                        .flatten()
+                        .map_while(Result::ok)
                         .filter(|l| l.contains("ERROR"))
                         .collect();
                     if !errs.is_empty() {

--- a/crates/player/src/player.rs
+++ b/crates/player/src/player.rs
@@ -130,16 +130,22 @@ struct CrossfadeState {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+type SharedConsumer = Arc<Mutex<rb::Consumer<f32>>>;
+
+#[cfg(not(target_arch = "wasm32"))]
+type ActiveConsumerSlot = Arc<Mutex<Option<SharedConsumer>>>;
+
+#[cfg(not(target_arch = "wasm32"))]
 pub struct Player {
     state: Arc<Mutex<PlaybackState>>,
     active_state_handle: Arc<Mutex<Arc<Mutex<PlaybackState>>>>,
     _device: cpal::Device,
     stream_config: cpal::StreamConfig,
     _stream: Option<cpal::Stream>,
-    active_consumer: Arc<Mutex<Option<Arc<Mutex<rb::Consumer<f32>>>>>>,
-    fading_consumer: Arc<Mutex<Option<Arc<Mutex<rb::Consumer<f32>>>>>>,
+    active_consumer: ActiveConsumerSlot,
+    fading_consumer: ActiveConsumerSlot,
     crossfade_state: Arc<Mutex<Option<CrossfadeState>>>,
-    ring_buf_consumer: Option<Arc<Mutex<rb::Consumer<f32>>>>,
+    ring_buf_consumer: Option<SharedConsumer>,
     ring_buf: Option<SpscRb<f32>>,
     decoder_handle: Option<std::thread::JoinHandle<()>>,
     fading_session_state: Arc<Mutex<Option<Arc<Mutex<PlaybackState>>>>>,
@@ -768,8 +774,7 @@ impl Player {
                 .as_deref()
                 .and_then(parse_opushead_channels)
                 .unwrap_or(2);
-            audio_params.channels =
-                Some(symphonia::core::audio::Channels::Discrete(ch as u16));
+            audio_params.channels = Some(symphonia::core::audio::Channels::Discrete(ch as u16));
             if audio_params.sample_rate.is_none() {
                 audio_params.sample_rate = Some(48_000);
             }
@@ -802,8 +807,7 @@ impl Player {
                 }
 
                 if let Some(seek_time) = st.seek_to.take() {
-                    let time =
-                        Time::try_from_secs_f64(seek_time.as_secs_f64()).unwrap_or_default();
+                    let time = Time::try_from_secs_f64(seek_time.as_secs_f64()).unwrap_or_default();
                     let seek_to = SeekTo::Time {
                         time,
                         track_id: Some(track_id),

--- a/crates/player/src/systemint/linux.rs
+++ b/crates/player/src/systemint/linux.rs
@@ -251,19 +251,21 @@ pub fn update_now_playing(
             // thumbs, YT Music covers) through unchanged so clients can
             // fetch them directly; only wrap actual local file paths
             // with file://.
-            b = b.art_url(if art.starts_with("http://")
-                || art.starts_with("https://")
-                || art.starts_with("file://")
-            {
-                art.to_string()
-            } else if art.starts_with('/') {
-                format!("file://{art}")
-            } else {
-                format!(
-                    "file://{}/{art}",
-                    std::env::current_dir().unwrap_or_default().display()
-                )
-            });
+            b = b.art_url(
+                if art.starts_with("http://")
+                    || art.starts_with("https://")
+                    || art.starts_with("file://")
+                {
+                    art.to_string()
+                } else if art.starts_with('/') {
+                    format!("file://{art}")
+                } else {
+                    format!(
+                        "file://{}/{art}",
+                        std::env::current_dir().unwrap_or_default().display()
+                    )
+                },
+            );
         }
         *s = (
             b.build(),

--- a/crates/radio/src/manifest.rs
+++ b/crates/radio/src/manifest.rs
@@ -260,10 +260,10 @@ impl StationManifest {
                     if static_def.artist.trim().is_empty() {
                         return Err(ManifestError::EmptyStaticArtist);
                     }
-                    if let Some(url) = &static_def.cover_url {
-                        if !url.starts_with("https://") {
-                            return Err(ManifestError::InsecureStaticCoverUrl(url.clone()));
-                        }
+                    if let Some(url) = &static_def.cover_url
+                        && !url.starts_with("https://")
+                    {
+                        return Err(ManifestError::InsecureStaticCoverUrl(url.clone()));
                     }
                     for ov in static_def.stream_overrides.values() {
                         if ov.title.trim().is_empty() {
@@ -272,10 +272,10 @@ impl StationManifest {
                         if ov.artist.trim().is_empty() {
                             return Err(ManifestError::EmptyStaticArtist);
                         }
-                        if let Some(url) = &ov.cover_url {
-                            if !url.starts_with("https://") {
-                                return Err(ManifestError::InsecureStaticCoverUrl(url.clone()));
-                            }
+                        if let Some(url) = &ov.cover_url
+                            && !url.starts_with("https://")
+                        {
+                            return Err(ManifestError::InsecureStaticCoverUrl(url.clone()));
                         }
                     }
                 }

--- a/crates/radio/src/provider.rs
+++ b/crates/radio/src/provider.rs
@@ -245,11 +245,11 @@ async fn start_ws_metadata(
                     }
                     tokio::select! {
                         _ = heartbeat_timer.tick(), if def.heartbeat.is_some() => {
-                            if let Some(hb) = &def.heartbeat {
-                                if let Err(e) = ws_stream.send(tokio_tungstenite::tungstenite::Message::Text(hb.message.clone().into())).await {
-                                    tracing::warn!("WebSocket heartbeat failed: {}", e);
-                                    break;
-                                }
+                            if let Some(hb) = &def.heartbeat
+                                && let Err(e) = ws_stream.send(tokio_tungstenite::tungstenite::Message::Text(hb.message.clone().into())).await
+                            {
+                                tracing::warn!("WebSocket heartbeat failed: {}", e);
+                                break;
                             }
                         }
                         msg = ws_stream.next() => {

--- a/crates/reader/src/metadata.rs
+++ b/crates/reader/src/metadata.rs
@@ -303,8 +303,7 @@ pub fn write_tags(track_path: &Path, edits: &TrackEdits) -> Result<(), String> {
             }
         }
         CoverChange::Set(bytes) => {
-            let mut picture =
-                Picture::from_reader(&mut &bytes[..]).map_err(|e| e.to_string())?;
+            let mut picture = Picture::from_reader(&mut &bytes[..]).map_err(|e| e.to_string())?;
             picture.set_pic_type(PictureType::CoverFront);
             while !tag.pictures().is_empty() {
                 tag.remove_picture(0);
@@ -408,7 +407,13 @@ fn read_with_symphonia(
         if let Some(track_info) = format
             .tracks()
             .iter()
-            .find(|track| track.codec_params.as_ref().and_then(|p| p.audio()).is_some())
+            .find(|track| {
+                track
+                    .codec_params
+                    .as_ref()
+                    .and_then(|p| p.audio())
+                    .is_some()
+            })
             .or_else(|| format.tracks().first())
         {
             if let Some(audio) = track_info.codec_params.as_ref().and_then(|p| p.audio()) {
@@ -447,14 +452,18 @@ fn read_with_symphonia(
         .or(parent_path.as_deref())
         .unwrap_or(&artist);
 
-    let title = find_symphonia_tag(&tags, |t| matches!(t, StandardTag::TrackTitle(_)), &["TITLE"])
-        .and_then(symphonia_tag_to_string)
-        .or_else(|| {
-            track_path
-                .file_stem()
-                .map(|stem| stem.to_string_lossy().into_owned())
-        })
-        .unwrap_or_else(|| "Unknown Title".to_string());
+    let title = find_symphonia_tag(
+        &tags,
+        |t| matches!(t, StandardTag::TrackTitle(_)),
+        &["TITLE"],
+    )
+    .and_then(symphonia_tag_to_string)
+    .or_else(|| {
+        track_path
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().into_owned())
+    })
+    .unwrap_or_else(|| "Unknown Title".to_string());
 
     let bitrate_kbps = (file_size * 8)
         .checked_div(duration)
@@ -538,8 +547,8 @@ fn read_with_symphonia(
             &["DATE", "YEAR"],
         )
         .and_then(symphonia_tag_to_string)
-            .and_then(|value| value.get(..4).and_then(|prefix| prefix.parse::<u16>().ok()))
-            .unwrap_or(0);
+        .and_then(|value| value.get(..4).and_then(|prefix| prefix.parse::<u16>().ok()))
+        .unwrap_or(0);
 
         library.add_album(Album {
             id: album_id.clone(),

--- a/crates/reader/src/models.rs
+++ b/crates/reader/src/models.rs
@@ -250,7 +250,11 @@ impl PlaylistStore {
         let data = fs::read_to_string(path)?;
         let store: Self = serde_json::from_str(&data)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
-        tracing::debug!(bytes = data.len(), playlists = store.playlists.len(), "playlists loaded");
+        tracing::debug!(
+            bytes = data.len(),
+            playlists = store.playlists.len(),
+            "playlists loaded"
+        );
         Ok(store)
     }
 

--- a/crates/scrobble/src/musicbrainz.rs
+++ b/crates/scrobble/src/musicbrainz.rs
@@ -94,7 +94,7 @@ pub fn make_listen<'a>(
             artist_name: artist,
             track_name: track,
             release_name: release.filter(|s| !s.is_empty()),
-            additional_info: additional_info,
+            additional_info,
         },
     }
 }
@@ -111,7 +111,7 @@ pub fn make_playing_now<'a>(
             artist_name: artist,
             track_name: track,
             release_name: release.filter(|s| !s.is_empty()),
-            additional_info: additional_info,
+            additional_info,
         },
     }
 }

--- a/crates/server/examples/duration_probe.rs
+++ b/crates/server/examples/duration_probe.rs
@@ -3,7 +3,10 @@
 //! prints Some(N), the wire-extraction half of the duration fix is
 //! working and any remaining 0:00 in the UI is a signal-plumbing bug
 //! in the player controller, not a network/parse bug.
-#![expect(clippy::print_stdout, reason = "CLI probe example reports its findings on stdout")]
+#![expect(
+    clippy::print_stdout,
+    reason = "CLI probe example reports its findings on stdout"
+)]
 
 use serde_json::Value;
 use server::ytmusic::YouTubeMusicClient;
@@ -36,7 +39,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("  format          = {:?}", info.format);
     println!("  user_agent      = {}", info.user_agent);
     println!("  content_length  = {:?}", info.content_length);
-    println!("  duration_secs   = {:?}  ← THE FIELD UNDER TEST", info.duration_secs);
+    println!(
+        "  duration_secs   = {:?}  ← THE FIELD UNDER TEST",
+        info.duration_secs
+    );
     if info.duration_secs.is_none() {
         println!("\n  ⚠ duration_secs is None — pick_plain_format didn't populate it.");
     } else if info.duration_secs == Some(0) {

--- a/crates/server/src/server_ops.rs
+++ b/crates/server/src/server_ops.rs
@@ -217,9 +217,10 @@ mod tests {
         if let Some(u) = user_id {
             server["user_id"] = u.into();
         }
-        let mut c = config::AppConfig::default();
-        c.server = Some(serde_json::from_value(server).unwrap());
-        c
+        config::AppConfig {
+            server: Some(serde_json::from_value(server).unwrap()),
+            ..Default::default()
+        }
     }
 
     #[test]

--- a/crates/server/src/ytmusic/clients.rs
+++ b/crates/server/src/ytmusic/clients.rs
@@ -108,7 +108,4 @@ pub const MAIN_CLIENT: YouTubeClient = WEB_REMIX;
 /// were dropped — their stream URLs are rate-limited to the first ~1 MiB
 /// from byte 0, so even when /player returns OK, chunked Range fetches
 /// for the rest of the track 403 mid-playback. Worse than failing fast.
-pub const STREAM_FALLBACK_CLIENTS: &[YouTubeClient] = &[
-    ANDROID_VR_1_43_32,
-    ANDROID_VR_1_61_48,
-];
+pub const STREAM_FALLBACK_CLIENTS: &[YouTubeClient] = &[ANDROID_VR_1_43_32, ANDROID_VR_1_61_48];

--- a/crates/server/src/ytmusic/cookies.rs
+++ b/crates/server/src/ytmusic/cookies.rs
@@ -23,23 +23,24 @@ pub async fn extract_from(browser: Browser, profile_root: &Path) -> Result<Strin
     let browser_name = rookie_browser_name(browser);
     let profile_root_owned = profile_root.to_path_buf();
 
-    let cookies = tokio::task::spawn_blocking(move || -> Result<Vec<rookie::enums::Cookie>, String> {
-        let domains = Some(vec!["youtube.com".to_string()]);
-        #[cfg(not(target_os = "windows"))]
-        {
-            let _ = profile_root_owned;
-            let config = rookie::config::get_browser_config(browser_name);
-            rookie::chromium_based(config, db_path, domains).map_err(|e| e.to_string())
-        }
-        #[cfg(target_os = "windows")]
-        {
-            let _ = browser_name;
-            let key_path = profile_root_owned.join("Local State");
-            rookie::chromium_based(key_path, db_path, domains).map_err(|e| e.to_string())
-        }
-    })
-    .await
-    .map_err(|e| format!("cookie extract task: {e}"))??;
+    let cookies =
+        tokio::task::spawn_blocking(move || -> Result<Vec<rookie::enums::Cookie>, String> {
+            let domains = Some(vec!["youtube.com".to_string()]);
+            #[cfg(not(target_os = "windows"))]
+            {
+                let _ = profile_root_owned;
+                let config = rookie::config::get_browser_config(browser_name);
+                rookie::chromium_based(config, db_path, domains).map_err(|e| e.to_string())
+            }
+            #[cfg(target_os = "windows")]
+            {
+                let _ = browser_name;
+                let key_path = profile_root_owned.join("Local State");
+                rookie::chromium_based(key_path, db_path, domains).map_err(|e| e.to_string())
+            }
+        })
+        .await
+        .map_err(|e| format!("cookie extract task: {e}"))??;
 
     let header = cookies
         .iter()

--- a/crates/server/src/ytmusic/decipher/mod.rs
+++ b/crates/server/src/ytmusic/decipher/mod.rs
@@ -229,13 +229,16 @@ fn pct_encode(s: &str) -> String {
 /// every few hours and its `signatureTimestamp` must match, so we re-fetch the
 /// pair periodically instead of pinning it for the whole process — otherwise a
 /// rotation would break decipher until restart.
-static PLAYER_JS: Mutex<Option<(Instant, Arc<(String, u64)>)>> = Mutex::new(None);
+type CachedPlayerJs = Arc<(String, u64)>;
+type PlayerJsCacheEntry = (Instant, CachedPlayerJs);
+
+static PLAYER_JS: Mutex<Option<PlayerJsCacheEntry>> = Mutex::new(None);
 const PLAYER_JS_TTL: Duration = Duration::from_secs(60 * 60);
 
 /// Fetch YouTube's player `base.js` and its embedded `signatureTimestamp`,
 /// cached for [`PLAYER_JS_TTL`]. Seeded from any `video_id`'s watch page.
 #[tracing::instrument(name = "yt.player_js", fields(video_id = %video_id))]
-pub async fn player_js(video_id: &str) -> Result<Arc<(String, u64)>, String> {
+pub async fn player_js(video_id: &str) -> Result<CachedPlayerJs, String> {
     if let Ok(g) = PLAYER_JS.lock()
         && let Some((at, data)) = g.as_ref()
         && at.elapsed() < PLAYER_JS_TTL
@@ -310,10 +313,22 @@ fn detect_runtime() -> Option<Runtime> {
     static RT: OnceLock<Option<Runtime>> = OnceLock::new();
     *RT.get_or_init(|| {
         const CANDIDATES: &[Runtime] = &[
-            Runtime { bin: "deno", args: &["run", "--quiet", "--no-prompt"] },
-            Runtime { bin: "node", args: &[] },
-            Runtime { bin: "bun", args: &["run"] },
-            Runtime { bin: "qjs", args: &[] },
+            Runtime {
+                bin: "deno",
+                args: &["run", "--quiet", "--no-prompt"],
+            },
+            Runtime {
+                bin: "node",
+                args: &[],
+            },
+            Runtime {
+                bin: "bun",
+                args: &["run"],
+            },
+            Runtime {
+                bin: "qjs",
+                args: &[],
+            },
         ];
         CANDIDATES.iter().copied().find(|c| {
             std::process::Command::new(c.bin)
@@ -479,7 +494,10 @@ mod tests {
             { "type": "result", "data": { "SCRAMBLED": "UNSCRAMBLED" } }
         ]);
         assert_eq!(lookup(&responses, "OLD").as_deref(), Some("NEW"));
-        assert_eq!(lookup(&responses, "SCRAMBLED").as_deref(), Some("UNSCRAMBLED"));
+        assert_eq!(
+            lookup(&responses, "SCRAMBLED").as_deref(),
+            Some("UNSCRAMBLED")
+        );
         assert_eq!(lookup(&responses, "MISSING"), None);
     }
 
@@ -513,12 +531,7 @@ mod tests {
             .and_then(|v| v.as_array())
             .expect("formats")
             .iter()
-            .filter(|f| {
-                f["mimeType"]
-                    .as_str()
-                    .unwrap_or("")
-                    .starts_with("audio/")
-            })
+            .filter(|f| f["mimeType"].as_str().unwrap_or("").starts_with("audio/"))
             .max_by_key(|f| f["bitrate"].as_u64().unwrap_or(0))
             .expect("audio format");
         assert!(

--- a/crates/server/src/ytmusic/discover.rs
+++ b/crates/server/src/ytmusic/discover.rs
@@ -225,7 +225,9 @@ fn best_artist_banner(header: &Value) -> Option<String> {
 fn parse_artist_carousel(section: &Value) -> Option<DiscoverShelf> {
     let shelf = section.get("musicCarouselShelfRenderer")?;
     let header = shelf.pointer("/header/musicCarouselShelfBasicHeaderRenderer");
-    let title = header.and_then(|h| runs_text(h, "/title/runs")).unwrap_or_default();
+    let title = header
+        .and_then(|h| runs_text(h, "/title/runs"))
+        .unwrap_or_default();
     if title.is_empty() {
         return None;
     }
@@ -306,7 +308,11 @@ fn parse_artist_song_row(row: &Value) -> Option<Track> {
     let mut flex_duration: Option<u64> = None;
     for c in &cols {
         match c {
-            RowColumn::Title { text, video_id: vid, .. } => {
+            RowColumn::Title {
+                text,
+                video_id: vid,
+                ..
+            } => {
                 if title.is_empty() {
                     title = text.clone();
                 }
@@ -419,7 +425,11 @@ fn parse_album(browse_id: &str, resp: &Value) -> YtAlbum {
             // no /flexColumns/N positional dive.
             if audio_pid_from_rows.is_none() {
                 for c in classify_flex_columns(row) {
-                    if let RowColumn::Title { playlist_id: Some(pid), .. } = c {
+                    if let RowColumn::Title {
+                        playlist_id: Some(pid),
+                        ..
+                    } = c
+                    {
                         audio_pid_from_rows = Some(pid);
                         break;
                     }
@@ -529,7 +539,9 @@ fn pick_album_artist(header: Option<&Value>) -> Option<String> {
     // Use `let else continue` instead of `?` so a single empty/structural
     // run in the middle doesn't abort the whole scan and miss the real
     // artist later in the array.
-    let arr = header.pointer("/subtitle/runs").and_then(|v| v.as_array())?;
+    let arr = header
+        .pointer("/subtitle/runs")
+        .and_then(|v| v.as_array())?;
     for r in arr {
         let Some(text) = r.get("text").and_then(|v| v.as_str()) else {
             continue;
@@ -616,7 +628,11 @@ fn parse_album_row(
     let mut flex_duration: Option<u64> = None;
     for c in &cols {
         match c {
-            RowColumn::Title { text, video_id: vid, .. } => {
+            RowColumn::Title {
+                text,
+                video_id: vid,
+                ..
+            } => {
                 if title.is_empty() {
                     title = text.clone();
                 }
@@ -756,8 +772,7 @@ async fn post(url: &str, body: &Value, cookies: &str) -> Result<Value, String> {
 }
 
 fn parse_initial(resp: &Value) -> DiscoverHome {
-    let sections =
-        tab_section_contents(resp, "/contents/singleColumnBrowseResultsRenderer/tabs");
+    let sections = tab_section_contents(resp, "/contents/singleColumnBrowseResultsRenderer/tabs");
     let continuation = resp
         .pointer("/contents/singleColumnBrowseResultsRenderer/tabs")
         .and_then(|v| v.as_array())
@@ -794,7 +809,9 @@ fn parse_continuation(resp: &Value) -> DiscoverHome {
 fn parse_shelf(section: &Value) -> Option<DiscoverShelf> {
     let shelf = section.get("musicCarouselShelfRenderer")?;
     let header = shelf.pointer("/header/musicCarouselShelfBasicHeaderRenderer");
-    let title = header.and_then(|h| runs_text(h, "/title/runs")).unwrap_or_default();
+    let title = header
+        .and_then(|h| runs_text(h, "/title/runs"))
+        .unwrap_or_default();
     if title.is_empty() {
         return None;
     }
@@ -899,21 +916,11 @@ fn parse_tile(item: &Value) -> Option<DiscoverItem> {
     None
 }
 
-fn build_song_track(
-    video_id: &str,
-    title: &str,
-    subtitle: &str,
-    thumbnail: Option<&str>,
-) -> Track {
+fn build_song_track(video_id: &str, title: &str, subtitle: &str, thumbnail: Option<&str>) -> Track {
     // Subtitle for songs/videos is typically "Artist • N views" — take
     // the first run as the primary artist; everything after the first
     // dot is metadata that doesn't belong in the artist field.
-    let primary_artist = subtitle
-        .split('•')
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_string();
+    let primary_artist = subtitle.split('•').next().unwrap_or("").trim().to_string();
     let artists = if primary_artist.is_empty() {
         Vec::new()
     } else {
@@ -1150,10 +1157,8 @@ fn fixed_columns_duration(row: &Value) -> Option<u64> {
         // `let else continue` — a textless column (e.g. a like-toggle
         // fixedColumn before the duration column) must not abort the
         // whole scan; iterate until we find one that parses as mm:ss.
-        let Some(text) = runs_text(
-            col,
-            "/musicResponsiveListItemFixedColumnRenderer/text/runs",
-        ) else {
+        let Some(text) = runs_text(col, "/musicResponsiveListItemFixedColumnRenderer/text/runs")
+        else {
             continue;
         };
         if let Some(secs) = parse_mm_ss(text.trim()) {

--- a/crates/server/src/ytmusic/innertube.rs
+++ b/crates/server/src/ytmusic/innertube.rs
@@ -19,15 +19,15 @@ pub(super) fn http_client() -> &'static reqwest::Client {
 
 /// Builds the `Authorization: SAPISIDHASH <ts>_<sha1(ts " " SAPISID " " origin)>` header.
 pub fn sapisid_hash(cookies: &str, origin: &str) -> Option<String> {
-    let sapisid = cookie_value(cookies, "SAPISID")
-        .or_else(|| cookie_value(cookies, "__Secure-3PAPISID"))?;
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .ok()?
-        .as_secs();
+    let sapisid =
+        cookie_value(cookies, "SAPISID").or_else(|| cookie_value(cookies, "__Secure-3PAPISID"))?;
+    let ts = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
     let mut hasher = Sha1::new();
     hasher.update(format!("{ts} {sapisid} {origin}").as_bytes());
-    Some(format!("SAPISIDHASH {ts}_{}", hex::encode(hasher.finalize())))
+    Some(format!(
+        "SAPISIDHASH {ts}_{}",
+        hex::encode(hasher.finalize())
+    ))
 }
 
 fn cookie_value(header: &str, name: &str) -> Option<String> {
@@ -43,7 +43,10 @@ fn cookie_value(header: &str, name: &str) -> Option<String> {
 
 fn build_context(client: YouTubeClient) -> Value {
     let mut obj = serde_json::Map::new();
-    obj.insert("clientName".into(), Value::String(client.client_name.into()));
+    obj.insert(
+        "clientName".into(),
+        Value::String(client.client_name.into()),
+    );
     obj.insert(
         "clientVersion".into(),
         Value::String(client.client_version.into()),
@@ -57,7 +60,10 @@ fn build_context(client: YouTubeClient) -> Value {
         obj.insert("osVersion".into(), Value::String(client.os_version.into()));
     }
     if !client.device_make.is_empty() {
-        obj.insert("deviceMake".into(), Value::String(client.device_make.into()));
+        obj.insert(
+            "deviceMake".into(),
+            Value::String(client.device_make.into()),
+        );
     }
     if !client.device_model.is_empty() {
         obj.insert(
@@ -147,8 +153,8 @@ pub async fn player(
     if client.login_supported
         && let Some(c) = cookies
     {
-        let auth = sapisid_hash(c, ORIGIN_YOUTUBE_MUSIC)
-            .ok_or_else(|| "SAPISID missing".to_string())?;
+        let auth =
+            sapisid_hash(c, ORIGIN_YOUTUBE_MUSIC).ok_or_else(|| "SAPISID missing".to_string())?;
         req = req.header("Cookie", c).header("Authorization", auth);
     }
 
@@ -170,10 +176,7 @@ pub async fn player(
 
 /// Hits `/youtubei/v1/browse` (used for Liked Music validation and library
 /// fetches). Always WEB_REMIX with cookies.
-pub async fn browse(
-    browse_id: &str,
-    cookies: &str,
-) -> Result<Value, String> {
+pub async fn browse(browse_id: &str, cookies: &str) -> Result<Value, String> {
     browse_maybe_auth(browse_id, Some(cookies)).await
 }
 
@@ -183,10 +186,7 @@ pub async fn browse(
 /// recs). Private surfaces (Liked, user library) will return a
 /// sign-in shelf for anonymous callers — caller has to detect that.
 #[tracing::instrument(name = "yt.browse", skip(cookies), fields(browse_id = %browse_id, anon = cookies.is_none()))]
-pub async fn browse_maybe_auth(
-    browse_id: &str,
-    cookies: Option<&str>,
-) -> Result<Value, String> {
+pub async fn browse_maybe_auth(browse_id: &str, cookies: Option<&str>) -> Result<Value, String> {
     let client = super::clients::WEB_REMIX;
     let context = build_context(client);
     let body = json!({
@@ -194,7 +194,9 @@ pub async fn browse_maybe_auth(
         "browseId": browse_id,
     });
     let mut req = http_client()
-        .post(format!("{ORIGIN_YOUTUBE_MUSIC}/youtubei/v1/browse?prettyPrint=false"))
+        .post(format!(
+            "{ORIGIN_YOUTUBE_MUSIC}/youtubei/v1/browse?prettyPrint=false"
+        ))
         .header("User-Agent", client.user_agent)
         .header("Content-Type", "application/json")
         .header("X-Goog-Api-Format-Version", "1")
@@ -203,8 +205,8 @@ pub async fn browse_maybe_auth(
         .header("X-Origin", ORIGIN_YOUTUBE_MUSIC)
         .header("Referer", format!("{ORIGIN_YOUTUBE_MUSIC}/"));
     if let Some(c) = cookies {
-        let auth = sapisid_hash(c, ORIGIN_YOUTUBE_MUSIC)
-            .ok_or_else(|| "SAPISID missing".to_string())?;
+        let auth =
+            sapisid_hash(c, ORIGIN_YOUTUBE_MUSIC).ok_or_else(|| "SAPISID missing".to_string())?;
         req = req.header("Cookie", c).header("Authorization", auth);
     }
     let resp = req
@@ -232,10 +234,7 @@ pub fn extract_visitor_data(resp: &Value) -> Option<String> {
 /// Hit `/browse` with a continuation token instead of a browseId — used
 /// to walk paginated playlist shelves (Liked Music returns ~100 tracks
 /// per page).
-pub async fn browse_continuation(
-    continuation: &str,
-    cookies: &str,
-) -> Result<Value, String> {
+pub async fn browse_continuation(continuation: &str, cookies: &str) -> Result<Value, String> {
     browse_continuation_maybe_auth(continuation, Some(cookies)).await
 }
 
@@ -261,8 +260,8 @@ pub async fn browse_continuation_maybe_auth(
         .header("X-Origin", ORIGIN_YOUTUBE_MUSIC)
         .header("Referer", format!("{ORIGIN_YOUTUBE_MUSIC}/"));
     if let Some(c) = cookies {
-        let auth = sapisid_hash(c, ORIGIN_YOUTUBE_MUSIC)
-            .ok_or_else(|| "SAPISID missing".to_string())?;
+        let auth =
+            sapisid_hash(c, ORIGIN_YOUTUBE_MUSIC).ok_or_else(|| "SAPISID missing".to_string())?;
         req = req.header("Cookie", c).header("Authorization", auth);
     }
     let resp = req

--- a/crates/server/src/ytmusic/isolated_profile.rs
+++ b/crates/server/src/ytmusic/isolated_profile.rs
@@ -15,8 +15,7 @@ use std::time::{Duration, Instant};
 use config::Browser;
 use tokio::process::Command;
 
-const SIGNIN_URL: &str =
-    "https://accounts.google.com/ServiceLogin?service=youtube&continue=https%3A%2F%2Fmusic.youtube.com%2F";
+const SIGNIN_URL: &str = "https://accounts.google.com/ServiceLogin?service=youtube&continue=https%3A%2F%2Fmusic.youtube.com%2F";
 
 pub fn profile_dir(server_id: &str) -> PathBuf {
     let safe: String = server_id
@@ -60,21 +59,11 @@ fn browser_candidates(browser: Browser) -> &'static [&'static str] {
 #[cfg(target_os = "macos")]
 fn macos_app_paths(browser: Browser) -> &'static [&'static str] {
     match browser {
-        Browser::Brave => &[
-            "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
-        ],
-        Browser::Chrome => &[
-            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-        ],
-        Browser::Chromium => &[
-            "/Applications/Chromium.app/Contents/MacOS/Chromium",
-        ],
-        Browser::Edge => &[
-            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
-        ],
-        Browser::Vivaldi => &[
-            "/Applications/Vivaldi.app/Contents/MacOS/Vivaldi",
-        ],
+        Browser::Brave => &["/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"],
+        Browser::Chrome => &["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"],
+        Browser::Chromium => &["/Applications/Chromium.app/Contents/MacOS/Chromium"],
+        Browser::Edge => &["/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"],
+        Browser::Vivaldi => &["/Applications/Vivaldi.app/Contents/MacOS/Vivaldi"],
     }
 }
 
@@ -121,7 +110,10 @@ fn windows_install_paths(browser: Browser) -> Vec<PathBuf> {
 }
 
 fn find_browser_bin(browser: Browser) -> Option<String> {
-    let env_key = format!("KOPUZ_{}_BIN", browser.id().to_uppercase().replace('-', "_"));
+    let env_key = format!(
+        "KOPUZ_{}_BIN",
+        browser.id().to_uppercase().replace('-', "_")
+    );
     if let Some(v) = std::env::var_os(&env_key)
         && !v.is_empty()
     {
@@ -165,7 +157,10 @@ async fn find_host_browser_bin(browser: Browser) -> Option<String> {
     // Honour an explicit override (e.g. a non-standard host install path) — same
     // escape hatch as the native `find_browser_bin`. `flatpak-spawn --host` runs
     // it in the host environment, so an absolute host path works.
-    let env_key = format!("KOPUZ_{}_BIN", browser.id().to_uppercase().replace('-', "_"));
+    let env_key = format!(
+        "KOPUZ_{}_BIN",
+        browser.id().to_uppercase().replace('-', "_")
+    );
     if let Some(v) = std::env::var_os(&env_key)
         && !v.is_empty()
     {

--- a/crates/server/src/ytmusic/mix.rs
+++ b/crates/server/src/ytmusic/mix.rs
@@ -35,8 +35,13 @@ pub async fn start_mix(seed_video_id: &str, cookies: &str) -> Result<Vec<Track>,
     // Mix endpoint works without auth (anonymous radio for any public
     // video). Skip Cookie + SAPISID when cookies is empty so anon
     // YT mode can still hit Start-Radio.
-    let cookies_opt = if cookies.is_empty() { None } else { Some(cookies) };
-    let mut req = super::innertube::http_client().clone()
+    let cookies_opt = if cookies.is_empty() {
+        None
+    } else {
+        Some(cookies)
+    };
+    let mut req = super::innertube::http_client()
+        .clone()
         .post(format!("{ORIGIN}/youtubei/v1/next?prettyPrint=false"))
         .header("Content-Type", "application/json")
         .header("X-YouTube-Client-Name", client.client_id)
@@ -44,8 +49,7 @@ pub async fn start_mix(seed_video_id: &str, cookies: &str) -> Result<Vec<Track>,
         .header("Origin", ORIGIN)
         .header("Referer", format!("{ORIGIN}/"));
     if let Some(c) = cookies_opt {
-        let auth = sapisid_hash(c, ORIGIN)
-            .ok_or_else(|| "SAPISID missing".to_string())?;
+        let auth = sapisid_hash(c, ORIGIN).ok_or_else(|| "SAPISID missing".to_string())?;
         req = req.header("Cookie", c).header("Authorization", auth);
     }
     let resp: Value = req
@@ -91,9 +95,11 @@ fn walk_queue(resp: &Value) -> Vec<Track> {
 
     let mut out = Vec::new();
     for item in items {
-        let row = item
-            .get("playlistPanelVideoRenderer")
-            .or_else(|| item.pointer("/playlistPanelVideoWrapperRenderer/primaryRenderer/playlistPanelVideoRenderer"));
+        let row = item.get("playlistPanelVideoRenderer").or_else(|| {
+            item.pointer(
+                "/playlistPanelVideoWrapperRenderer/primaryRenderer/playlistPanelVideoRenderer",
+            )
+        });
         let Some(row) = row else {
             continue;
         };
@@ -111,7 +117,12 @@ fn parse_queue_row(row: &Value) -> Option<Track> {
         .and_then(|v| v.as_str());
     if !matches!(
         mvt,
-        Some("MUSIC_VIDEO_TYPE_ATV" | "MUSIC_VIDEO_TYPE_OMV" | "MUSIC_VIDEO_TYPE_UGC" | "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC")
+        Some(
+            "MUSIC_VIDEO_TYPE_ATV"
+                | "MUSIC_VIDEO_TYPE_OMV"
+                | "MUSIC_VIDEO_TYPE_UGC"
+                | "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC"
+        )
     ) {
         return None;
     }
@@ -161,7 +172,10 @@ fn parse_queue_row(row: &Value) -> Option<Track> {
     let thumbnail = row
         .pointer("/thumbnail/thumbnails")
         .and_then(|v| v.as_array())
-        .and_then(|arr| arr.iter().max_by_key(|t| t.get("width").and_then(|w| w.as_u64()).unwrap_or(0)))
+        .and_then(|arr| {
+            arr.iter()
+                .max_by_key(|t| t.get("width").and_then(|w| w.as_u64()).unwrap_or(0))
+        })
         .and_then(|t| t.get("url"))
         .and_then(|u| u.as_str())
         .map(normalize_yt_thumbnail);

--- a/crates/server/src/ytmusic/mod.rs
+++ b/crates/server/src/ytmusic/mod.rs
@@ -62,10 +62,7 @@ impl YouTubeMusicClient {
         search::music_search_tracks(query, self.cookies.as_deref()).await
     }
 
-    pub async fn resolve_artist_channel_id(
-        &self,
-        query: &str,
-    ) -> Result<Option<String>, String> {
+    pub async fn resolve_artist_channel_id(&self, query: &str) -> Result<Option<String>, String> {
         search::resolve_artist_channel_id(query, self.cookies.as_deref()).await
     }
 
@@ -76,9 +73,7 @@ impl YouTubeMusicClient {
     /// Library playlists view (FEmusic_liked_playlists). Auth-only —
     /// returns Ok(vec![]) in anonymous mode so the playlists tab
     /// just shows empty rather than erroring.
-    pub async fn list_playlists(
-        &self,
-    ) -> Result<Vec<playlists::YtPlaylistSummary>, String> {
+    pub async fn list_playlists(&self) -> Result<Vec<playlists::YtPlaylistSummary>, String> {
         let Some(cookies) = self.cookies.as_deref() else {
             return Ok(Vec::new());
         };
@@ -87,10 +82,7 @@ impl YouTubeMusicClient {
 
     /// Playlist contents. Public playlists work anonymously; the
     /// user's personal/private ones obviously won't.
-    pub async fn get_playlist_entries(
-        &self,
-        playlist_id: &str,
-    ) -> Result<Vec<Track>, String> {
+    pub async fn get_playlist_entries(&self, playlist_id: &str) -> Result<Vec<Track>, String> {
         playlists::get_playlist_entries(playlist_id, self.cookies.as_deref().unwrap_or("")).await
     }
 
@@ -102,7 +94,12 @@ impl YouTubeMusicClient {
     where
         F: FnMut(Vec<Track>),
     {
-        playlists::stream_playlist_entries(playlist_id, self.cookies.as_deref().unwrap_or(""), on_batch).await
+        playlists::stream_playlist_entries(
+            playlist_id,
+            self.cookies.as_deref().unwrap_or(""),
+            on_batch,
+        )
+        .await
     }
 
     // Mutations are inherently auth-only — keep the explicit "not
@@ -118,11 +115,7 @@ impl YouTubeMusicClient {
         mutations::unlike_video(video_id, cookies).await
     }
 
-    pub async fn add_to_playlist(
-        &self,
-        playlist_id: &str,
-        video_id: &str,
-    ) -> Result<(), String> {
+    pub async fn add_to_playlist(&self, playlist_id: &str, video_id: &str) -> Result<(), String> {
         let cookies = self.cookies.as_deref().ok_or(ANON_AUTH_REQUIRED)?;
         mutations::add_to_playlist(playlist_id, video_id, cookies).await
     }
@@ -170,20 +163,21 @@ impl YouTubeMusicClient {
         // boundaries; dedup against a video-id set across the entire stream so the
         // callback always sees unique tracks.
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let dedup = |page: Vec<Track>, seen: &mut std::collections::HashSet<String>| -> Vec<Track> {
-            page.into_iter()
-                .filter(|t| {
-                    let id = t
-                        .path
-                        .to_string_lossy()
-                        .split(':')
-                        .nth(1)
-                        .unwrap_or("")
-                        .to_string();
-                    !id.is_empty() && seen.insert(id)
-                })
-                .collect()
-        };
+        let dedup =
+            |page: Vec<Track>, seen: &mut std::collections::HashSet<String>| -> Vec<Track> {
+                page.into_iter()
+                    .filter(|t| {
+                        let id = t
+                            .path
+                            .to_string_lossy()
+                            .split(':')
+                            .nth(1)
+                            .unwrap_or("")
+                            .to_string();
+                        !id.is_empty() && seen.insert(id)
+                    })
+                    .collect()
+            };
 
         let (page1, mut next) = search::walk_playlist_shelf(&resp);
         let page1 = dedup(page1, &mut seen);

--- a/crates/server/src/ytmusic/mutations.rs
+++ b/crates/server/src/ytmusic/mutations.rs
@@ -10,7 +10,8 @@ async fn post(endpoint: &str, body: Value, cookies: &str) -> Result<Value, Strin
     let client = WEB_REMIX;
     let auth =
         sapisid_hash(cookies, ORIGIN_YOUTUBE_MUSIC).ok_or_else(|| "SAPISID missing".to_string())?;
-    let resp = super::innertube::http_client().clone()
+    let resp = super::innertube::http_client()
+        .clone()
         .post(format!(
             "{ORIGIN_YOUTUBE_MUSIC}/youtubei/v1/{endpoint}?prettyPrint=false"
         ))
@@ -82,7 +83,9 @@ pub async fn add_to_playlist(
             "addedVideoId": video_id,
         }],
     });
-    post("browse/edit_playlist", body, cookies).await.map(|_| ())
+    post("browse/edit_playlist", body, cookies)
+        .await
+        .map(|_| ())
 }
 
 /// Remove a video from a user playlist by video ID. (YT's API also
@@ -102,7 +105,9 @@ pub async fn remove_from_playlist(
             "removedVideoId": video_id,
         }],
     });
-    post("browse/edit_playlist", body, cookies).await.map(|_| ())
+    post("browse/edit_playlist", body, cookies)
+        .await
+        .map(|_| ())
 }
 
 /// Create a new playlist with an optional initial set of video IDs.

--- a/crates/server/src/ytmusic/player.rs
+++ b/crates/server/src/ytmusic/player.rs
@@ -117,8 +117,7 @@ pub async fn resolve(video_id: &str, cookies: Option<&str>) -> Result<YtStreamIn
 
     // Anonymous: ANDROID_VR + content_pot. Mint + visitor_data in parallel.
     let mut last_err = {
-        let (pot, visitor) =
-            tokio::join!(botguard::mint_content_pot(video_id), visitor_data(None));
+        let (pot, visitor) = tokio::join!(botguard::mint_content_pot(video_id), visitor_data(None));
         match (pot, visitor) {
             (Ok(pot), Ok(visitor)) => {
                 let extras = PlayerExtras {
@@ -152,7 +151,11 @@ pub async fn resolve(video_id: &str, cookies: Option<&str>) -> Result<YtStreamIn
     tracing::debug!(%last_err, "ANDROID_VR+pot failed — trying bare clients");
 
     for client in STREAM_FALLBACK_CLIENTS {
-        let cookies_for = if client.login_supported { cookies } else { None };
+        let cookies_for = if client.login_supported {
+            cookies
+        } else {
+            None
+        };
         match innertube::player(*client, video_id, cookies_for, PlayerExtras::default()).await {
             Ok(json) => {
                 let status = PlayabilityStatus::from_response(&json);
@@ -174,7 +177,9 @@ pub async fn resolve(video_id: &str, cookies: Option<&str>) -> Result<YtStreamIn
         }
     }
     if let Some(info) = decipher_fallback {
-        tracing::warn!("no content pot available (minter not running?) — using the non-Premium decipher stream; deep seeks may 403");
+        tracing::warn!(
+            "no content pot available (minter not running?) — using the non-Premium decipher stream; deep seeks may 403"
+        );
         return Ok(info);
     }
     Err(format!("all stream paths failed; last error: {last_err}"))
@@ -382,7 +387,10 @@ fn stream_info_from(
                 .and_then(|s| s.parse::<u64>().ok())
                 .map(|ms| (ms + 500) / 1000)
         });
-    let bitrate = fmt.get("bitrate").and_then(|v| v.as_u64()).map(|v| v as u32);
+    let bitrate = fmt
+        .get("bitrate")
+        .and_then(|v| v.as_u64())
+        .map(|v| v as u32);
     let itag = fmt.get("itag").and_then(|v| v.as_u64()).map(|v| v as u32);
     let vid = json
         .pointer("/videoDetails/videoId")
@@ -468,7 +476,9 @@ mod tests {
     #[ignore = "hits live YouTube + needs a system JS runtime"]
     #[expect(clippy::print_stderr, reason = "test diagnostic output")]
     async fn resolve_populates_bitrate_itag_duration() {
-        let info = resolve("dQw4w9WgXcQ", None).await.expect("resolve should succeed");
+        let info = resolve("dQw4w9WgXcQ", None)
+            .await
+            .expect("resolve should succeed");
         eprintln!(
             "[test] resolved itag={:?} bitrate={:?} kbps duration={:?}s",
             info.itag,

--- a/crates/server/src/ytmusic/playlists.rs
+++ b/crates/server/src/ytmusic/playlists.rs
@@ -96,10 +96,7 @@ pub async fn list_playlists(cookies: &str) -> Result<Vec<YtPlaylistSummary>, Str
 /// playlist ID (without the `VL` prefix); we add it here. Follows
 /// `nextContinuationData` until exhausted so playlists longer than the
 /// first ~100-track page come through complete.
-pub async fn get_playlist_entries(
-    playlist_id: &str,
-    cookies: &str,
-) -> Result<Vec<Track>, String> {
+pub async fn get_playlist_entries(playlist_id: &str, cookies: &str) -> Result<Vec<Track>, String> {
     let mut out = Vec::new();
     stream_playlist_entries(playlist_id, cookies, |batch| out.extend(batch)).await?;
     Ok(out)
@@ -127,7 +124,11 @@ where
     // Public playlists (the ones Discover surfaces) load anonymously.
     // Empty cookies (anon mode) → None so browse skips SAPISID auth
     // instead of erroring "SAPISID missing".
-    let auth = if cookies.is_empty() { None } else { Some(cookies) };
+    let auth = if cookies.is_empty() {
+        None
+    } else {
+        Some(cookies)
+    };
     let resp: Value = innertube::browse_maybe_auth(&browse_id, auth).await?;
     let (raw_first, mut next) = walk_playlist_shelf(&resp);
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -153,11 +154,20 @@ where
             break;
         }
         page += 1;
-        tracing::debug!(page, new_tracks = unique.len(), total = seen.len(), "playlist continuation page");
+        tracing::debug!(
+            page,
+            new_tracks = unique.len(),
+            total = seen.len(),
+            "playlist continuation page"
+        );
         on_batch(unique);
         next = next_token;
     }
-    tracing::debug!(pages = page, total = seen.len(), "playlist pagination complete");
+    tracing::debug!(
+        pages = page,
+        total = seen.len(),
+        "playlist pagination complete"
+    );
     Ok(())
 }
 
@@ -167,8 +177,7 @@ where
 fn has_sign_in_endpoint(v: &Value) -> bool {
     match v {
         Value::Object(map) => {
-            map.contains_key("signInEndpoint")
-                || map.values().any(has_sign_in_endpoint)
+            map.contains_key("signInEndpoint") || map.values().any(has_sign_in_endpoint)
         }
         Value::Array(items) => items.iter().any(has_sign_in_endpoint),
         _ => false,

--- a/crates/server/src/ytmusic/search.rs
+++ b/crates/server/src/ytmusic/search.rs
@@ -54,10 +54,7 @@ struct ParsedRow {
 }
 
 #[tracing::instrument(name = "yt.search", skip(cookies), fields(query = %query))]
-pub async fn music_search_tracks(
-    query: &str,
-    cookies: Option<&str>,
-) -> Result<Vec<Track>, String> {
+pub async fn music_search_tracks(query: &str, cookies: Option<&str>) -> Result<Vec<Track>, String> {
     let http = super::innertube::http_client();
     let (top, songs, videos) = tokio::join!(
         do_search(http, query, None, cookies),
@@ -157,10 +154,14 @@ async fn do_search_raw(
         "query": query,
     });
     if let Some(p) = params {
-        body.as_object_mut().unwrap().insert("params".into(), json!(p));
+        body.as_object_mut()
+            .unwrap()
+            .insert("params".into(), json!(p));
     }
     let mut req = http
-        .post(format!("{ORIGIN_YT_MUSIC}/youtubei/v1/search?prettyPrint=false"))
+        .post(format!(
+            "{ORIGIN_YT_MUSIC}/youtubei/v1/search?prettyPrint=false"
+        ))
         .header("Content-Type", "application/json")
         .header("X-YouTube-Client-Name", client.client_id)
         .header("X-YouTube-Client-Version", client.client_version)
@@ -248,7 +249,10 @@ fn track_id(t: &Track) -> String {
 
 fn parse_card_shelf(card: &Value) -> Option<ParsedRow> {
     let endpoint = card.pointer("/onTap/watchEndpoint")?;
-    let video_id = endpoint.get("videoId").and_then(|v| v.as_str())?.to_string();
+    let video_id = endpoint
+        .get("videoId")
+        .and_then(|v| v.as_str())?
+        .to_string();
     let mvt = endpoint
         .pointer("/watchEndpointMusicSupportedConfigs/watchEndpointMusicConfig/musicVideoType")
         .and_then(|v| v.as_str())
@@ -288,7 +292,10 @@ fn parse_card_shelf(card: &Value) -> Option<ParsedRow> {
     let thumbnail_url = card
         .pointer("/thumbnail/musicThumbnailRenderer/thumbnail/thumbnails")
         .and_then(|v| v.as_array())
-        .and_then(|arr| arr.iter().max_by_key(|t| t.get("width").and_then(|v| v.as_u64()).unwrap_or(0)))
+        .and_then(|arr| {
+            arr.iter()
+                .max_by_key(|t| t.get("width").and_then(|v| v.as_u64()).unwrap_or(0))
+        })
         .and_then(|t| t.get("url"))
         .and_then(|u| u.as_str())
         .map(normalize_yt_thumbnail);
@@ -323,7 +330,13 @@ fn parse_row(item: &Value) -> Option<ParsedRow> {
     // " • " runs. The shapes are visually distinct in the JSON so we
     // dispatch on presence, not on guesswork.
     if row.get("fixedColumns").is_some() {
-        Some(parse_playlist_track(row, video_id, title, mvt, thumbnail_url))
+        Some(parse_playlist_track(
+            row,
+            video_id,
+            title,
+            mvt,
+            thumbnail_url,
+        ))
     } else {
         Some(parse_search_row(row, video_id, title, mvt, thumbnail_url))
     }
@@ -387,11 +400,7 @@ fn parse_search_row(
     // duration is always last; the slot before it is album OR view-count
     // depending on mvt. We dispatch on mvt — no view-count text sniffing.
     let mut tokens = pick_all_runs(row, 1);
-    let duration = tokens
-        .pop()
-        .as_deref()
-        .and_then(parse_mm_ss)
-        .unwrap_or(0);
+    let duration = tokens.pop().as_deref().and_then(parse_mm_ss).unwrap_or(0);
     let second_last = tokens.pop();
     let (album, artists) = if mvt.has_album() {
         let album = second_last.filter(|s| !s.is_empty());
@@ -452,7 +461,11 @@ fn pick_run(row: &Value, col: usize, run: usize) -> String {
     row.get("flexColumns")
         .and_then(|c| c.as_array())
         .and_then(|cs| cs.get(col))
-        .and_then(|c| c.pointer(&format!("/musicResponsiveListItemFlexColumnRenderer/text/runs/{run}/text")))
+        .and_then(|c| {
+            c.pointer(&format!(
+                "/musicResponsiveListItemFlexColumnRenderer/text/runs/{run}/text"
+            ))
+        })
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string()

--- a/crates/server/src/ytmusic/verify_session_keepalive.rs
+++ b/crates/server/src/ytmusic/verify_session_keepalive.rs
@@ -20,7 +20,8 @@ pub async fn tick(cookies: &str) -> Result<Option<String>, String> {
     let auth = innertube::sapisid_hash(cookies, ORIGIN_YOUTUBE_MUSIC)
         .ok_or_else(|| "SAPISID missing — cannot build SAPISIDHASH".to_string())?;
 
-    let resp = super::innertube::http_client().clone()
+    let resp = super::innertube::http_client()
+        .clone()
         .get(format!("{ORIGIN_YOUTUBE_MUSIC}/verify_session"))
         .header("User-Agent", super::clients::WEB_REMIX.user_agent)
         .header("Accept", "*/*")

--- a/crates/utils/src/color.rs
+++ b/crates/utils/src/color.rs
@@ -20,8 +20,8 @@ pub async fn get_palette_from_url(url: &str) -> Option<Vec<Color>> {
     let bytes = if url.starts_with("http") {
         reqwest::get(url).await.ok()?.bytes().await.ok()?.to_vec()
     } else {
-        let path = if url.starts_with("artwork://local") {
-            let decoded = percent_encoding::percent_decode_str(&url[15..]).decode_utf8_lossy();
+        let path = if let Some(stripped) = url.strip_prefix("artwork://local") {
+            let decoded = percent_encoding::percent_decode_str(stripped).decode_utf8_lossy();
             decoded.to_string()
         } else {
             url.to_string()

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -36,85 +36,84 @@ pub async fn sleep(duration: std::time::Duration) {
 }
 
 fn format_artwork_url_impl(path: Option<&impl AsRef<Path>>, size: Option<u32>) -> Option<CoverUrl> {
-    path.and_then(|p| {
-        let p = p.as_ref();
-        let p_str = p.to_string_lossy();
+    let p = path?;
+    let p = p.as_ref();
+    let p_str = p.to_string_lossy();
 
-        let abs_path = if let Some(stripped) = p_str.strip_prefix("./") {
-            std::env::current_dir().unwrap_or_default().join(stripped)
-        } else {
-            p.to_path_buf()
-        };
+    let abs_path = if let Some(stripped) = p_str.strip_prefix("./") {
+        std::env::current_dir().unwrap_or_default().join(stripped)
+    } else {
+        p.to_path_buf()
+    };
 
-        let abs_str = abs_path.to_string_lossy();
-        let abs_str = if abs_str.starts_with('~') {
-            if let Ok(home) = std::env::var("HOME") {
-                std::borrow::Cow::Owned(abs_str.replacen('~', &home, 1))
-            } else {
-                abs_str
-            }
+    let abs_str = abs_path.to_string_lossy();
+    let abs_str = if abs_str.starts_with('~') {
+        if let Ok(home) = std::env::var("HOME") {
+            std::borrow::Cow::Owned(abs_str.replacen('~', &home, 1))
         } else {
             abs_str
+        }
+    } else {
+        abs_str
+    };
+
+    // Android WebView is unreliable with custom URL schemes (artwork://) and the
+    // http localhost shim, so inline the cover as a base64 data URL instead.
+    #[cfg(target_os = "android")]
+    {
+        use base64::{Engine as _, engine::general_purpose};
+        return match std::fs::read(&*abs_str) {
+            Ok(bytes) => {
+                let mime = if abs_str.ends_with(".png") {
+                    "image/png"
+                } else if abs_str.ends_with(".gif") {
+                    "image/gif"
+                } else if abs_str.ends_with(".webp") {
+                    "image/webp"
+                } else {
+                    "image/jpeg"
+                };
+                let b64 = general_purpose::STANDARD.encode(&bytes);
+                Some(cover_url_from_string(format!("data:{mime};base64,{b64}")))
+            }
+            Err(_) => None,
         };
+    }
 
-        // Android WebView is unreliable with custom URL schemes (artwork://) and the
-        // http localhost shim, so inline the cover as a base64 data URL instead.
-        #[cfg(target_os = "android")]
-        {
-            use base64::{Engine as _, engine::general_purpose};
-            return match std::fs::read(&*abs_str) {
-                Ok(bytes) => {
-                    let mime = if abs_str.ends_with(".png") {
-                        "image/png"
-                    } else if abs_str.ends_with(".gif") {
-                        "image/gif"
-                    } else if abs_str.ends_with(".webp") {
-                        "image/webp"
-                    } else {
-                        "image/jpeg"
-                    };
-                    let b64 = general_purpose::STANDARD.encode(&bytes);
-                    Some(cover_url_from_string(format!("data:{mime};base64,{b64}")))
-                }
-                Err(_) => None,
-            };
+    const QUERY_VAL: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
+        .add(b' ')
+        .add(b'"')
+        .add(b'#')
+        .add(b'%')
+        .add(b'&')
+        .add(b'+')
+        .add(b'=')
+        .add(b'?')
+        .add(b'<')
+        .add(b'>')
+        .add(b'`')
+        .add(b'\\')
+        .add(b':');
+
+    if cfg!(target_os = "windows") {
+        let mut url = format!(
+            "http://artwork.dioxus.localhost/local?p={}",
+            percent_encoding::utf8_percent_encode(&abs_str, QUERY_VAL)
+        );
+        if let Some(size) = size {
+            url.push_str(&format!("&s={size}"));
         }
-
-        const QUERY_VAL: &percent_encoding::AsciiSet = &percent_encoding::CONTROLS
-            .add(b' ')
-            .add(b'"')
-            .add(b'#')
-            .add(b'%')
-            .add(b'&')
-            .add(b'+')
-            .add(b'=')
-            .add(b'?')
-            .add(b'<')
-            .add(b'>')
-            .add(b'`')
-            .add(b'\\')
-            .add(b':');
-
-        if cfg!(target_os = "windows") {
-            let mut url = format!(
-                "http://artwork.dioxus.localhost/local?p={}",
-                percent_encoding::utf8_percent_encode(&abs_str, QUERY_VAL)
-            );
-            if let Some(size) = size {
-                url.push_str(&format!("&s={size}"));
-            }
-            Some(cover_url_from_string(url))
-        } else {
-            let mut url = format!(
-                "artwork://local?p={}",
-                percent_encoding::utf8_percent_encode(&abs_str, QUERY_VAL)
-            );
-            if let Some(size) = size {
-                url.push_str(&format!("&s={size}"));
-            }
-            Some(cover_url_from_string(url))
+        Some(cover_url_from_string(url))
+    } else {
+        let mut url = format!(
+            "artwork://local?p={}",
+            percent_encoding::utf8_percent_encode(&abs_str, QUERY_VAL)
+        );
+        if let Some(size) = size {
+            url.push_str(&format!("&s={size}"));
         }
-    })
+        Some(cover_url_from_string(url))
+    }
 }
 
 pub fn format_artwork_url(path: Option<&impl AsRef<Path>>) -> Option<CoverUrl> {

--- a/crates/utils/src/logs.rs
+++ b/crates/utils/src/logs.rs
@@ -8,11 +8,11 @@
 //! Layout under `<cache>/logs/`:
 //!   - `latest.log`        — the current session (the appender writes here).
 //!   - `kopuz-<ts>.log`    — previous sessions, archived on startup so a
-//!                           restart never erases a crashing run. `<ts>` is
-//!                           UTC `YYYY-MM-DD_HH-MM-SS`, which sorts
-//!                           alphabetically == chronologically.
+//!     restart never erases a crashing run. `<ts>` is UTC
+//!     `YYYY-MM-DD_HH-MM-SS`, which sorts alphabetically ==
+//!     chronologically.
 //!   - `crash-<ts>.txt`    — written only on a panic (message + backtrace +
-//!                           recent log tail + version/OS).
+//!     recent log tail + version/OS).
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -138,7 +138,12 @@ pub fn write_crash_report(
     let mut f = std::fs::File::create(&path).ok()?;
     let _ = writeln!(f, "kopuz crash report — {ts} UTC");
     let _ = writeln!(f, "version: {version}");
-    let _ = writeln!(f, "os: {} / {}", std::env::consts::OS, std::env::consts::ARCH);
+    let _ = writeln!(
+        f,
+        "os: {} / {}",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    );
     let _ = writeln!(f, "\npanic: {message}");
     let _ = writeln!(f, "location: {location}");
     let _ = writeln!(f, "\n--- backtrace ---\n{backtrace}");
@@ -201,7 +206,12 @@ pub fn export_logs(dest: &Path) -> io::Result<()> {
 
     let mut out = std::fs::File::create(dest)?;
     writeln!(out, "=== kopuz log export — {} UTC ===", timestamp())?;
-    writeln!(out, "os: {} / {}", std::env::consts::OS, std::env::consts::ARCH)?;
+    writeln!(
+        out,
+        "os: {} / {}",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    )?;
 
     writeln!(out, "\n=== {LATEST} ===")?;
     match latest {
@@ -244,7 +254,11 @@ mod tests {
         content.push_str("TAIL LINE");
         std::fs::write(&p, content.as_bytes()).unwrap();
         let out = read_tail(&p).unwrap();
-        assert!(out.len() <= TAIL_BYTES as usize, "tail {} exceeds cap", out.len());
+        assert!(
+            out.len() <= TAIL_BYTES as usize,
+            "tail {} exceeds cap",
+            out.len()
+        );
         assert_eq!(out, "TAIL LINE", "partial first line should be trimmed");
         let _ = std::fs::remove_file(&p);
     }

--- a/crates/utils/src/lyrics.rs
+++ b/crates/utils/src/lyrics.rs
@@ -283,6 +283,7 @@ struct PaxsenixYoutubeSearchResult {
 // as a span field, which would leak server_token (and url/user_id) into the
 // trace + log. Record only artist/title, explicitly.
 #[tracing::instrument(name = "lyrics.fetch", skip_all, fields(artist = %artist, title = %title))]
+#[allow(clippy::too_many_arguments)]
 pub async fn fetch_lyrics(
     artist: &str,
     title: &str,
@@ -312,6 +313,7 @@ pub async fn fetch_lyrics(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn fetch_lyrics_progressive<F>(
     artist: &str,
     title: &str,
@@ -345,6 +347,7 @@ where
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn fetch_lyrics_with_progress<F>(
     artist: &str,
     title: &str,
@@ -1041,10 +1044,10 @@ fn read_local_lrc(audio_path: &str) -> Option<String> {
             .as_ref()
             .map(|s| cand_name == format!("{s}.lrc"))
             .unwrap_or(false);
-        if matches_appended || matches_stem {
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                return Some(content);
-            }
+        if (matches_appended || matches_stem)
+            && let Ok(content) = std::fs::read_to_string(&path)
+        {
+            return Some(content);
         }
     }
 
@@ -2166,10 +2169,10 @@ fn parse_lrc(lrc_text: &str) -> Vec<LyricLine> {
                     background: false,
                     opposite_turn: false,
                 });
-            } else if !text.is_empty() {
-                if let Some(last) = lines.last_mut() {
-                    append_line_translation(last, &text);
-                }
+            } else if !text.is_empty()
+                && let Some(last) = lines.last_mut()
+            {
+                append_line_translation(last, &text);
             }
             continue;
         }
@@ -2200,17 +2203,17 @@ fn parse_lrc(lrc_text: &str) -> Vec<LyricLine> {
     let mut merged: Vec<LyricLine> = Vec::new();
 
     for mut line in lines {
-        if let Some(last) = merged.last_mut() {
-            if last.start_time == line.start_time {
-                if last.chunks.is_empty() && !line.chunks.is_empty() {
-                    last.chunks = std::mem::take(&mut line.chunks);
-                }
-                if last.end_time.is_none() {
-                    last.end_time = line.end_time;
-                }
-                append_line_translation(last, &line.text);
-                continue;
+        if let Some(last) = merged.last_mut()
+            && last.start_time == line.start_time
+        {
+            if last.chunks.is_empty() && !line.chunks.is_empty() {
+                last.chunks = std::mem::take(&mut line.chunks);
             }
+            if last.end_time.is_none() {
+                last.end_time = line.end_time;
+            }
+            append_line_translation(last, &line.text);
+            continue;
         }
 
         merged.push(line);
@@ -2223,10 +2226,7 @@ fn extract_line_timestamps(line: &str) -> (Vec<f64>, &str) {
     let mut timestamps = Vec::new();
     let mut rest = line.trim_start();
 
-    loop {
-        let Some(after_open) = rest.strip_prefix('[') else {
-            break;
-        };
+    while let Some(after_open) = rest.strip_prefix('[') {
         let Some(close_idx) = after_open.find(']') else {
             break;
         };

--- a/crates/utils/src/musicbrainz.rs
+++ b/crates/utils/src/musicbrainz.rs
@@ -1,4 +1,4 @@
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use std::time::Duration;
 
 pub async fn track_page_url(release_id: Option<&str>, artist: &str, title: &str) -> Option<String> {

--- a/crates/utils/src/range_source.rs
+++ b/crates/utils/src/range_source.rs
@@ -40,8 +40,8 @@ impl RangeStreamSource {
     /// total size and confirm Range support. Returns the source positioned
     /// at byte 0 with an empty cache.
     pub fn new(url: String, user_agent: Option<String>) -> IoResult<Self> {
-        let ua = user_agent
-            .unwrap_or_else(|| concat!("Kopuz/", env!("CARGO_PKG_VERSION")).to_string());
+        let ua =
+            user_agent.unwrap_or_else(|| concat!("Kopuz/", env!("CARGO_PKG_VERSION")).to_string());
         let client = reqwest::blocking::Client::builder()
             .tcp_nodelay(true)
             .user_agent(ua)
@@ -58,13 +58,10 @@ impl RangeStreamSource {
             .map_err(IoError::other)?;
         let status = resp.status();
         if !status.is_success() {
-            return Err(IoError::other(format!(
-                "range probe HTTP {status}"
-            )));
+            return Err(IoError::other(format!("range probe HTTP {status}")));
         }
-        let total_size = parse_total_size(&resp).ok_or_else(|| {
-            IoError::other("server didn't expose total size on range probe")
-        })?;
+        let total_size = parse_total_size(&resp)
+            .ok_or_else(|| IoError::other("server didn't expose total size on range probe"))?;
 
         Ok(Self {
             url,

--- a/crates/utils/src/stream_buffer.rs
+++ b/crates/utils/src/stream_buffer.rs
@@ -44,11 +44,7 @@ impl StreamBuffer {
         Self::with_user_agent(url, is_radio, None)
     }
 
-    pub fn with_user_agent(
-        url: String,
-        is_radio: bool,
-        user_agent: Option<String>,
-    ) -> Self {
+    pub fn with_user_agent(url: String, is_radio: bool, user_agent: Option<String>) -> Self {
         let prebuffer_size = if is_radio {
             16 * 1024
         } else {


### PR DESCRIPTION
Resolves #380 
Added `fmt` and `clippy` and applied the suggestions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Code Quality**
  * Broadened linting/workflow checks and updated Clippy rules for more consistent warnings.
  * Widespread formatting and refactors to improve maintainability.

* **UI / UX**
  * Progress bar estimation improved for downloads with unknown total size.

* **Presence**
  * Discord “Now Playing” state formatting adjusted for more consistent artist display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->