### PR TITLE
feat(ui): make album artist header a visible link to artist page

### DIFF
--- a/crates/components/src/album_details.rs
+++ b/crates/components/src/album_details.rs
@@ -2,6 +2,8 @@ use dioxus::prelude::*;
 use reader::Library;
 use std::path::PathBuf;
 
+use crate::NavigationController;
+
 #[component]
 #[allow(clippy::await_holding_invalid_type)]
 pub fn AlbumDetails(
@@ -10,6 +12,7 @@ pub fn AlbumDetails(
     playlist_store: Signal<reader::PlaylistStore>,
     on_close: EventHandler<()>,
 ) -> Element {
+    let nav_ctrl = use_context::<NavigationController>();
     let lib = library.read();
     let album = match lib.albums.iter().find(|a| a.id == album_id) {
         Some(a) => a,
@@ -22,6 +25,7 @@ pub fn AlbumDetails(
 
     let album_title = album.title.clone();
     let album_artist = album.artist.clone();
+    let album_artist_for_nav = album_artist.clone();
     let cover_url = utils::format_artwork_url(album.cover_path.as_ref());
     let current_cover = album.cover_path.clone();
     let current_manual = album.manual_cover;
@@ -106,6 +110,9 @@ pub fn AlbumDetails(
             crate::track_list_view::TrackListView {
                 name: album_title,
                 description: album_artist,
+                on_description_click: Some(EventHandler::new(move |_| {
+                    nav_ctrl.navigate_to_artist(album_artist_for_nav.clone());
+                })),
                 cover_url,
                 is_album: true,
                 back_label: i18n::t("back_to_albums").to_string(),

--- a/crates/components/src/modern/showcase.rs
+++ b/crates/components/src/modern/showcase.rs
@@ -111,10 +111,19 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
 
                 div { class: "flex flex-col gap-1 pb-1 min-w-0",
                     if !props.description.is_empty() {
-                        p {
-                            class: "text-xs font-bold tracking-widest uppercase mb-1",
-                            style: "color: var(--color-white); opacity: 0.35;",
-                            "{props.description}"
+                        if let Some(on_description_click) = props.on_description_click {
+                            button {
+                                class: "text-xs font-bold tracking-widest uppercase mb-1 text-left cursor-pointer hover:underline transition-colors",
+                                style: "color: var(--color-white); opacity: 0.45;",
+                                onclick: move |_| on_description_click.call(()),
+                                "{props.description}"
+                            }
+                        } else {
+                            p {
+                                class: "text-xs font-bold tracking-widest uppercase mb-1",
+                                style: "color: var(--color-white); opacity: 0.35;",
+                                "{props.description}"
+                            }
                         }
                     }
                     h1 { class: "text-4xl font-bold text-white truncate mb-1", "{props.name}" }

--- a/crates/components/src/normal/showcase.rs
+++ b/crates/components/src/normal/showcase.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use crate::NavigationController;
 use crate::constants::{COLUMNS_NORMAL, COLUMNS_NORMAL_ALBUM};
 use crate::header::Header;
 use crate::reorder_buttons::ReorderButtons;
@@ -13,6 +14,7 @@ use hooks::use_player_controller::PlayerController;
 pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
     let mut ctrl = use_context::<PlayerController>();
     let config = use_context::<Signal<AppConfig>>();
+    let _nav_ctrl = use_context::<NavigationController>();
     let total_seconds: u64 = props.tracks.iter().map(|t| t.duration).sum();
     let duration_min = total_seconds / 60;
 
@@ -120,7 +122,15 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                  }
                  div { class: "flex-1",
                      if !props.description.is_empty() {
-                         h5 { class: "text-sm font-bold tracking-widest text-white/60 uppercase mb-2", "{props.description}" }
+                         if let Some(on_description_click) = props.on_description_click {
+                             button {
+                                 class: "text-sm font-bold tracking-widest text-white/60 uppercase mb-2 text-left cursor-pointer hover:underline hover:text-white transition-colors",
+                                 onclick: move |_| on_description_click.call(()),
+                                 "{props.description}"
+                             }
+                         } else {
+                             h5 { class: "text-sm font-bold tracking-widest text-white/60 uppercase mb-2", "{props.description}" }
+                         }
                      }
                      h1 { class: if cfg!(target_os = "android") { "text-3xl font-bold text-white mb-3" } else { "text-5xl md:text-7xl font-bold text-white mb-6" }, "{props.name}" }
                      div { class: if cfg!(target_os = "android") { "flex items-center justify-center gap-4 text-slate-400" } else { "flex items-center gap-6 text-slate-400" },

--- a/crates/components/src/showcase.rs
+++ b/crates/components/src/showcase.rs
@@ -107,6 +107,8 @@ fn compare_text(left: &str, right: &str) -> Ordering {
 pub struct ShowcaseProps {
     pub name: String,
     pub description: String,
+    #[props(default)]
+    pub on_description_click: Option<EventHandler<()>>,
     pub cover_url: Option<utils::CoverUrl>,
     pub tracks: Vec<Track>,
     pub library: Signal<Library>,

--- a/crates/components/src/track_list_view.rs
+++ b/crates/components/src/track_list_view.rs
@@ -8,6 +8,8 @@ use std::path::PathBuf;
 pub struct TrackListViewProps {
     pub name: String,
     pub description: String,
+    #[props(default)]
+    pub on_description_click: Option<EventHandler<()>>,
     pub cover_url: Option<utils::CoverUrl>,
     pub back_label: String,
     pub tracks: Vec<Track>,
@@ -87,6 +89,7 @@ pub fn TrackListView(mut props: TrackListViewProps) -> Element {
             crate::showcase::Showcase {
                 name: props.name.clone(),
                 description: props.description.clone(),
+                on_description_click: props.on_description_click,
                 cover_url: props.cover_url.clone(),
                 tracks: props.tracks.clone(),
                 library: props.library,

--- a/crates/pages/src/server/album.rs
+++ b/crates/pages/src/server/album.rs
@@ -1,4 +1,5 @@
 use crate::server::download_manager::{DownloadQueue, DownloadStatus, queue_downloads};
+use components::NavigationController;
 use components::dots_menu::{DotsMenu, MenuAction};
 use components::playlist_modal::PlaylistModal;
 use components::selection_bar::SelectionBar;
@@ -226,6 +227,7 @@ pub fn JellyfinAlbumDetails(
     on_close: EventHandler<()>,
 ) -> Element {
     let is_offline = use_context::<Signal<bool>>();
+    let nav_ctrl = use_context::<NavigationController>();
     let mut ctrl = use_context::<hooks::use_player_controller::PlayerController>();
     let mut active_menu_track = use_signal(|| None::<PathBuf>);
     let mut show_playlist_modal = use_signal(|| false);
@@ -518,9 +520,13 @@ pub fn JellyfinAlbumDetails(
                     }
                     div { class: "flex flex-col gap-1 pb-1 min-w-0",
                         if !artist.is_empty() {
-                            p {
-                                class: "text-xs font-bold tracking-widest uppercase mb-1",
-                                style: "color: rgba(255,255,255,0.35);",
+                            button {
+                                class: "text-xs font-bold tracking-widest uppercase mb-1 text-left cursor-pointer hover:underline transition-colors",
+                                style: "color: rgba(255,255,255,0.45);",
+                                onclick: {
+                                    let artist = artist.clone();
+                                    move |_| nav_ctrl.navigate_to_artist(artist.clone())
+                                },
                                 "{artist}"
                             }
                         }
@@ -643,7 +649,14 @@ pub fn JellyfinAlbumDetails(
                     }
                     div { class: "flex-1",
                         if !artist.is_empty() {
-                            h5 { class: "text-sm font-bold tracking-widest text-white/60 uppercase mb-2", "{artist}" }
+                            button {
+                                class: "text-sm font-bold tracking-widest text-white/60 uppercase mb-2 text-left cursor-pointer hover:underline hover:text-white transition-colors",
+                                onclick: {
+                                    let artist = artist.clone();
+                                    move |_| nav_ctrl.navigate_to_artist(artist.clone())
+                                },
+                                "{artist}"
+                            }
                         }
                         h1 { class: "text-5xl md:text-7xl font-bold text-white mb-6", "{album_title}" }
                         div { class: "flex items-center gap-6 text-slate-400",


### PR DESCRIPTION
<img width="583" height="262" alt="image" src="https://github.com/user-attachments/assets/a161f3a1-db19-4a95-9206-49d4c1101810" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Artist names and descriptions in album details are now interactive. Users can click to navigate directly to the artist's page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->