### PR TITLE
feat(soundcloud): add soundcloud as a server option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,13 +35,11 @@ wasm-bindgen = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["rt", "time", "sync", "macros", "io-util"] }
-async-recursion = "1.0"
 discord-rich-presence = "1.1.0"
 lofty = "0.24.0"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 rfd = "0.17.2"
 percent-encoding = "2.3.2"
-dotenvy = "0.15"
 http = "1.4.0"
 uuid = { version = "1.20.0", features = ["v4", "fast-rng", "macro-diagnostics", "js"] }
 cpal = "0.17"
@@ -66,7 +64,6 @@ hooks = { path = "./crates/hooks" }
 pages = { path = "./crates/pages" }
 utils = { path = "./crates/utils" }
 config = { path = "./crates/config" }
-kopuz = { path = "./crates/kopuz" }
 server = { path = "./crates/server" }
 kopuz_route = { path = "./crates/kopuz_route" }
 discord-presence = { path = "./crates/discord-presence" }

--- a/crates/components/src/modern/bottombar.rs
+++ b/crates/components/src/modern/bottombar.rs
@@ -84,7 +84,7 @@ pub fn BottombarModern(
                 div { class: "flex items-center gap-0.5 pr-1",
                     button {
                         class: if fav { "w-10 h-10 flex items-center justify-center text-red-400 active:scale-90 transition-transform" } else { "w-10 h-10 flex items-center justify-center text-slate-400 active:scale-90 transition-transform" },
-                        onclick: move |evt| { evt.stop_propagation(); toggle_favorite(ctrl.current_track_snapshot.read().clone(), favorites_store, config); },
+                        onclick: move |evt| { evt.stop_propagation(); toggle_favorite(ctrl.current_track_snapshot.read().clone(), favorites_store, config, ctrl.playback_error); },
                         i { class: if fav { "fa-solid fa-heart text-sm" } else { "fa-regular fa-heart text-sm" } }
                     }
                     button {
@@ -255,7 +255,7 @@ pub fn BottombarModern(
                 button {
                     class: "{heart_class} w-7 h-7 flex items-center justify-center",
                     title: if is_favorite { i18n::t("remove_from_favorites").to_string() } else { i18n::t("add_to_favorites").to_string() },
-                    onclick: move |_| toggle_favorite(ctrl.current_track_snapshot.read().clone(), favorites_store, config),
+                    onclick: move |_| toggle_favorite(ctrl.current_track_snapshot.read().clone(), favorites_store, config, ctrl.playback_error),
                     i { class: "{heart_icon} text-xs" }
                 }
                 div {

--- a/crates/components/src/modern/showcase.rs
+++ b/crates/components/src/modern/showcase.rs
@@ -279,9 +279,11 @@ pub fn ShowcaseModern(props: ShowcaseProps) -> Element {
                                                     )
                                             });
                                         Some(url.map_or_else(utils::default_cover_url, |u| std::sync::Arc::from(u.as_str())))
-                                    } else if path_str.starts_with("ytmusic:") {
-                                        // YT thumbnails come baked into
-                                        // album_id via urlhex; empty
+                                    } else if path_str.starts_with("ytmusic:")
+                                        || path_str.starts_with("soundcloud:")
+                                    {
+                                        // YT/SoundCloud thumbnails come baked
+                                        // into album_id via urlhex; empty
                                         // server_url skips the Jellyfin
                                         // URL fallback branch.
                                         let url = utils::jellyfin_image::track_cover_url_with_album_fallback(

--- a/crates/components/src/normal/bottombar.rs
+++ b/crates/components/src/normal/bottombar.rs
@@ -160,7 +160,7 @@ pub fn BottombarNormal(
                 button {
                     class: "{heart_class}",
                     title: if is_favorite { i18n::t("remove_from_favorites").to_string() } else { i18n::t("add_to_favorites").to_string() },
-                    onclick: move |_| toggle_favorite(ctrl.current_track_snapshot.read().clone(), favorites_store, config),
+                    onclick: move |_| toggle_favorite(ctrl.current_track_snapshot.read().clone(), favorites_store, config, ctrl.playback_error),
                     i { class: "{heart_icon}" }
                 }
             }

--- a/crates/components/src/normal/showcase.rs
+++ b/crates/components/src/normal/showcase.rs
@@ -252,7 +252,7 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                                                  80,
                                              )
                                          }
-                                         MusicService::YtMusic => {
+                                         MusicService::YtMusic | MusicService::SoundCloud => {
                                              utils::jellyfin_image::track_cover_url_with_album_fallback(
                                                  &path_str,
                                                  &track.album_id,

--- a/crates/components/src/playlist_detail.rs
+++ b/crates/components/src/playlist_detail.rs
@@ -244,7 +244,18 @@ pub fn PlaylistDetail(
                                         has_loaded_jellyfin_tracks.set(true);
                                     }
                                 }
-                                MusicService::SoundCloud => {}
+                                MusicService::SoundCloud => {
+                                    if !token.is_empty()
+                                        && let Ok(sc_tracks) =
+                                            server::soundcloud::get_playlist_entries(
+                                                &pid_clone, &token,
+                                            )
+                                            .await
+                                    {
+                                        tracks.set(sc_tracks);
+                                        has_loaded_jellyfin_tracks.set(true);
+                                    }
+                                }
                             }
                         }
                     }

--- a/crates/components/src/playlist_detail.rs
+++ b/crates/components/src/playlist_detail.rs
@@ -23,15 +23,16 @@ pub fn PlaylistDetail(
     let mut tracks = use_signal(Vec::<reader::models::Track>::new);
     let mut has_loaded_jellyfin_tracks = use_signal(|| false);
 
-    // YT Music's InnerTube has no playlist-reorder mutation, so reorder
-    // affordances need to be hidden / no-op on YT playlists. Doing the
-    // optimistic local swap and then no-op'ing the server side leaves a
-    // visual ghost that reverts on next sync — silent UX loss.
-    let active_service_is_ytmusic = config
+    // Neither YT Music's InnerTube nor SoundCloud's API exposes a
+    // playlist-reorder mutation, so reorder affordances need to be hidden /
+    // no-op on those playlists. Doing the optimistic local swap and then
+    // no-op'ing the server side leaves a visual ghost that reverts on next
+    // sync — silent UX loss.
+    let active_service_blocks_reorder = config
         .peek()
         .server
         .as_ref()
-        .map(|s| s.service == MusicService::YtMusic)
+        .map(|s| matches!(s.service, MusicService::YtMusic | MusicService::SoundCloud))
         .unwrap_or(false);
 
     let (playlist_name, local_tracks_paths, is_jellyfin, playlist_custom_cover, playlist_image_tag) =
@@ -506,9 +507,9 @@ pub fn PlaylistDetail(
                     }
                 }
             },
-            is_reorderable: !active_service_is_ytmusic,
+            is_reorderable: !active_service_blocks_reorder,
             on_move_up: move |idx: usize| {
-                if idx == 0 || active_service_is_ytmusic { return; }
+                if idx == 0 || active_service_blocks_reorder { return; }
                 tracks.write().swap(idx - 1, idx);
                 if !is_jellyfin {
                     let mut store = playlist_store.write();
@@ -588,7 +589,7 @@ pub fn PlaylistDetail(
             },
             on_move_down: move |idx: usize| {
                 let len = tracks.read().len();
-                if idx + 1 >= len || active_service_is_ytmusic { return; }
+                if idx + 1 >= len || active_service_blocks_reorder { return; }
                 tracks.write().swap(idx, idx + 1);
                 if !is_jellyfin {
                     let mut store = playlist_store.write();

--- a/crates/components/src/playlist_detail.rs
+++ b/crates/components/src/playlist_detail.rs
@@ -244,6 +244,7 @@ pub fn PlaylistDetail(
                                         has_loaded_jellyfin_tracks.set(true);
                                     }
                                 }
+                                MusicService::SoundCloud => {}
                             }
                         }
                     }
@@ -484,6 +485,7 @@ pub fn PlaylistDetail(
                                             .await
                                             .is_ok()
                                     }
+                                    MusicService::SoundCloud => false,
                                 };
                                 if removed && remove_idx < tracks.read().len() {
                                     tracks.write().remove(remove_idx);
@@ -530,7 +532,7 @@ pub fn PlaylistDetail(
                             let moved_item =
                                 track_list.get(idx - 1).and_then(|t| t.playlist_item_id.clone());
                             match service {
-                                MusicService::YtMusic => {}
+                                MusicService::YtMusic | MusicService::SoundCloud => {}
                                 MusicService::Jellyfin => {
                                     if let Some(item_id) = moved_item {
                                         let remote = server::jellyfin::JellyfinClient::new(
@@ -610,7 +612,7 @@ pub fn PlaylistDetail(
                             let moved_item =
                                 track_list.get(idx + 1).and_then(|t| t.playlist_item_id.clone());
                             match service {
-                                MusicService::YtMusic => {}
+                                MusicService::YtMusic | MusicService::SoundCloud => {}
                                 MusicService::Jellyfin => {
                                     if let Some(item_id) = moved_item {
                                         let remote = server::jellyfin::JellyfinClient::new(

--- a/crates/components/src/playlist_detail.rs
+++ b/crates/components/src/playlist_detail.rs
@@ -246,15 +246,30 @@ pub fn PlaylistDetail(
                                     }
                                 }
                                 MusicService::SoundCloud => {
-                                    if !token.is_empty()
-                                        && let Ok(sc_tracks) =
+                                    if !token.is_empty() {
+                                        // "LM" is the synthetic Liked Songs
+                                        // entry (mirrors YT Music), not a real
+                                        // SoundCloud playlist id — hydrate it
+                                        // from the account's likes instead of
+                                        // the playlists endpoint.
+                                        if pid_clone == "LM" {
+                                            let mut acc = Vec::new();
+                                            let _ = server::soundcloud::stream_liked_tracks(
+                                                &token,
+                                                |page| acc.extend(page),
+                                            )
+                                            .await;
+                                            tracks.set(acc);
+                                            has_loaded_jellyfin_tracks.set(true);
+                                        } else if let Ok(sc_tracks) =
                                             server::soundcloud::get_playlist_entries(
                                                 &pid_clone, &token,
                                             )
                                             .await
-                                    {
-                                        tracks.set(sc_tracks);
-                                        has_loaded_jellyfin_tracks.set(true);
+                                        {
+                                            tracks.set(sc_tracks);
+                                            has_loaded_jellyfin_tracks.set(true);
+                                        }
                                     }
                                 }
                             }

--- a/crates/components/src/queue_list_view.rs
+++ b/crates/components/src/queue_list_view.rs
@@ -411,7 +411,7 @@ pub fn QueueListView(
                             80,
                         )
                     }
-                    config::MusicService::YtMusic => {
+                    config::MusicService::YtMusic | config::MusicService::SoundCloud => {
                         utils::jellyfin_image::track_cover_url_with_album_fallback(
                             &path_str,
                             &track.album_id,

--- a/crates/components/src/settings_popups.rs
+++ b/crates/components/src/settings_popups.rs
@@ -251,16 +251,21 @@ fn ServerServiceFields(
     });
 
     match server_service() {
-        MusicService::YtMusic => {
+        service @ (MusicService::YtMusic | MusicService::SoundCloud) => {
             let anon = yt_anonymous();
+            let service_name = service.display_name();
+            let hq_note = if service == MusicService::SoundCloud {
+                " Signing in also unlocks Go+ high-quality (256 kbps AAC) playback if your account has it."
+            } else {
+                ""
+            };
             rsx! {
-                // Auth method selector (sign-in row hidden on Windows).
                 div { class: "flex flex-col gap-2 mb-2",
                     if !windows {
                         label { class: "flex items-center gap-2 text-sm text-white cursor-pointer",
                             input {
                                 r#type: "radio",
-                                name: "yt-auth-method",
+                                name: "server-auth-method",
                                 checked: !anon,
                                 onchange: move |_| yt_anonymous.set(false),
                             }
@@ -270,7 +275,7 @@ fn ServerServiceFields(
                     label { class: "flex items-center gap-2 text-sm text-white cursor-pointer",
                         input {
                             r#type: "radio",
-                            name: "yt-auth-method",
+                            name: "server-auth-method",
                             checked: anon,
                             onchange: move |_| yt_anonymous.set(true),
                         }
@@ -281,14 +286,14 @@ fn ServerServiceFields(
                 if anon {
                     p { class: "text-xs text-white/60",
                         if windows {
-                            "On Windows, kopuz uses YouTube Music anonymously (browser sign-in isn't supported here yet). You can browse, search, and play — but Liked Music, library playlists, and following/liking are disabled."
+                            "On Windows, kopuz uses {service_name} anonymously (browser sign-in isn't supported here yet). You can browse, search, and play — but your likes, library playlists, and following are disabled."
                         } else {
-                            "kopuz will use YouTube Music without signing in. You can browse, search, and play — but Liked Music, your library playlists, and following/liking are disabled."
+                            "kopuz will use {service_name} without signing in. You can browse, search, and play — but your likes, library playlists, and following are disabled."
                         }
                     }
                 } else {
                     p { class: "text-xs text-white/60",
-                        "Pick which browser kopuz should use for the YouTube Music sign-in window. It opens in an isolated profile (a fresh, separate session) — your normal browsing is untouched. Make sure the browser is installed."
+                        "Pick which browser kopuz should use for the {service_name} sign-in window. It opens in an isolated profile (a fresh, separate session) — your normal browsing is untouched. Make sure the browser is installed.{hq_note}"
                     }
                     select {
                         onchange: move |e| {
@@ -308,11 +313,6 @@ fn ServerServiceFields(
                 }
             }
         }
-        MusicService::SoundCloud => rsx! {
-            p { class: "text-xs text-white/60",
-                "kopuz streams SoundCloud's public catalog — no sign-in needed. Search and play full tracks right away. Library, playlists, and likes aren't available."
-            }
-        },
         _ => rsx! {
             input {
                 placeholder: "{server_url_placeholder}",

--- a/crates/components/src/settings_popups.rs
+++ b/crates/components/src/settings_popups.rs
@@ -21,6 +21,7 @@ pub fn AddServerPopup(
         MusicService::Subsonic => "subsonic",
         MusicService::Custom => "custom",
         MusicService::YtMusic => "ytmusic",
+        MusicService::SoundCloud => "soundcloud",
     };
 
     let server_name_optional = i18n::t("server_name_optional").to_string();
@@ -65,6 +66,7 @@ pub fn AddServerPopup(
                             "subsonic" => MusicService::Subsonic,
                             "custom" => MusicService::Custom,
                             "ytmusic" => MusicService::YtMusic,
+                            "soundcloud" => MusicService::SoundCloud,
                             _ => MusicService::Jellyfin,
                         };
                         server_service.set(service);
@@ -89,6 +91,11 @@ pub fn AddServerPopup(
                         value: "ytmusic",
                         selected: server_service() == MusicService::YtMusic,
                         "YouTube Music"
+                    }
+                    option {
+                        value: "soundcloud",
+                        selected: server_service() == MusicService::SoundCloud,
+                        "SoundCloud"
                     }
                 }
 
@@ -301,6 +308,11 @@ fn ServerServiceFields(
                 }
             }
         }
+        MusicService::SoundCloud => rsx! {
+            p { class: "text-xs text-white/60",
+                "kopuz streams SoundCloud's public catalog — no sign-in needed. Search and play full tracks right away. Library, playlists, and likes aren't available."
+            }
+        },
         _ => rsx! {
             input {
                 placeholder: "{server_url_placeholder}",

--- a/crates/components/src/settings_popups.rs
+++ b/crates/components/src/settings_popups.rs
@@ -16,14 +16,6 @@ pub fn AddServerPopup(
     on_close: EventHandler<()>,
     on_save: EventHandler<()>,
 ) -> Element {
-    let _service_value = match server_service() {
-        MusicService::Jellyfin => "jellyfin",
-        MusicService::Subsonic => "subsonic",
-        MusicService::Custom => "custom",
-        MusicService::YtMusic => "ytmusic",
-        MusicService::SoundCloud => "soundcloud",
-    };
-
     let server_name_optional = i18n::t("server_name_optional").to_string();
     let server_url_placeholder = i18n::t("server_url_placeholder").to_string();
     let custom_manual = i18n::t("custom_manual").to_string();

--- a/crates/components/src/shared.rs
+++ b/crates/components/src/shared.rs
@@ -20,6 +20,7 @@ pub fn get_favorite(
             || path_str.starts_with("subsonic:")
             || path_str.starts_with("custom:")
             || path_str.starts_with("ytmusic:")
+            || path_str.starts_with("soundcloud:")
         {
             let parts: Vec<&str> = path_str.split(':').collect();
             if parts.len() >= 2 && !parts[1].trim().is_empty() {
@@ -45,7 +46,8 @@ pub fn toggle_favorite(
         let is_server_item = path_str.starts_with("jellyfin:")
             || path_str.starts_with("subsonic:")
             || path_str.starts_with("custom:")
-            || path_str.starts_with("ytmusic:");
+            || path_str.starts_with("ytmusic:")
+            || path_str.starts_with("soundcloud:");
         if is_server_item {
             let parts: Vec<String> = path_str.split(':').map(|s| s.to_string()).collect();
             if parts.len() >= 2 && !parts[1].trim().is_empty() {

--- a/crates/components/src/shared.rs
+++ b/crates/components/src/shared.rs
@@ -40,14 +40,16 @@ pub fn toggle_favorite(
     current_track: Option<reader::models::Track>,
     mut favorites_store: Signal<FavoritesStore>,
     config: Signal<config::AppConfig>,
+    mut playback_error: Signal<Option<String>>,
 ) {
     if let Some(track) = current_track {
         let path_str = track.path.to_string_lossy().to_string();
+        let is_soundcloud = path_str.starts_with("soundcloud:");
         let is_server_item = path_str.starts_with("jellyfin:")
             || path_str.starts_with("subsonic:")
             || path_str.starts_with("custom:")
             || path_str.starts_with("ytmusic:")
-            || path_str.starts_with("soundcloud:");
+            || is_soundcloud;
         if is_server_item {
             let parts: Vec<String> = path_str.split(':').map(|s| s.to_string()).collect();
             if parts.len() >= 2 && !parts[1].trim().is_empty() {
@@ -70,6 +72,9 @@ pub fn toggle_favorite(
                             if let Err(e) = result {
                                 tracing::warn!(error = %e, "failed to sync favorite to server");
                                 favorites_store.write().set_jellyfin(item_id, !new_fav);
+                                if is_soundcloud {
+                                    playback_error.set(Some(e));
+                                }
                             }
                         }
                         None => {

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -171,10 +171,10 @@ impl MusicService {
         }
     }
 
-    /// Backends that authenticate with no server URL and no username/password
-    /// (YT Music anonymous, SoundCloud). Adding one of these marks the server
-    /// immediately active/playable instead of opening a login form.
-    pub fn is_tokenless(&self) -> bool {
+    /// Backends that authenticate via an isolated-browser sign-in (or run
+    /// anonymously) instead of a server URL + username/password. Adding one
+    /// opens the browser/anonymous selector rather than a login form.
+    pub fn uses_browser_signin(&self) -> bool {
         matches!(self, Self::YtMusic | Self::SoundCloud)
     }
 }
@@ -629,17 +629,16 @@ pub struct MusicServer {
     pub user_id: Option<String>,
     #[serde(default)]
     pub id: Option<String>,
-    /// For `MusicService::YtMusic` only: which Chromium-family browser
-    /// the cookies were extracted from. Lets boot-time refresh hit the
-    /// right browser directly instead of falling through every
-    /// candidate.
+    /// For browser-sign-in backends (`YtMusic`, `SoundCloud`): which
+    /// Chromium-family browser the token/cookies were extracted from. Lets
+    /// boot-time refresh hit the right browser directly instead of falling
+    /// through every candidate.
     #[serde(default)]
     pub yt_browser: Option<Browser>,
-    /// For `MusicService::YtMusic` only: anonymous mode — no sign-in,
-    /// no cookies. Browse + play public surfaces work; Liked / Library
-    /// Playlists / follow / like are disabled. Set when the user picks
-    /// "Continue without signing in" (the only option on Windows for
-    /// now — see isolated_profile.rs).
+    /// For browser-sign-in backends (`YtMusic`, `SoundCloud`): anonymous mode
+    /// — no sign-in, no token. Browse + play public surfaces work; the user's
+    /// likes / library playlists / follow / like are disabled. Set when the
+    /// user picks "Continue without signing in".
     #[serde(default)]
     pub yt_anonymous: bool,
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -157,6 +157,7 @@ pub enum MusicService {
     Subsonic,
     Custom,
     YtMusic,
+    SoundCloud,
 }
 
 impl MusicService {
@@ -166,7 +167,15 @@ impl MusicService {
             Self::Subsonic => "Subsonic",
             Self::Custom => "Custom",
             Self::YtMusic => "YouTube Music",
+            Self::SoundCloud => "SoundCloud",
         }
+    }
+
+    /// Backends that authenticate with no server URL and no username/password
+    /// (YT Music anonymous, SoundCloud). Adding one of these marks the server
+    /// immediately active/playable instead of opening a login form.
+    pub fn is_tokenless(&self) -> bool {
+        matches!(self, Self::YtMusic | Self::SoundCloud)
     }
 }
 

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -767,8 +767,20 @@ impl PlayerController {
                                 }
                             }
                         } else if let Some(track_id) = stream_url.strip_prefix("__SC_PENDING:") {
-                            match ::server::soundcloud::resolve_stream(track_id).await {
-                                Ok(url) => (url, None, None),
+                            let token = cfg_signal
+                                .peek()
+                                .server
+                                .as_ref()
+                                .and_then(|s| s.access_token.clone())
+                                .filter(|t| !t.is_empty());
+                            use ::server::soundcloud::ResolvedStream;
+                            match ::server::soundcloud::resolve_stream(track_id, token.as_deref())
+                                .await
+                            {
+                                Ok(ResolvedStream::Progressive(url)) => (url, None, None),
+                                Ok(ResolvedStream::HlsAac(m3u8)) => {
+                                    (format!("__SC_HLS:{m3u8}"), None, None)
+                                }
                                 Err(e) => {
                                     if *play_generation.read() != current_gen {
                                         return;
@@ -809,6 +821,16 @@ impl PlayerController {
                                 let len = Some(range.total_size());
                                 let (source, mut hint) = decoder::from_stream_with_len(range, len);
                                 hint.with_extension(fmt.extension());
+                                Ok::<_, std::io::Error>((source, hint))
+                            } else if let Some(hls_url) =
+                                stream_url_for_blocking.strip_prefix("__SC_HLS:")
+                            {
+                                let bytes = utils::hls_source::assemble(hls_url, None)?;
+                                let len = Some(bytes.len() as u64);
+                                let cursor = std::io::Cursor::new(bytes);
+                                let (source, mut hint) =
+                                    decoder::from_stream_with_len(cursor, len);
+                                hint.with_extension("m4a");
                                 Ok::<_, std::io::Error>((source, hint))
                             } else {
                                 let stream = utils::stream_buffer::StreamBuffer::with_user_agent(

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -159,9 +159,9 @@ impl PlayerController {
                     )
                 })
                 .unwrap_or_default(),
-            "ytmusic" => {
-                // YT tracks carry their thumbnail in album_id as
-                // `ytmusic:_:urlhex_HEX`. Pass empty server_url so
+            "ytmusic" | "soundcloud" => {
+                // YT/SoundCloud tracks carry their thumbnail in album_id as
+                // `<src>:_:urlhex_HEX`. Pass empty server_url so
                 // `track_cover_url_with_album_fallback` skips its
                 // jellyfin-URL fallback path and only returns the
                 // embedded URL via decode_embedded_cover_url.
@@ -428,7 +428,7 @@ impl PlayerController {
             let is_radio_item = scheme.as_str() == "radio";
             let is_server_item = matches!(
                 scheme.as_str(),
-                "jellyfin" | "subsonic" | "custom" | "ytmusic"
+                "jellyfin" | "subsonic" | "custom" | "ytmusic" | "soundcloud"
             );
 
             if is_server_item || is_radio_item {
@@ -631,6 +631,19 @@ impl PlayerController {
                                     .unwrap_or_default();
                                 (format!("__YT_PENDING:{id}"), cover_url)
                             }
+                            MusicService::SoundCloud => {
+                                let cover_url =
+                                    utils::jellyfin_image::track_cover_url_with_album_fallback(
+                                        &path_str,
+                                        &track.album_id,
+                                        "",
+                                        None,
+                                        800,
+                                        90,
+                                    )
+                                    .unwrap_or_default();
+                                (format!("__SC_PENDING:{id}"), cover_url)
+                            }
                         })
                     }
                 } {
@@ -747,6 +760,22 @@ impl PlayerController {
                                     tracing::error!(error = %e, "YT Music stream URL fetch failed");
                                     playback_error.set(Some(format!(
                                         "YouTube Music couldn't load this track:\n{e}"
+                                    )));
+                                    is_loading.set(false);
+                                    skip_in_progress.set(false);
+                                    return;
+                                }
+                            }
+                        } else if let Some(track_id) = stream_url.strip_prefix("__SC_PENDING:") {
+                            match ::server::soundcloud::resolve_stream(track_id).await {
+                                Ok(url) => (url, None, None),
+                                Err(e) => {
+                                    if *play_generation.read() != current_gen {
+                                        return;
+                                    }
+                                    tracing::error!(error = %e, "SoundCloud stream URL fetch failed");
+                                    playback_error.set(Some(format!(
+                                        "SoundCloud couldn't load this track:\n{e}"
                                     )));
                                     is_loading.set(false);
                                     skip_in_progress.set(false);

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -846,6 +846,22 @@ impl PlayerController {
                         })
                         .await;
 
+                        if let Err(_) | Ok(Err(_)) = &source_res {
+                            // Surface decode/stream-assembly failures (e.g. an
+                            // HLS playlist/segment fetch or fMP4 decode error)
+                            // instead of dropping them and leaving the player
+                            // stuck in the loading state.
+                            if *play_generation.read() == current_gen {
+                                let msg = match &source_res {
+                                    Ok(Err(e)) => format!("Couldn't load this track:\n{e}"),
+                                    _ => "Playback failed unexpectedly".to_string(),
+                                };
+                                playback_error.set(Some(msg));
+                                is_loading.set(false);
+                                skip_in_progress.set(false);
+                            }
+                            return;
+                        }
                         if let Ok(Ok((source, hint))) = source_res {
                             if *play_generation.read() == current_gen {
                                 let meta = NowPlayingMeta {

--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -282,7 +282,8 @@ pub fn use_player_task(ctrl: PlayerController) {
                         last_recent_path = Some(path.clone());
                         let is_server = path.starts_with("jellyfin:")
                             || path.starts_with("subsonic:")
-                            || path.starts_with("ytmusic:");
+                            || path.starts_with("ytmusic:")
+                            || path.starts_with("soundcloud:");
                         let id = if is_server {
                             path.split(':').nth(1).unwrap_or(&path).to_string()
                         } else {

--- a/crates/hooks/src/use_search_data.rs
+++ b/crates/hooks/src/use_search_data.rs
@@ -157,9 +157,7 @@ fn search_server(
                                 80,
                             )
                         }
-                        Some(MusicService::YtMusic)
-                        | Some(MusicService::SoundCloud)
-                        | None => None,
+                        Some(MusicService::YtMusic) | Some(MusicService::SoundCloud) | None => None,
                     };
                     utils::map_cover_url(url)
                 })
@@ -320,8 +318,8 @@ pub fn use_search_data(
                                         )
                                     }
                                     Some(MusicService::YtMusic)
-                        | Some(MusicService::SoundCloud)
-                        | None => None,
+                                    | Some(MusicService::SoundCloud)
+                                    | None => None,
                                 }
                             })
                         } else {

--- a/crates/hooks/src/use_search_data.rs
+++ b/crates/hooks/src/use_search_data.rs
@@ -102,10 +102,10 @@ fn search_server(
                             80,
                         )
                     }
-                    Some(MusicService::YtMusic) => {
-                        // YT thumbnails are urlhex-encoded into album_id;
-                        // pass empty server_url so the fallback function
-                        // skips its Jellyfin URL constructor and only
+                    Some(MusicService::YtMusic) | Some(MusicService::SoundCloud) => {
+                        // YT/SoundCloud thumbnails are urlhex-encoded into
+                        // album_id; pass empty server_url so the fallback
+                        // function skips its Jellyfin URL constructor and only
                         // returns the embedded URL via decode.
                         utils::jellyfin_image::track_cover_url_with_album_fallback(
                             &path_str,
@@ -157,7 +157,9 @@ fn search_server(
                                 80,
                             )
                         }
-                        Some(MusicService::YtMusic) | None => None,
+                        Some(MusicService::YtMusic)
+                        | Some(MusicService::SoundCloud)
+                        | None => None,
                     };
                     utils::map_cover_url(url)
                 })
@@ -183,6 +185,11 @@ async fn run_search(
     {
         let cookies = server.as_ref().and_then(|s| s.access_token.clone());
         return search_ytmusic(&query, cookies).await;
+    }
+    if matches!(active_source, MusicSource::Server)
+        && matches!(active_service, Some(MusicService::SoundCloud))
+    {
+        return search_soundcloud(&query).await;
     }
     tokio::task::spawn_blocking(move || match active_source {
         MusicSource::Local => search_local(&query, tracks, albums),
@@ -210,6 +217,34 @@ async fn search_ytmusic(query: &str, cookies: Option<String>) -> Option<(TrackRe
     // Each track's `album_id` carries its YT thumbnail as
     // `ytmusic:_:urlhex_HEX`; the standard fallback resolver decodes
     // that embedded URL when we pass an empty server_url.
+    let result_tracks: TrackRes = tracks
+        .into_iter()
+        .map(|t| {
+            let path_str = t.path.to_string_lossy();
+            let cover_url =
+                utils::map_cover_url(utils::jellyfin_image::track_cover_url_with_album_fallback(
+                    &path_str,
+                    &t.album_id,
+                    "",
+                    None,
+                    80,
+                    80,
+                ));
+            (t, cover_url)
+        })
+        .collect();
+    Some((result_tracks, Vec::new()))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn search_soundcloud(query: &str) -> Option<(TrackRes, AlbumRes)> {
+    if query.trim().is_empty() {
+        return Some((Vec::new(), Vec::new()));
+    }
+    let tracks = server::soundcloud::search_tracks(query)
+        .await
+        .map_err(|e| tracing::warn!(error = %e, "SoundCloud search failed"))
+        .ok()?;
     let result_tracks: TrackRes = tracks
         .into_iter()
         .map(|t| {
@@ -284,7 +319,9 @@ pub fn use_search_data(
                                             80,
                                         )
                                     }
-                                    Some(MusicService::YtMusic) | None => None,
+                                    Some(MusicService::YtMusic)
+                        | Some(MusicService::SoundCloud)
+                        | None => None,
                                 }
                             })
                         } else {

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -2086,7 +2086,12 @@ fn App() -> Element {
                 .read()
                 .server
                 .as_ref()
-                .map(|s| s.service == config::MusicService::YtMusic)
+                .map(|s| {
+                    matches!(
+                        s.service,
+                        config::MusicService::YtMusic | config::MusicService::SoundCloud
+                    )
+                })
                 .unwrap_or(false)
             {
                 if let Some(msg) = ctrl.playback_error.read().clone() {

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -138,6 +138,8 @@ pub fn Album(
                                                     token,
                                                     user_id,
                                                     device_id,
+                                                    sc_browser: None,
+                                                    sc_server_id: None,
                                                 };
                                                 let item_ids: Vec<String> = paths
                                                     .iter()
@@ -242,6 +244,8 @@ pub fn Album(
                                                     token,
                                                     user_id,
                                                     device_id,
+                                                    sc_browser: None,
+                                                    sc_server_id: None,
                                                 };
                                                 let item_ids: Vec<String> = paths
                                                     .iter()

--- a/crates/pages/src/playlists.rs
+++ b/crates/pages/src/playlists.rs
@@ -58,6 +58,8 @@ pub fn PlaylistsPage(
                         token,
                         user_id,
                         device_id,
+                        sc_browser: None,
+                        sc_server_id: None,
                     };
                     let result =
                         ::server::server_ops::create_server_playlist(&conn, &name, &[]).await;

--- a/crates/pages/src/server/activity.rs
+++ b/crates/pages/src/server/activity.rs
@@ -261,7 +261,8 @@ pub fn ServerLogs(library: Signal<Library>, config: Signal<AppConfig>) -> Elemen
         MusicService::Jellyfin
         | MusicService::Subsonic
         | MusicService::Custom
-        | MusicService::YtMusic => rsx! {
+        | MusicService::YtMusic
+        | MusicService::SoundCloud => rsx! {
             JellyfinLogs { library, config }
         },
     }

--- a/crates/pages/src/server/album.rs
+++ b/crates/pages/src/server/album.rs
@@ -958,7 +958,7 @@ pub fn ServerAlbum(
                 pending_album_id_for_playlist,
             }
         },
-        MusicService::Custom | MusicService::YtMusic => rsx! {
+        MusicService::Custom | MusicService::YtMusic | MusicService::SoundCloud => rsx! {
             CustomAlbum {
                 library,
                 config,
@@ -1058,7 +1058,7 @@ pub fn ServerAlbumDetails(
                 on_close,
             }
         },
-        MusicService::Custom | MusicService::YtMusic => rsx! {
+        MusicService::Custom | MusicService::YtMusic | MusicService::SoundCloud => rsx! {
             CustomAlbumDetails {
                 album_jellyfin_id,
                 library,

--- a/crates/pages/src/server/album.rs
+++ b/crates/pages/src/server/album.rs
@@ -259,11 +259,19 @@ pub fn JellyfinAlbumDetails(
         let offline = *is_offline.read();
         let info = album_info();
         let album_name = info.as_ref().map(|a| a.title.clone()).unwrap_or_default();
+        // Match tracks by album name (Jellyfin/Subsonic) OR album_id. Synthetic
+        // albums (YT/SoundCloud "Singles" from `synthesize_albums`) carry an
+        // empty track `album` field, so they only join on `album_id` — the same
+        // canonical album↔track key used in artist.rs and the album menus.
+        let album_id = info.as_ref().map(|a| a.id.clone()).unwrap_or_default();
 
         let mut tracks: Vec<_> = lib
             .jellyfin_tracks
             .iter()
-            .filter(|t| !album_name.is_empty() && t.album == album_name)
+            .filter(|t| {
+                (!album_name.is_empty() && t.album == album_name)
+                    || (!album_id.is_empty() && t.album_id == album_id)
+            })
             .filter(|t| {
                 if !offline {
                     return true;

--- a/crates/pages/src/server/artist.rs
+++ b/crates/pages/src/server/artist.rs
@@ -136,7 +136,7 @@ pub fn JellyfinArtist(
                             }
                         }
                     }
-                    config::MusicService::YtMusic => {}
+                    config::MusicService::YtMusic | config::MusicService::SoundCloud => {}
                 }
 
                 fetched_artist_images.set(images);
@@ -947,7 +947,7 @@ pub fn ServerArtist(
                 current_queue_index,
             }
         },
-        MusicService::Custom | MusicService::YtMusic => rsx! {
+        MusicService::Custom | MusicService::YtMusic | MusicService::SoundCloud => rsx! {
             CustomArtist {
                 library,
                 config,

--- a/crates/pages/src/server/download_manager.rs
+++ b/crates/pages/src/server/download_manager.rs
@@ -174,6 +174,22 @@ async fn download_worker(
                         None
                     }
                 }
+            } else if matches!(service, Some(MusicService::SoundCloud)) {
+                // Resolve anonymously (token = None) so we always get the
+                // keyless progressive MP3 rather than a Go+ HLS playlist, which
+                // can't be saved as a single offline file.
+                match ::server::soundcloud::resolve_stream(&id, None).await {
+                    Ok(::server::soundcloud::ResolvedStream::Progressive(url)) => {
+                        Some((url, "mp3", None, None))
+                    }
+                    Ok(::server::soundcloud::ResolvedStream::HlsAac(url)) => {
+                        Some((url, "m4a", None, None))
+                    }
+                    Err(e) => {
+                        tracing::warn!(%id, error = %e, "SoundCloud download URL resolve failed");
+                        None
+                    }
+                }
             } else {
                 let conf = config.read();
                 super::build_download_url(&id, &conf).map(|(u, ext)| (u, ext, None, None))

--- a/crates/pages/src/server/favorites.rs
+++ b/crates/pages/src/server/favorites.rs
@@ -53,9 +53,12 @@ pub fn JellyfinFavorites(
             None => return,
         };
         let service = config.peek().server.as_ref().map(|s| s.service);
-        let is_ytmusic = service == Some(MusicService::YtMusic);
+        let is_account_backend = matches!(
+            service,
+            Some(MusicService::YtMusic) | Some(MusicService::SoundCloud)
+        );
 
-        if is_ytmusic && nonce == 0 && library.peek().last_yt_sync_at.is_some() {
+        if is_account_backend && nonce == 0 && library.peek().last_yt_sync_at.is_some() {
             return;
         }
 
@@ -159,7 +162,53 @@ pub fn JellyfinFavorites(
                             }
                         }
                     }
-                    MusicService::SoundCloud => Vec::new(),
+                    MusicService::SoundCloud => {
+                        if token.is_empty() {
+                            Vec::new()
+                        } else {
+                            {
+                                let mut lib = library.write();
+                                lib.jellyfin_tracks.clear();
+                                lib.jellyfin_albums.clear();
+                            }
+                            let mut accumulated: Vec<reader::models::Track> = Vec::new();
+                            let result =
+                                ::server::soundcloud::stream_liked_tracks(&token, |page| {
+                                    accumulated.extend(page.iter().cloned());
+                                    let albums = synthesize_albums(&accumulated);
+                                    {
+                                        let mut lib = library.write();
+                                        lib.jellyfin_tracks.extend(page);
+                                        lib.jellyfin_albums = albums;
+                                    }
+                                    synced_so_far.set(accumulated.len());
+                                })
+                                .await;
+                            match result {
+                                Ok(()) => {
+                                    let now = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map(|d| d.as_secs())
+                                        .unwrap_or(0);
+                                    library.write().last_yt_sync_at = Some(now);
+                                    accumulated
+                                        .iter()
+                                        .filter_map(|t| {
+                                            t.path
+                                                .to_string_lossy()
+                                                .split(':')
+                                                .nth(1)
+                                                .map(|s| s.to_string())
+                                        })
+                                        .collect()
+                                }
+                                Err(e) => {
+                                    tracing::warn!(error = %e, "SoundCloud favorites sync failed");
+                                    Vec::new()
+                                }
+                            }
+                        }
+                    }
                 };
 
                 favorites_store.write().jellyfin_favorites = ids;

--- a/crates/pages/src/server/favorites.rs
+++ b/crates/pages/src/server/favorites.rs
@@ -191,7 +191,7 @@ pub fn JellyfinFavorites(
                                         .map(|d| d.as_secs())
                                         .unwrap_or(0);
                                     library.write().last_yt_sync_at = Some(now);
-                                    accumulated
+                                    let ids: Vec<String> = accumulated
                                         .iter()
                                         .filter_map(|t| {
                                             t.path
@@ -200,7 +200,33 @@ pub fn JellyfinFavorites(
                                                 .nth(1)
                                                 .map(|s| s.to_string())
                                         })
-                                        .collect()
+                                        .collect();
+                                    let liked_cover = accumulated.first().and_then(|t| {
+                                        t.path
+                                            .to_string_lossy()
+                                            .split(':')
+                                            .nth(2)
+                                            .filter(|s| s.starts_with("urlhex_"))
+                                            .map(|s| s.to_string())
+                                    });
+                                    let liked_entry = reader::models::JellyfinPlaylist {
+                                        id: "LM".to_string(),
+                                        name: "Liked Songs".to_string(),
+                                        tracks: ids.clone(),
+                                        image_tag: liked_cover,
+                                        cover_path: None,
+                                    };
+                                    {
+                                        let mut ps = playlist_store.write();
+                                        if let Some(existing) =
+                                            ps.jellyfin_playlists.iter_mut().find(|p| p.id == "LM")
+                                        {
+                                            *existing = liked_entry;
+                                        } else {
+                                            ps.jellyfin_playlists.insert(0, liked_entry);
+                                        }
+                                    }
+                                    ids
                                 }
                                 Err(e) => {
                                     tracing::warn!(error = %e, "SoundCloud favorites sync failed");

--- a/crates/pages/src/server/favorites.rs
+++ b/crates/pages/src/server/favorites.rs
@@ -159,6 +159,7 @@ pub fn JellyfinFavorites(
                             }
                         }
                     }
+                    MusicService::SoundCloud => Vec::new(),
                 };
 
                 favorites_store.write().jellyfin_favorites = ids;

--- a/crates/pages/src/server/favorites.rs
+++ b/crates/pages/src/server/favorites.rs
@@ -58,7 +58,15 @@ pub fn JellyfinFavorites(
             Some(MusicService::YtMusic) | Some(MusicService::SoundCloud)
         );
 
-        if is_account_backend && nonce == 0 && library.peek().last_yt_sync_at.is_some() {
+        // Self-heal: a prior sync that completed but produced zero tracks
+        // (e.g. an API-shape bug) still stamped `last_yt_sync_at`, which would
+        // otherwise wedge this view empty forever. Only honour the cached
+        // stamp when there's actually cached data to show.
+        if is_account_backend
+            && nonce == 0
+            && library.peek().last_yt_sync_at.is_some()
+            && !library.peek().jellyfin_tracks.is_empty()
+        {
             return;
         }
 

--- a/crates/pages/src/server/home.rs
+++ b/crates/pages/src/server/home.rs
@@ -36,7 +36,8 @@ fn server_track_id(path: &str) -> Option<String> {
     let mut parts = path.split(':');
     let prefix = parts.next()?;
     let id = parts.next()?;
-    if prefix == "jellyfin" || prefix == "subsonic" || prefix == "ytmusic" {
+    if prefix == "jellyfin" || prefix == "subsonic" || prefix == "ytmusic" || prefix == "soundcloud"
+    {
         Some(id.to_string())
     } else {
         None

--- a/crates/pages/src/server/mod.rs
+++ b/crates/pages/src/server/mod.rs
@@ -57,7 +57,7 @@ pub fn build_download_url(item_id: &str, config: &AppConfig) -> Option<(String, 
             let kbps = quality.subsonic_max_bitrate_kbps();
             client.stream_url_with_bitrate(item_id, Some(kbps)).ok()?
         }
-        MusicService::YtMusic => return None,
+        MusicService::YtMusic | MusicService::SoundCloud => return None,
     };
     Some((url, ext))
 }

--- a/crates/pages/src/server/playlists.rs
+++ b/crates/pages/src/server/playlists.rs
@@ -43,12 +43,12 @@ pub fn JellyfinPlaylists(
                 }
             })
         };
-        let is_ytmusic = fetch_context
+        let is_account_backend = fetch_context
             .as_ref()
-            .map(|(s, _, _, _, _)| *s == MusicService::YtMusic)
+            .map(|(s, _, _, _, _)| matches!(s, MusicService::YtMusic | MusicService::SoundCloud))
             .unwrap_or(false);
 
-        if is_ytmusic
+        if is_account_backend
             && yt_nonce == 0
             && trigger == 0
             && library.peek().last_yt_playlists_sync_at.is_some()
@@ -284,7 +284,126 @@ pub fn JellyfinPlaylists(
                     yt_synced_so_far.set(total);
                     return;
                 }
-                MusicService::SoundCloud => {}
+                MusicService::SoundCloud => {
+                    if token.is_empty() {
+                        return;
+                    }
+                    yt_is_syncing.set(true);
+                    yt_synced_so_far.set(0);
+                    let summaries = match ::server::soundcloud::list_playlists(&token).await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "SoundCloud list_playlists failed");
+                            yt_is_syncing.set(false);
+                            return;
+                        }
+                    };
+                    if *fetch_request_id.read() != request_id {
+                        return;
+                    }
+                    let total = summaries.len();
+
+                    {
+                        let mut store_write = playlist_store.write();
+                        let mut seeded: Vec<reader::models::JellyfinPlaylist> = summaries
+                            .iter()
+                            .map(|s| {
+                                let image_tag = s
+                                    .artwork_url
+                                    .as_ref()
+                                    .map(|u| utils::jellyfin_image::encode_cover_url(u));
+                                let existing_cover_path = store_write
+                                    .jellyfin_playlists
+                                    .iter()
+                                    .find(|e| e.id == s.id)
+                                    .and_then(|e| e.cover_path.clone());
+                                reader::models::JellyfinPlaylist {
+                                    id: s.id.clone(),
+                                    name: s.title.clone(),
+                                    tracks: Vec::new(),
+                                    image_tag,
+                                    cover_path: existing_cover_path,
+                                }
+                            })
+                            .collect();
+                        for existing in store_write.jellyfin_playlists.drain(..) {
+                            if !seeded.iter().any(|s| s.id == existing.id) {
+                                seeded.push(existing);
+                            }
+                        }
+                        store_write.jellyfin_playlists = seeded;
+                    }
+
+                    let mut accumulated: Vec<reader::models::Track> = Vec::new();
+                    let mut seen_paths: std::collections::HashSet<std::path::PathBuf> =
+                        std::collections::HashSet::new();
+                    for (i, summary) in summaries.into_iter().enumerate() {
+                        if *fetch_request_id.read() != request_id {
+                            return;
+                        }
+                        yt_synced_so_far.set(i + 1);
+                        let tracks =
+                            match ::server::soundcloud::get_playlist_entries(&summary.id, &token)
+                                .await
+                            {
+                                Ok(t) => t,
+                                Err(e) => {
+                                    tracing::warn!(playlist = %summary.id, error = %e, "SoundCloud playlist entries failed");
+                                    Vec::new()
+                                }
+                            };
+                        let track_ids: Vec<String> = tracks
+                            .iter()
+                            .filter_map(|t| {
+                                t.path
+                                    .to_string_lossy()
+                                    .split(':')
+                                    .nth(1)
+                                    .map(|s| s.to_string())
+                            })
+                            .collect();
+                        {
+                            let mut store_write = playlist_store.write();
+                            if let Some(entry) = store_write
+                                .jellyfin_playlists
+                                .iter_mut()
+                                .find(|e| e.id == summary.id)
+                            {
+                                entry.tracks = track_ids;
+                            }
+                        }
+                        for t in tracks {
+                            if seen_paths.insert(t.path.clone()) {
+                                accumulated.push(t);
+                            }
+                        }
+                    }
+
+                    if *fetch_request_id.read() != request_id {
+                        return;
+                    }
+                    let now = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0);
+                    {
+                        let mut lib = library.write();
+                        let mut existing: std::collections::HashSet<std::path::PathBuf> = lib
+                            .jellyfin_tracks
+                            .iter()
+                            .map(|t| t.path.clone())
+                            .collect();
+                        for t in accumulated {
+                            if existing.insert(t.path.clone()) {
+                                lib.jellyfin_tracks.push(t);
+                            }
+                        }
+                        lib.last_yt_playlists_sync_at = Some(now);
+                    }
+                    yt_is_syncing.set(false);
+                    yt_synced_so_far.set(total);
+                    return;
+                }
             }
 
             if *fetch_request_id.read() != request_id {

--- a/crates/pages/src/server/playlists.rs
+++ b/crates/pages/src/server/playlists.rs
@@ -448,16 +448,21 @@ pub fn JellyfinPlaylists(
     });
 
     let playlists = jellyfin_playlists.read().clone();
-    let is_ytmusic_active = config
+    let is_music_sync_active = config
         .read()
         .server
         .as_ref()
-        .map(|s| s.service == MusicService::YtMusic)
+        .map(|s| {
+            matches!(
+                s.service,
+                MusicService::YtMusic | MusicService::SoundCloud
+            )
+        })
         .unwrap_or(false);
 
     rsx! {
         div {
-            if is_ytmusic_active {
+            if is_music_sync_active {
                 {
                     let syncing = *yt_is_syncing.read();
                     let done = *yt_synced_so_far.read();

--- a/crates/pages/src/server/playlists.rs
+++ b/crates/pages/src/server/playlists.rs
@@ -284,6 +284,7 @@ pub fn JellyfinPlaylists(
                     yt_synced_so_far.set(total);
                     return;
                 }
+                MusicService::SoundCloud => {}
             }
 
             if *fetch_request_id.read() != request_id {

--- a/crates/pages/src/server/playlists.rs
+++ b/crates/pages/src/server/playlists.rs
@@ -52,6 +52,7 @@ pub fn JellyfinPlaylists(
             && yt_nonce == 0
             && trigger == 0
             && library.peek().last_yt_playlists_sync_at.is_some()
+            && !playlist_store.peek().jellyfin_playlists.is_empty()
         {
             return;
         }
@@ -452,12 +453,7 @@ pub fn JellyfinPlaylists(
         .read()
         .server
         .as_ref()
-        .map(|s| {
-            matches!(
-                s.service,
-                MusicService::YtMusic | MusicService::SoundCloud
-            )
-        })
+        .map(|s| matches!(s.service, MusicService::YtMusic | MusicService::SoundCloud))
         .unwrap_or(false);
 
     rsx! {

--- a/crates/pages/src/server/subsonic_sync.rs
+++ b/crates/pages/src/server/subsonic_sync.rs
@@ -338,7 +338,7 @@ pub async fn sync_server_library(
             }
             info!("Subsonic/Custom sync completed successfully.");
         }
-        MusicService::YtMusic => {}
+        MusicService::YtMusic | MusicService::SoundCloud => {}
     }
 
     Ok(())
@@ -356,6 +356,7 @@ pub async fn fetch_subsonic_library(
         MusicService::Custom => "custom",
         MusicService::Jellyfin => "jellyfin",
         MusicService::YtMusic => "ytmusic",
+        MusicService::SoundCloud => "soundcloud",
     };
 
     let mut albums_out = Vec::new();

--- a/crates/pages/src/settings.rs
+++ b/crates/pages/src/settings.rs
@@ -168,6 +168,38 @@ async fn ensure_signed_in(
     Ok(cookies)
 }
 
+/// Resolve a usable SoundCloud `oauth_token`: reuse a still-valid stored token,
+/// else re-extract from the isolated profile, else launch a fresh browser
+/// sign-in. Mirrors [`ensure_signed_in`] but SoundCloud tokens are long-lived,
+/// so there's no keepalive/rotation step.
+async fn sc_ensure_signed_in(
+    existing: Option<String>,
+    browser: Browser,
+    server_id: &str,
+) -> Result<String, String> {
+    if let Some(t) = existing.filter(|t| !t.is_empty())
+        && ::server::soundcloud::get_me(&t).await.is_ok()
+    {
+        return Ok(t);
+    }
+
+    let profile = ::server::soundcloud::signin::profile_dir(server_id);
+    if profile.is_dir()
+        && let Ok(Some(t)) =
+            ::server::soundcloud::signin::extract_oauth_token(browser, &profile).await
+        && ::server::soundcloud::get_me(&t).await.is_ok()
+    {
+        return Ok(t);
+    }
+
+    ::server::soundcloud::signin::launch_signin_and_extract(
+        browser,
+        server_id,
+        std::time::Duration::from_secs(300),
+    )
+    .await
+}
+
 #[component]
 pub fn Settings(config: Signal<AppConfig>) -> Element {
     let mut ctrl = use_context::<PlayerController>();
@@ -300,6 +332,44 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
         });
     };
 
+    let soundcloud_auto_login = move || {
+        let (browser, existing, server_id) = {
+            let cfg = config.peek();
+            let srv = cfg.server.as_ref();
+            (
+                srv.and_then(|s| s.yt_browser).unwrap_or(*yt_browser.peek()),
+                srv.and_then(|s| s.access_token.clone())
+                    .filter(|t| !t.is_empty()),
+                srv.and_then(|s| s.id.clone()).unwrap_or_default(),
+            )
+        };
+        let mut report = move |msg: String| {
+            error.set(Some(msg.clone()));
+            ctrl.playback_error.set(Some(msg));
+        };
+        spawn(async move {
+            let token = match sc_ensure_signed_in(existing, browser, &server_id).await {
+                Ok(t) => t,
+                Err(e) => {
+                    report(format!("SoundCloud sign-in failed ({browser}): {e}"));
+                    return;
+                }
+            };
+            let user_id = ::server::soundcloud::derive_user_id(&token)
+                .await
+                .unwrap_or_else(|| "me".to_string());
+            {
+                let mut cfg = config.write();
+                if let Some(srv) = cfg.server.as_mut() {
+                    srv.access_token = Some(token);
+                    srv.user_id = Some(user_id);
+                    srv.yt_browser = Some(browser);
+                }
+            }
+            error.set(None);
+        });
+    };
+
     let handle_add_server = move |_| {
         let selected_service = server_service();
         let is_ytmusic = selected_service == MusicService::YtMusic;
@@ -310,9 +380,6 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
             return;
         }
 
-        // Snapshot the synchronous inputs so the async block doesn't have
-        // to re-read signals (which it could, but this keeps the data
-        // flow obvious).
         let name_input = server_name();
         let url_input = server_url();
 
@@ -337,25 +404,20 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                     effective_url,
                     selected_service,
                 );
-                let is_anon = is_ytmusic && *yt_anonymous.peek();
+                let is_browser_signin = is_ytmusic || is_soundcloud;
+                let is_anon = is_browser_signin && *yt_anonymous.peek();
                 new_server.yt_anonymous = is_anon;
-                if is_anon || is_soundcloud {
-                    // Mark the server active with an empty (non-None) access
-                    // token. For anonymous YT that's the "no cookies, public
-                    // surfaces only" signal get_stream/discover read; for
-                    // SoundCloud it just means "tokenless, ready to play".
+                if is_anon {
                     new_server.access_token = Some(String::new());
                 }
-                // Persist the chosen browser on the active server too (not just the
-                // saved-list entry), so the sign-in flow knows which browser to use.
-                new_server.yt_browser = (is_ytmusic && !is_anon).then(|| *yt_browser.peek());
+                new_server.yt_browser = (is_browser_signin && !is_anon).then(|| *yt_browser.peek());
 
                 let saved = config::SavedServer {
                     id: new_server.id.clone().unwrap_or_default(),
                     name: new_server.name.clone(),
                     url: new_server.url.clone(),
                     service: new_server.service,
-                    yt_browser: (is_ytmusic && !is_anon).then(|| *yt_browser.peek()),
+                    yt_browser: (is_browser_signin && !is_anon).then(|| *yt_browser.peek()),
                     yt_anonymous: is_anon,
                 };
                 {
@@ -370,15 +432,17 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                 error.set(None);
                 show_add_server.set(false);
 
-                if is_ytmusic && !is_anon {
-                    ytmusic_auto_login();
-                } else if !is_ytmusic && !is_soundcloud {
-                    show_login.set(true);
+                if !is_anon {
+                    if is_ytmusic {
+                        ytmusic_auto_login();
+                    } else if is_soundcloud {
+                        soundcloud_auto_login();
+                    } else {
+                        show_login.set(true);
+                    }
                 }
-                // Anonymous YT and SoundCloud need no further setup — the
-                // server entry is already active and playable.
             }
-            .instrument(tracing::info_span!("yt.anon_setup")),
+            .instrument(tracing::info_span!("server.add_setup")),
         );
     };
 
@@ -390,42 +454,41 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
         if let Some(saved) = server {
             let is_ytmusic = saved.service == MusicService::YtMusic;
             let is_soundcloud = saved.service == MusicService::SoundCloud;
-            let is_anon = is_ytmusic && saved.yt_anonymous;
+            let is_anon = (is_ytmusic || is_soundcloud) && saved.yt_anonymous;
             let active = config::MusicServer {
                 name: saved.name,
                 url: saved.url,
                 service: saved.service,
-                // An empty (non-None) token marks the server active without a
-                // sign-in: anonymous YT (treated as "no cookies") and the
-                // tokenless SoundCloud backend.
-                access_token: (is_anon || is_soundcloud).then(String::new),
+                access_token: is_anon.then(String::new),
                 user_id: None,
                 id: Some(saved.id),
-                // Carry the saved browser choice over so the sign-in
-                // launch hits the binary the user picked, not whatever
-                // the popup's default selector happens to be.
                 yt_browser: saved.yt_browser,
                 yt_anonymous: is_anon,
             };
             config.write().server = Some(active);
-            if is_ytmusic && !is_anon {
-                ytmusic_auto_login();
-            } else if !is_ytmusic && !is_soundcloud {
-                show_login.set(true);
+            if !is_anon {
+                if is_ytmusic {
+                    ytmusic_auto_login();
+                } else if is_soundcloud {
+                    soundcloud_auto_login();
+                } else {
+                    show_login.set(true);
+                }
             }
-            // Anonymous YT and SoundCloud are immediately active — no sign-in.
         }
     };
 
     let handle_delete_saved = move |id: String| {
-        let was_ytmusic = config
-            .peek()
-            .find_saved_server(&id)
-            .map(|s| s.service == MusicService::YtMusic)
-            .unwrap_or(false);
+        let service = config.peek().find_saved_server(&id).map(|s| s.service);
         config.write().remove_saved_server(&id);
-        if was_ytmusic {
-            let _ = ::server::ytmusic::isolated_profile::delete_profile(&id);
+        match service {
+            Some(MusicService::YtMusic) => {
+                let _ = ::server::ytmusic::isolated_profile::delete_profile(&id);
+            }
+            Some(MusicService::SoundCloud) => {
+                let _ = ::server::soundcloud::signin::delete_profile(&id);
+            }
+            _ => {}
         }
     };
 
@@ -598,16 +661,17 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                                     on_delete: handle_delete_saved,
                                     on_switch: handle_switch_server,
                                     on_login: move |_| {
-                                        let is_ytmusic = config
+                                        let service = config
                                             .read()
                                             .server
                                             .as_ref()
-                                            .map(|s| s.service == MusicService::YtMusic)
-                                            .unwrap_or(false);
-                                        if is_ytmusic {
-                                            ytmusic_auto_login();
-                                        } else {
-                                            show_login.set(true);
+                                            .map(|s| s.service);
+                                        match service {
+                                            Some(MusicService::YtMusic) => ytmusic_auto_login(),
+                                            Some(MusicService::SoundCloud) => {
+                                                soundcloud_auto_login()
+                                            }
+                                            _ => show_login.set(true),
                                         }
                                     },
                                 }

--- a/crates/pages/src/settings.rs
+++ b/crates/pages/src/settings.rs
@@ -303,8 +303,9 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
     let handle_add_server = move |_| {
         let selected_service = server_service();
         let is_ytmusic = selected_service == MusicService::YtMusic;
+        let is_soundcloud = selected_service == MusicService::SoundCloud;
 
-        if !is_ytmusic && !server_url().starts_with("http") {
+        if !is_ytmusic && !is_soundcloud && !server_url().starts_with("http") {
             error.set(Some(i18n::t("invalid_server_url").to_string()));
             return;
         }
@@ -325,6 +326,8 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
 
                 let effective_url = if is_ytmusic {
                     "https://music.youtube.com".to_string()
+                } else if is_soundcloud {
+                    "https://soundcloud.com".to_string()
                 } else {
                     url_input
                 };
@@ -336,11 +339,11 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                 );
                 let is_anon = is_ytmusic && *yt_anonymous.peek();
                 new_server.yt_anonymous = is_anon;
-                if is_anon {
-                    // Mark anonymous mode at the server level. Empty access
-                    // token + yt_anonymous=true is what get_stream /
-                    // discover etc. read as "no cookies, public surfaces
-                    // only".
+                if is_anon || is_soundcloud {
+                    // Mark the server active with an empty (non-None) access
+                    // token. For anonymous YT that's the "no cookies, public
+                    // surfaces only" signal get_stream/discover read; for
+                    // SoundCloud it just means "tokenless, ready to play".
                     new_server.access_token = Some(String::new());
                 }
                 // Persist the chosen browser on the active server too (not just the
@@ -369,11 +372,11 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
 
                 if is_ytmusic && !is_anon {
                     ytmusic_auto_login();
-                } else if !is_ytmusic {
+                } else if !is_ytmusic && !is_soundcloud {
                     show_login.set(true);
                 }
-                // Anonymous YT needs no further setup — the server entry
-                // is already active and playable.
+                // Anonymous YT and SoundCloud need no further setup — the
+                // server entry is already active and playable.
             }
             .instrument(tracing::info_span!("yt.anon_setup")),
         );
@@ -386,14 +389,16 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
         };
         if let Some(saved) = server {
             let is_ytmusic = saved.service == MusicService::YtMusic;
+            let is_soundcloud = saved.service == MusicService::SoundCloud;
             let is_anon = is_ytmusic && saved.yt_anonymous;
             let active = config::MusicServer {
                 name: saved.name,
                 url: saved.url,
                 service: saved.service,
-                // Anonymous YT keeps an empty (non-None) token so the
-                // backend treats it as anon rather than "needs sign-in".
-                access_token: is_anon.then(String::new),
+                // An empty (non-None) token marks the server active without a
+                // sign-in: anonymous YT (treated as "no cookies") and the
+                // tokenless SoundCloud backend.
+                access_token: (is_anon || is_soundcloud).then(String::new),
                 user_id: None,
                 id: Some(saved.id),
                 // Carry the saved browser choice over so the sign-in
@@ -405,10 +410,10 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
             config.write().server = Some(active);
             if is_ytmusic && !is_anon {
                 ytmusic_auto_login();
-            } else if !is_ytmusic {
+            } else if !is_ytmusic && !is_soundcloud {
                 show_login.set(true);
             }
-            // Anonymous YT is immediately active — no sign-in launch.
+            // Anonymous YT and SoundCloud are immediately active — no sign-in.
         }
     };
 

--- a/crates/pages/src/settings.rs
+++ b/crates/pages/src/settings.rs
@@ -360,10 +360,16 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                 .unwrap_or_else(|| "me".to_string());
             {
                 let mut cfg = config.write();
+                let saved_id = cfg.server.as_ref().and_then(|s| s.id.clone());
                 if let Some(srv) = cfg.server.as_mut() {
                     srv.access_token = Some(token);
                     srv.user_id = Some(user_id);
                     srv.yt_browser = Some(browser);
+                }
+                if let Some(id) = saved_id
+                    && let Some(saved) = cfg.servers.iter_mut().find(|s| s.id == id)
+                {
+                    saved.yt_browser = Some(browser);
                 }
             }
             error.set(None);

--- a/crates/scrobble/src/librefm.rs
+++ b/crates/scrobble/src/librefm.rs
@@ -74,7 +74,7 @@ fn make_api_sig(params: &[(&str, &str)], api_secret: &str) -> String {
 }
 
 pub async fn get_auth_token(api_key: &str) -> Result<String, reqwest::Error> {
-    let client = Client::new();
+    let client = client();
 
     let resp = client
         .get(API_URL)
@@ -98,7 +98,7 @@ pub async fn get_session_key(
     api_secret: &str,
     token: &str,
 ) -> Result<String, reqwest::Error> {
-    let client = Client::new();
+    let client = client();
 
     let params = [
         ("api_key", api_key),
@@ -133,7 +133,7 @@ pub async fn submit_scrobble(
     session_key: &str,
     scrobble: &Scrobble<'_>,
 ) -> Result<String, reqwest::Error> {
-    let client = Client::new();
+    let client = client();
 
     let artist = scrobble.track_metadata.artist_name.trim();
     let track = scrobble.track_metadata.track_name.trim();
@@ -179,7 +179,7 @@ pub async fn submit_now_playing(
     session_key: &str,
     now_playing: &NowPlaying<'_>,
 ) -> Result<String, reqwest::Error> {
-    let client = Client::new();
+    let client = client();
 
     let artist = now_playing.track_metadata.artist_name.trim();
     let track = now_playing.track_metadata.track_name.trim();

--- a/crates/scrobble/src/librefm.rs
+++ b/crates/scrobble/src/librefm.rs
@@ -74,7 +74,7 @@ fn make_api_sig(params: &[(&str, &str)], api_secret: &str) -> String {
 }
 
 pub async fn get_auth_token(api_key: &str) -> Result<String, reqwest::Error> {
-    let client = client();
+    let client = Client::new();
 
     let resp = client
         .get(API_URL)
@@ -98,7 +98,7 @@ pub async fn get_session_key(
     api_secret: &str,
     token: &str,
 ) -> Result<String, reqwest::Error> {
-    let client = client();
+    let client = Client::new();
 
     let params = [
         ("api_key", api_key),
@@ -133,7 +133,7 @@ pub async fn submit_scrobble(
     session_key: &str,
     scrobble: &Scrobble<'_>,
 ) -> Result<String, reqwest::Error> {
-    let client = client();
+    let client = Client::new();
 
     let artist = scrobble.track_metadata.artist_name.trim();
     let track = scrobble.track_metadata.track_name.trim();
@@ -179,7 +179,7 @@ pub async fn submit_now_playing(
     session_key: &str,
     now_playing: &NowPlaying<'_>,
 ) -> Result<String, reqwest::Error> {
-    let client = client();
+    let client = Client::new();
 
     let artist = now_playing.track_metadata.artist_name.trim();
     let track = now_playing.track_metadata.track_name.trim();

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -2,6 +2,7 @@ pub mod download_queue;
 pub mod jellyfin;
 pub mod provider;
 pub mod server_ops;
+pub mod soundcloud;
 pub mod subsonic;
 pub mod ytmusic;
 

--- a/crates/server/src/provider.rs
+++ b/crates/server/src/provider.rs
@@ -58,9 +58,9 @@ impl ProviderClient {
                 "YouTube Music uses OAuth device flow; call login_ytmusic_device() instead"
                     .to_string(),
             ),
-            MusicService::SoundCloud => Err(
-                "SoundCloud needs no login; the server entry is active on add".to_string(),
-            ),
+            MusicService::SoundCloud => {
+                Err("SoundCloud needs no login; the server entry is active on add".to_string())
+            }
         }
     }
 

--- a/crates/server/src/provider.rs
+++ b/crates/server/src/provider.rs
@@ -58,6 +58,9 @@ impl ProviderClient {
                 "YouTube Music uses OAuth device flow; call login_ytmusic_device() instead"
                     .to_string(),
             ),
+            MusicService::SoundCloud => Err(
+                "SoundCloud needs no login; the server entry is active on add".to_string(),
+            ),
         }
     }
 

--- a/crates/server/src/server_ops.rs
+++ b/crates/server/src/server_ops.rs
@@ -132,9 +132,7 @@ pub async fn create_server_playlist(
             let yt = YouTubeMusicClient::with_cookies(conn.token.clone());
             yt.create_playlist(name, "", &id_refs).await
         }
-        MusicService::SoundCloud => {
-            Err("SoundCloud doesn't support server playlists".to_string())
-        }
+        MusicService::SoundCloud => Err("SoundCloud doesn't support server playlists".to_string()),
     }
 }
 
@@ -198,7 +196,12 @@ pub async fn set_tracks_favorite(
             }
         }
         MusicService::SoundCloud => {
-            return Err("SoundCloud doesn't support favorites".to_string());
+            if conn.token.is_empty() {
+                return Err("Sign in to SoundCloud to like tracks".to_string());
+            }
+            for id in item_ids {
+                record!(crate::soundcloud::set_track_like(id, favorite, &conn.token).await);
+            }
         }
     }
     match first_err {

--- a/crates/server/src/server_ops.rs
+++ b/crates/server/src/server_ops.rs
@@ -18,6 +18,11 @@ pub struct ServerConn {
     pub token: String,
     pub user_id: String,
     pub device_id: String,
+    /// SoundCloud only: the browser + server id needed to re-read the isolated
+    /// profile's `datadome` cookie at write time (required to clear bot
+    /// protection on the like endpoint).
+    pub sc_browser: Option<config::Browser>,
+    pub sc_server_id: Option<String>,
 }
 
 impl ServerConn {
@@ -43,6 +48,8 @@ impl ServerConn {
             token,
             user_id,
             device_id: config.device_id.clone(),
+            sc_browser: server.yt_browser,
+            sc_server_id: server.id.clone(),
         })
     }
 }
@@ -199,8 +206,23 @@ pub async fn set_tracks_favorite(
             if conn.token.is_empty() {
                 return Err("Sign in to SoundCloud to like tracks".to_string());
             }
+            // DataDome bot-protection gates the like endpoint; re-read the
+            // session cookie from the isolated profile so the write isn't 403'd.
+            let datadome = match (conn.sc_browser, &conn.sc_server_id) {
+                (Some(browser), Some(server_id)) => {
+                    let profile = crate::soundcloud::signin::profile_dir(server_id);
+                    crate::soundcloud::signin::extract_datadome(browser, &profile)
+                        .await
+                        .ok()
+                        .flatten()
+                }
+                _ => None,
+            };
             for id in item_ids {
-                record!(crate::soundcloud::set_track_like(id, favorite, &conn.token).await);
+                record!(
+                    crate::soundcloud::set_track_like(id, favorite, &conn.token, datadome.as_deref())
+                        .await
+                );
             }
         }
     }

--- a/crates/server/src/server_ops.rs
+++ b/crates/server/src/server_ops.rs
@@ -290,5 +290,10 @@ mod tests {
         let yt = ServerConn::resolve(&cfg("YtMusic", Some("cookie"), None)).unwrap();
         assert_eq!(yt.token, "cookie");
         assert!(yt.user_id.is_empty());
+
+        // SoundCloud authenticates by token — user_id optional, still resolves.
+        let sc = ServerConn::resolve(&cfg("SoundCloud", Some("oauth"), None)).unwrap();
+        assert_eq!(sc.token, "oauth");
+        assert!(sc.user_id.is_empty());
     }
 }

--- a/crates/server/src/server_ops.rs
+++ b/crates/server/src/server_ops.rs
@@ -32,7 +32,9 @@ impl ServerConn {
         let server = config.server.as_ref()?;
         let token = server.access_token.clone()?;
         let user_id = match server.service {
-            MusicService::YtMusic => server.user_id.clone().unwrap_or_default(),
+            MusicService::YtMusic | MusicService::SoundCloud => {
+                server.user_id.clone().unwrap_or_default()
+            }
             _ => server.user_id.clone()?,
         };
         Some(Self {
@@ -95,6 +97,7 @@ pub async fn add_tracks_to_playlist(
                 }
             }
         }
+        MusicService::SoundCloud => {}
     }
     added
 }
@@ -128,6 +131,9 @@ pub async fn create_server_playlist(
         MusicService::YtMusic => {
             let yt = YouTubeMusicClient::with_cookies(conn.token.clone());
             yt.create_playlist(name, "", &id_refs).await
+        }
+        MusicService::SoundCloud => {
+            Err("SoundCloud doesn't support server playlists".to_string())
         }
     }
 }
@@ -190,6 +196,9 @@ pub async fn set_tracks_favorite(
                     record!(yt.unlike_video(id).await);
                 }
             }
+        }
+        MusicService::SoundCloud => {
+            return Err("SoundCloud doesn't support favorites".to_string());
         }
     }
     match first_err {

--- a/crates/server/src/server_ops.rs
+++ b/crates/server/src/server_ops.rs
@@ -220,8 +220,13 @@ pub async fn set_tracks_favorite(
             };
             for id in item_ids {
                 record!(
-                    crate::soundcloud::set_track_like(id, favorite, &conn.token, datadome.as_deref())
-                        .await
+                    crate::soundcloud::set_track_like(
+                        id,
+                        favorite,
+                        &conn.token,
+                        datadome.as_deref()
+                    )
+                    .await
                 );
             }
         }

--- a/crates/server/src/soundcloud.rs
+++ b/crates/server/src/soundcloud.rs
@@ -48,9 +48,7 @@ fn http_client() -> reqwest::Client {
 /// `force` is set after a stale-id error) and caching it for the process.
 async fn client_id(http: &reqwest::Client, force: bool) -> Result<String, String> {
     let mut guard = CLIENT_ID.lock().await;
-    if !force
-        && let Some(id) = guard.as_ref()
-    {
+    if !force && let Some(id) = guard.as_ref() {
         return Ok(id.clone());
     }
     let id = scrape_client_id(http).await?;
@@ -185,16 +183,25 @@ async fn api_search(http: &reqwest::Client, query: &str, cid: &str) -> Result<Va
         .map_err(|e| format!("SoundCloud search JSON: {e}"))
 }
 
-/// Resolve a track id to a playable progressive MP3 stream URL via the `/tracks`
-/// lookup endpoint. Called lazily at play time (the search results don't need to
-/// round-trip every stream URL through the queue).
-#[tracing::instrument(name = "soundcloud.resolve_stream", fields(track_id = %track_id))]
-pub async fn resolve_stream(track_id: &str) -> Result<String, String> {
+/// A resolved, playable SoundCloud stream. Progressive is the keyless 128 kbps
+/// MP3 every track exposes; `HlsAac` is the 256 kbps AAC HLS playlist that only
+/// surfaces for an authenticated SoundCloud Go+ subscriber.
+pub enum ResolvedStream {
+    Progressive(String),
+    HlsAac(String),
+}
+
+/// Resolve a track id to a playable stream via the `/tracks` lookup endpoint,
+/// called lazily at play time. When `token` is an authenticated Go+ session the
+/// track's AAC HLS transcoding is preferred for higher quality; otherwise it
+/// falls back to the universal progressive MP3.
+#[tracing::instrument(name = "soundcloud.resolve_stream", skip(token), fields(track_id = %track_id))]
+pub async fn resolve_stream(track_id: &str, token: Option<&str>) -> Result<ResolvedStream, String> {
     let http = http_client();
 
-    let track = match lookup_track(&http, track_id, &client_id(&http, false).await?).await {
+    let track = match lookup_track(&http, track_id, &client_id(&http, false).await?, token).await {
         Ok(v) => v,
-        Err(_) => lookup_track(&http, track_id, &client_id(&http, true).await?).await?,
+        Err(_) => lookup_track(&http, track_id, &client_id(&http, true).await?, token).await?,
     };
 
     let transcodings = track
@@ -203,17 +210,43 @@ pub async fn resolve_stream(track_id: &str) -> Result<String, String> {
         .and_then(|t| t.as_array())
         .ok_or("SoundCloud track exposes no media transcodings")?;
 
+    let track_auth = track.get("track_authorization").and_then(|v| v.as_str());
+
+    if let Some(tc) = transcodings.iter().find(|tc| {
+        transcoding_protocol(tc) == Some("hls") && transcoding_mime(tc) == Some("audio/mp4")
+    }) {
+        let hls_url = tc
+            .get("url")
+            .and_then(|v| v.as_str())
+            .ok_or("SoundCloud AAC transcoding has no url")?;
+        let media = resolve_media_url(&http, hls_url, track_auth, token).await?;
+        return Ok(ResolvedStream::HlsAac(media));
+    }
+
     let progressive_url = transcodings
         .iter()
         .find(|tc| transcoding_protocol(tc) == Some("progressive"))
         .and_then(|tc| tc.get("url"))
         .and_then(|v| v.as_str())
         .ok_or("SoundCloud track has no progressive (non-HLS) stream")?;
+    let media = resolve_media_url(&http, progressive_url, track_auth, token).await?;
+    Ok(ResolvedStream::Progressive(media))
+}
 
-    let track_auth = track.get("track_authorization").and_then(|v| v.as_str());
-    let cid = client_id(&http, false).await?;
-
-    let mut req = http.get(progressive_url).query(&[("client_id", cid.as_str())]);
+/// Exchange a transcoding URL for its time-limited CDN media URL (a direct MP3
+/// for progressive, or an `.m3u8` playlist for HLS).
+async fn resolve_media_url(
+    http: &reqwest::Client,
+    transcoding_url: &str,
+    track_auth: Option<&str>,
+    token: Option<&str>,
+) -> Result<String, String> {
+    let cid = client_id(http, false).await?;
+    let mut req = apply_auth(
+        http.get(transcoding_url)
+            .query(&[("client_id", cid.as_str())]),
+        token,
+    );
     if let Some(auth) = track_auth {
         req = req.query(&[("track_authorization", auth)]);
     }
@@ -236,23 +269,46 @@ pub async fn resolve_stream(track_id: &str) -> Result<String, String> {
         .ok_or_else(|| "SoundCloud returned no stream URL for this track".to_string())
 }
 
-async fn lookup_track(http: &reqwest::Client, id: &str, cid: &str) -> Result<Value, String> {
-    http.get(format!("{API_V2}/tracks/{id}"))
-        .query(&[("client_id", cid)])
-        .send()
-        .await
-        .map_err(|e| format!("SoundCloud lookup HTTP: {e}"))?
-        .error_for_status()
-        .map_err(|e| format!("SoundCloud lookup HTTP: {e}"))?
-        .json::<Value>()
-        .await
-        .map_err(|e| format!("SoundCloud lookup JSON: {e}"))
+async fn lookup_track(
+    http: &reqwest::Client,
+    id: &str,
+    cid: &str,
+    token: Option<&str>,
+) -> Result<Value, String> {
+    apply_auth(
+        http.get(format!("{API_V2}/tracks/{id}"))
+            .query(&[("client_id", cid)]),
+        token,
+    )
+    .send()
+    .await
+    .map_err(|e| format!("SoundCloud lookup HTTP: {e}"))?
+    .error_for_status()
+    .map_err(|e| format!("SoundCloud lookup HTTP: {e}"))?
+    .json::<Value>()
+    .await
+    .map_err(|e| format!("SoundCloud lookup JSON: {e}"))
+}
+
+/// Attach the web-app `Authorization: OAuth <token>` header for a signed-in
+/// session. A `None`/empty token leaves the request anonymous (keyless mode).
+fn apply_auth(req: reqwest::RequestBuilder, token: Option<&str>) -> reqwest::RequestBuilder {
+    match token {
+        Some(t) if !t.is_empty() => req.header("Authorization", format!("OAuth {t}")),
+        _ => req,
+    }
 }
 
 fn transcoding_protocol(tc: &Value) -> Option<&str> {
     tc.get("format")
         .and_then(|f| f.get("protocol"))
         .and_then(|p| p.as_str())
+}
+
+fn transcoding_mime(tc: &Value) -> Option<&str> {
+    tc.get("format")
+        .and_then(|f| f.get("mime_type"))
+        .and_then(|m| m.as_str())
 }
 
 /// Pull the id segment out of a `soundcloud:<id>[:tag]` track path.
@@ -341,6 +397,366 @@ fn parse_track(item: &Value) -> Option<Track> {
             vec![artist]
         },
     })
+}
+
+/// A SoundCloud playlist as listed in the user's library — enough to seed a
+/// store entry; the tracks are loaded lazily via [`get_playlist_entries`].
+pub struct PlaylistSummary {
+    pub id: String,
+    pub title: String,
+    pub artwork_url: Option<String>,
+}
+
+async fn auth_get_json(
+    http: &reqwest::Client,
+    url: &str,
+    token: Option<&str>,
+) -> Result<Value, String> {
+    apply_auth(http.get(url), token)
+        .send()
+        .await
+        .map_err(|e| format!("SoundCloud API HTTP: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("SoundCloud API HTTP: {e}"))?
+        .json::<Value>()
+        .await
+        .map_err(|e| format!("SoundCloud API JSON: {e}"))
+}
+
+/// Fetch the signed-in user's profile (`/me`).
+pub async fn get_me(token: &str) -> Result<Value, String> {
+    let http = http_client();
+    let cid = client_id(&http, false).await?;
+    auth_get_json(&http, &format!("{API_V2}/me?client_id={cid}"), Some(token)).await
+}
+
+/// Resolve a signed-in session to its numeric user id (used as `user_id`).
+pub async fn derive_user_id(token: &str) -> Option<String> {
+    get_me(token)
+        .await
+        .ok()
+        .and_then(|me| me.get("id").and_then(|v| v.as_u64()))
+        .map(|n| n.to_string())
+}
+
+/// Stream the user's liked tracks page-by-page, mirroring the YT Music
+/// `stream_liked_songs` shape so the favorites view can render incrementally.
+pub async fn stream_liked_tracks<F: FnMut(Vec<Track>)>(
+    token: &str,
+    mut on_page: F,
+) -> Result<(), String> {
+    let http = http_client();
+    let cid = client_id(&http, false).await?;
+    let mut next = Some(format!(
+        "{API_V2}/me/likes/tracks?client_id={cid}&limit=200&linked_partitioning=1"
+    ));
+    let mut pages = 0;
+    while let Some(url) = next.take() {
+        if pages >= 20 {
+            break;
+        }
+        pages += 1;
+        let json = auth_get_json(&http, &url, Some(token)).await?;
+        let page: Vec<Track> = json
+            .get("collection")
+            .and_then(|v| v.as_array())
+            .map(|arr| arr.iter().filter_map(parse_track).collect())
+            .unwrap_or_default();
+        if !page.is_empty() {
+            on_page(page);
+        }
+        next = json
+            .get("next_href")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+    }
+    Ok(())
+}
+
+/// List the signed-in user's own playlists.
+pub async fn list_playlists(token: &str) -> Result<Vec<PlaylistSummary>, String> {
+    let http = http_client();
+    let cid = client_id(&http, false).await?;
+    let mut next = Some(format!(
+        "{API_V2}/me/playlists?client_id={cid}&limit=50&linked_partitioning=1"
+    ));
+    let mut out = Vec::new();
+    let mut pages = 0;
+    while let Some(url) = next.take() {
+        if pages >= 10 {
+            break;
+        }
+        pages += 1;
+        let json = auth_get_json(&http, &url, Some(token)).await?;
+        if let Some(arr) = json.get("collection").and_then(|v| v.as_array()) {
+            for p in arr {
+                let Some(id) = p.get("id").and_then(|v| v.as_u64()) else {
+                    continue;
+                };
+                out.push(PlaylistSummary {
+                    id: id.to_string(),
+                    title: p
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                    artwork_url: p
+                        .get("artwork_url")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(upscale_artwork),
+                });
+            }
+        }
+        next = json
+            .get("next_href")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string());
+    }
+    Ok(out)
+}
+
+/// Load a playlist's full track list. SoundCloud returns most entries as bare
+/// `{id}` stubs, so the ids are collected in order and batch-hydrated through
+/// `/tracks?ids=` (capped at 50 per request) before parsing.
+pub async fn get_playlist_entries(playlist_id: &str, token: &str) -> Result<Vec<Track>, String> {
+    let http = http_client();
+    let cid = client_id(&http, false).await?;
+    let json = auth_get_json(
+        &http,
+        &format!("{API_V2}/playlists/{playlist_id}?client_id={cid}"),
+        Some(token),
+    )
+    .await?;
+
+    let ids: Vec<u64> = json
+        .get("tracks")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|t| t.get("id").and_then(|v| v.as_u64()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let mut by_id: std::collections::HashMap<u64, Value> = std::collections::HashMap::new();
+    for chunk in ids.chunks(50) {
+        let ids_str = chunk
+            .iter()
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        let url = format!("{API_V2}/tracks?ids={ids_str}&client_id={cid}");
+        if let Ok(arr) = auth_get_json(&http, &url, Some(token)).await
+            && let Some(items) = arr.as_array()
+        {
+            for t in items {
+                if let Some(id) = t.get("id").and_then(|v| v.as_u64()) {
+                    by_id.insert(id, t.clone());
+                }
+            }
+        }
+    }
+
+    Ok(ids
+        .iter()
+        .filter_map(|id| by_id.get(id))
+        .filter_map(parse_track)
+        .collect())
+}
+
+/// Like or unlike a track on the signed-in account.
+pub async fn set_track_like(track_id: &str, like: bool, token: &str) -> Result<(), String> {
+    let http = http_client();
+    let cid = client_id(&http, false).await?;
+    let uid = derive_user_id(token)
+        .await
+        .ok_or("SoundCloud: couldn't resolve the signed-in user id")?;
+    let url = format!("{API_V2}/users/{uid}/track_likes/{track_id}?client_id={cid}");
+    let req = if like {
+        http.put(url)
+    } else {
+        http.delete(url)
+    };
+    apply_auth(req, Some(token))
+        .send()
+        .await
+        .map_err(|e| format!("SoundCloud like HTTP: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("SoundCloud like HTTP: {e}"))?;
+    Ok(())
+}
+
+/// One-time SoundCloud sign-in via an isolated browser profile. Reuses the YT
+/// Music browser-launch machinery; the only differences are the sign-in URL,
+/// the cookie domain, and that we extract the single `oauth_token` cookie that
+/// the web app sends as `Authorization: OAuth <token>`.
+pub mod signin {
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, Instant};
+
+    use config::Browser;
+
+    use crate::ytmusic::isolated_profile as ip;
+
+    const SIGNIN_URL: &str = "https://soundcloud.com/signin";
+
+    pub fn profile_dir(server_id: &str) -> PathBuf {
+        let safe: String = server_id
+            .chars()
+            .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'))
+            .collect();
+        let leaf = if safe.is_empty() {
+            "sc-profile".to_string()
+        } else {
+            format!("sc-profile-{safe}")
+        };
+        directories::ProjectDirs::from("com", "temidaradev", "kopuz")
+            .map(|d| {
+                #[cfg(target_os = "windows")]
+                let base = d.data_local_dir();
+                #[cfg(not(target_os = "windows"))]
+                let base = d.config_dir();
+                base.join(&leaf)
+            })
+            .unwrap_or_else(|| PathBuf::from(format!("./{leaf}")))
+    }
+
+    pub fn delete_profile(server_id: &str) -> std::io::Result<()> {
+        match std::fs::remove_dir_all(profile_dir(server_id)) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Launch the chosen browser at the SoundCloud sign-in page and poll the
+    /// isolated profile's cookie store until `oauth_token` appears. The browser
+    /// is always killed before returning.
+    #[tracing::instrument(name = "sc.signin", skip(server_id, signin_timeout), fields(browser = %browser))]
+    pub async fn launch_signin_and_extract(
+        browser: Browser,
+        server_id: &str,
+        signin_timeout: Duration,
+    ) -> Result<String, String> {
+        let profile = profile_dir(server_id);
+        match tokio::fs::remove_dir_all(&profile).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(format!("wipe sc-profile: {e}")),
+        }
+        tokio::fs::create_dir_all(&profile)
+            .await
+            .map_err(|e| format!("mkdir sc-profile: {e}"))?;
+
+        let bin = if ip::in_flatpak() {
+            ip::find_host_browser_bin(browser).await.ok_or_else(|| {
+                format!(
+                    "{browser} not found on the host (looked for: {}). Install it on the host system.",
+                    ip::browser_candidates(browser).join(", ")
+                )
+            })?
+        } else {
+            ip::find_browser_bin(browser).ok_or_else(|| {
+                format!(
+                    "{browser} not found in PATH (looked for: {}). Install it, or set $KOPUZ_{}_BIN.",
+                    ip::browser_candidates(browser).join(", "),
+                    browser.id().to_uppercase().replace('-', "_")
+                )
+            })?
+        };
+
+        let mut cmd = ip::browser_command(&bin);
+        cmd.arg("--no-first-run")
+            .arg("--no-default-browser-check")
+            .arg(format!("--user-data-dir={}", profile.display()));
+        #[cfg(target_os = "windows")]
+        {
+            use std::os::windows::process::CommandExt;
+            cmd.creation_flags(0x0100_0000);
+        }
+        let mut child = cmd
+            .arg(SIGNIN_URL)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(|e| format!("spawn {bin}: {e}"))?;
+
+        let deadline = Instant::now() + signin_timeout;
+        let outcome = loop {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            if Instant::now() > deadline {
+                break Err(format!(
+                    "Sign-in not detected within {}s",
+                    signin_timeout.as_secs()
+                ));
+            }
+            let _ = child.try_wait();
+            if let Ok(Some(token)) = extract_oauth_token(browser, &profile).await {
+                break Ok(token);
+            }
+        };
+        let _ = child.kill().await;
+        outcome
+    }
+
+    /// Pull the `oauth_token` cookie value out of the isolated profile's cookie
+    /// store (decrypted by `rookie`, exactly like the YT cookie reader).
+    pub async fn extract_oauth_token(
+        browser: Browser,
+        profile_root: &Path,
+    ) -> Result<Option<String>, String> {
+        let db_path =
+            pick_cookies_path(profile_root).ok_or_else(|| "no Cookies database yet".to_string())?;
+        let profile_owned = profile_root.to_path_buf();
+        let browser_name = rookie_browser_name(browser);
+
+        let cookies =
+            tokio::task::spawn_blocking(move || -> Result<Vec<rookie::enums::Cookie>, String> {
+                let domains = Some(vec!["soundcloud.com".to_string()]);
+                #[cfg(not(target_os = "windows"))]
+                {
+                    let _ = profile_owned;
+                    let config = rookie::config::get_browser_config(browser_name);
+                    rookie::chromium_based(config, db_path, domains).map_err(|e| e.to_string())
+                }
+                #[cfg(target_os = "windows")]
+                {
+                    let _ = browser_name;
+                    let key_path = profile_owned.join("Local State");
+                    rookie::chromium_based(key_path, db_path, domains).map_err(|e| e.to_string())
+                }
+            })
+            .await
+            .map_err(|e| format!("cookie extract task: {e}"))??;
+
+        Ok(cookies
+            .into_iter()
+            .find(|c| c.name == "oauth_token" && !c.value.is_empty())
+            .map(|c| c.value))
+    }
+
+    fn rookie_browser_name(browser: Browser) -> &'static str {
+        match browser {
+            Browser::Brave => "brave",
+            Browser::Chrome => "chrome",
+            Browser::Chromium => "chromium",
+            Browser::Edge => "edge",
+            Browser::Vivaldi => "vivaldi",
+        }
+    }
+
+    fn pick_cookies_path(profile_root: &Path) -> Option<PathBuf> {
+        [
+            profile_root.join("Default").join("Network").join("Cookies"),
+            profile_root.join("Default").join("Cookies"),
+        ]
+        .into_iter()
+        .find(|p| p.exists())
+    }
 }
 
 #[cfg(test)]

--- a/crates/server/src/soundcloud.rs
+++ b/crates/server/src/soundcloud.rs
@@ -225,12 +225,19 @@ pub async fn resolve_stream(track_id: &str, token: Option<&str>) -> Result<Resol
     if let Some(tc) = transcodings.iter().find(|tc| {
         transcoding_protocol(tc) == Some("hls") && transcoding_mime(tc) == Some("audio/mp4")
     }) {
-        let hls_url = tc
-            .get("url")
-            .and_then(|v| v.as_str())
-            .ok_or("SoundCloud AAC transcoding has no url")?;
-        let media = resolve_media_url(&http, hls_url, track_auth, token).await?;
-        return Ok(ResolvedStream::HlsAac(media));
+        // Best-effort: if the AAC/HLS transcoding can't be resolved, fall
+        // through to the progressive MP3 stream rather than failing the play.
+        if let Some(hls_url) = tc.get("url").and_then(|v| v.as_str()) {
+            match resolve_media_url(&http, hls_url, track_auth, token).await {
+                Ok(media) => return Ok(ResolvedStream::HlsAac(media)),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "SoundCloud HLS resolve failed; falling back to progressive"
+                    );
+                }
+            }
+        }
     }
 
     let progressive_url = transcodings
@@ -463,6 +470,10 @@ pub async fn stream_liked_tracks<F: FnMut(Vec<Track>)>(
     let mut pages = 0;
     while let Some(url) = next.take() {
         if pages >= 20 {
+            tracing::warn!(
+                pages,
+                "SoundCloud liked-tracks pagination cap hit; sync is partial"
+            );
             break;
         }
         pages += 1;
@@ -495,6 +506,10 @@ pub async fn list_playlists(token: &str) -> Result<Vec<PlaylistSummary>, String>
     let mut pages = 0;
     while let Some(url) = next.take() {
         if pages >= 10 {
+            tracing::warn!(
+                pages,
+                "SoundCloud playlists pagination cap hit; list is partial"
+            );
             break;
         }
         pages += 1;
@@ -559,13 +574,21 @@ pub async fn get_playlist_entries(playlist_id: &str, token: &str) -> Result<Vec<
             .collect::<Vec<_>>()
             .join(",");
         let url = format!("{API_V2}/tracks?ids={ids_str}&client_id={cid}");
-        if let Ok(arr) = auth_get_json(&http, &url, Some(token)).await
-            && let Some(items) = arr.as_array()
-        {
-            for t in items {
-                if let Some(id) = t.get("id").and_then(|v| v.as_u64()) {
-                    by_id.insert(id, t.clone());
+        match auth_get_json(&http, &url, Some(token)).await {
+            Ok(arr) => {
+                if let Some(items) = arr.as_array() {
+                    for t in items {
+                        if let Some(id) = t.get("id").and_then(|v| v.as_u64()) {
+                            by_id.insert(id, t.clone());
+                        }
+                    }
                 }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "SoundCloud playlist hydration chunk failed; contents may be incomplete"
+                );
             }
         }
     }

--- a/crates/server/src/soundcloud.rs
+++ b/crates/server/src/soundcloud.rs
@@ -513,8 +513,13 @@ pub async fn stream_liked_tracks<F: FnMut(Vec<Track>)>(
 pub async fn list_playlists(token: &str) -> Result<Vec<PlaylistSummary>, String> {
     let http = http_client();
     let cid = client_id(&http, false).await?;
+    // `/me/playlists` 404s like `/me/likes/tracks`; the web player reads a
+    // user's playlists from `/users/{id}/playlists`.
+    let uid = derive_user_id(token)
+        .await
+        .ok_or("SoundCloud: couldn't resolve the signed-in user id")?;
     let mut next = Some(format!(
-        "{API_V2}/me/playlists?client_id={cid}&limit=50&linked_partitioning=1"
+        "{API_V2}/users/{uid}/playlists?client_id={cid}&limit=50&linked_partitioning=1"
     ));
     let mut out = Vec::new();
     let mut pages = 0;

--- a/crates/server/src/soundcloud.rs
+++ b/crates/server/src/soundcloud.rs
@@ -30,6 +30,10 @@ pub const SOURCE_PREFIX: &str = "soundcloud";
 /// `client_id` query param.
 const API_V2: &str = "https://api-v2.soundcloud.com";
 
+/// The public developer API host. Unlike `api-v2` it isn't behind DataDome, so
+/// authenticated writes (like/unlike) go through here.
+const API_V1: &str = "https://api.soundcloud.com";
+
 /// The web player whose HTML/JS bundles carry the `client_id`.
 const WEB_HOST: &str = "https://soundcloud.com";
 
@@ -37,9 +41,15 @@ const WEB_HOST: &str = "https://soundcloud.com";
 /// API forces a re-scrape (the id rotates server-side every so often).
 static CLIENT_ID: Mutex<Option<String>> = Mutex::const_new(None);
 
+/// Chrome-on-macOS UA. SoundCloud's api-v2 write endpoints (like/repost) 403 any
+/// request that doesn't look like the web player, so every request carries it.
+const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
 fn http_client() -> reqwest::Client {
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(15))
+        .user_agent(USER_AGENT)
         .build()
         .unwrap_or_default()
 }
@@ -568,24 +578,58 @@ pub async fn get_playlist_entries(playlist_id: &str, token: &str) -> Result<Vec<
 }
 
 /// Like or unlike a track on the signed-in account.
-pub async fn set_track_like(track_id: &str, like: bool, token: &str) -> Result<(), String> {
+///
+/// Routes through the public `api.soundcloud.com` like endpoint, which (unlike
+/// the web player's `api-v2` host) isn't behind DataDome bot-protection — so a
+/// plain request with the `OAuth` token works without matching a browser TLS
+/// fingerprint. `datadome` is kept only for the legacy `api-v2` fallback.
+pub async fn set_track_like(
+    track_id: &str,
+    like: bool,
+    token: &str,
+    datadome: Option<&str>,
+) -> Result<(), String> {
     let http = http_client();
+
+    // Public API: POST/DELETE https://api.soundcloud.com/likes/tracks/{id}
+    let url = format!("{API_V1}/likes/tracks/{track_id}");
+    let req = if like { http.post(&url) } else { http.delete(&url) }
+        .header("Accept", "application/json; charset=utf-8");
+    let resp = apply_auth(req, Some(token))
+        .send()
+        .await
+        .map_err(|e| format!("SoundCloud like HTTP: {e}"))?;
+    if resp.status().is_success() {
+        return Ok(());
+    }
+    let pub_status = resp.status();
+    let pub_body: String = resp.text().await.unwrap_or_default().chars().take(200).collect();
+    tracing::warn!(%pub_status, pub_body = %pub_body, "soundcloud public-api like failed; trying api-v2");
+
+    // Fallback: the web player's api-v2 endpoint (DataDome-gated; needs the
+    // browser session's datadome cookie + a real Chrome fingerprint, so this
+    // usually only succeeds from the browser itself).
     let cid = client_id(&http, false).await?;
     let uid = derive_user_id(token)
         .await
         .ok_or("SoundCloud: couldn't resolve the signed-in user id")?;
     let url = format!("{API_V2}/users/{uid}/track_likes/{track_id}?client_id={cid}");
-    let req = if like {
-        http.put(url)
-    } else {
-        http.delete(url)
-    };
-    apply_auth(req, Some(token))
+    let mut req = if like { http.put(url) } else { http.delete(url) }
+        .header("Origin", WEB_HOST)
+        .header("Referer", format!("{WEB_HOST}/"));
+    if let Some(dd) = datadome.filter(|s| !s.is_empty()) {
+        req = req.header("Cookie", format!("datadome={dd}"));
+    }
+    let resp = apply_auth(req, Some(token))
         .send()
         .await
-        .map_err(|e| format!("SoundCloud like HTTP: {e}"))?
-        .error_for_status()
         .map_err(|e| format!("SoundCloud like HTTP: {e}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        let body: String = body.chars().take(300).collect();
+        return Err(format!("SoundCloud like HTTP {status}: {body}"));
+    }
     Ok(())
 }
 
@@ -709,6 +753,27 @@ pub mod signin {
         browser: Browser,
         profile_root: &Path,
     ) -> Result<Option<String>, String> {
+        extract_cookie(browser, profile_root, "oauth_token").await
+    }
+
+    /// Pull the `datadome` cookie set by SoundCloud's DataDome bot-protection
+    /// during the human sign-in. api-v2 *write* endpoints (like/repost) 403 with
+    /// a captcha challenge unless the request carries this session cookie; reads
+    /// aren't gated, so this is only needed on mutations.
+    pub async fn extract_datadome(
+        browser: Browser,
+        profile_root: &Path,
+    ) -> Result<Option<String>, String> {
+        extract_cookie(browser, profile_root, "datadome").await
+    }
+
+    /// Decrypt the isolated profile's cookie store (via `rookie`) and return the
+    /// value of the named cookie, if present and non-empty.
+    pub async fn extract_cookie(
+        browser: Browser,
+        profile_root: &Path,
+        name: &str,
+    ) -> Result<Option<String>, String> {
         let db_path =
             pick_cookies_path(profile_root).ok_or_else(|| "no Cookies database yet".to_string())?;
         let profile_owned = profile_root.to_path_buf();
@@ -735,7 +800,7 @@ pub mod signin {
 
         Ok(cookies
             .into_iter()
-            .find(|c| c.name == "oauth_token" && !c.value.is_empty())
+            .find(|c| c.name == name && !c.value.is_empty())
             .map(|c| c.value))
     }
 

--- a/crates/server/src/soundcloud.rs
+++ b/crates/server/src/soundcloud.rs
@@ -1,0 +1,410 @@
+//! SoundCloud integration via the public `api-v2` web-player endpoint.
+//!
+//! Unlike Apple Music / Spotify, SoundCloud streams are **not** DRM'd: every
+//! publicly streamable track exposes a `progressive` transcoding that resolves
+//! to a plain MP3 URL on `cf-media.sndcdn.com`. Those flow through the exact
+//! same Symphonia/cpal decode path as every other backend, identically on
+//! Linux/macOS/Windows. So this is genuine full-track playback, not previews.
+//!
+//! There is no public, registerable API key anymore, so — like every
+//! SoundCloud client (`yt-dlp`, `scdl`, …) — we lift the web player's
+//! `client_id` out of its JS bundles at runtime and cache it. The id rotates
+//! occasionally; any `4xx` triggers one forced re-scrape before giving up.
+//!
+//! Track encoding mirrors the YouTube Music backend: the path is
+//! `soundcloud:<trackId>:urlhex_<artwork-url-hex>` so the shared cover resolver
+//! (`utils::jellyfin_image`) can decode artwork synchronously, and the stream
+//! URL is resolved lazily via [`resolve_stream`] (the controller tags it with a
+//! `__SC_PENDING:` sentinel, just like `__YT_PENDING:`).
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+
+use reader::models::Track;
+use serde_json::Value;
+use tokio::sync::Mutex;
+
+pub const SOURCE_PREFIX: &str = "soundcloud";
+
+/// SoundCloud's internal web-player API. Keyless apart from the scraped
+/// `client_id` query param.
+const API_V2: &str = "https://api-v2.soundcloud.com";
+
+/// The web player whose HTML/JS bundles carry the `client_id`.
+const WEB_HOST: &str = "https://soundcloud.com";
+
+/// Process-wide cached `client_id`. `None` until first scrape; a `4xx` from the
+/// API forces a re-scrape (the id rotates server-side every so often).
+static CLIENT_ID: Mutex<Option<String>> = Mutex::const_new(None);
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .unwrap_or_default()
+}
+
+/// Resolve the web player's `client_id`, scraping it on first use (or when
+/// `force` is set after a stale-id error) and caching it for the process.
+async fn client_id(http: &reqwest::Client, force: bool) -> Result<String, String> {
+    let mut guard = CLIENT_ID.lock().await;
+    if !force
+        && let Some(id) = guard.as_ref()
+    {
+        return Ok(id.clone());
+    }
+    let id = scrape_client_id(http).await?;
+    *guard = Some(id.clone());
+    Ok(id)
+}
+
+/// Pull a fresh `client_id` out of the web player's JavaScript bundles.
+///
+/// The homepage references a handful of `*.sndcdn.com/assets/*.js` chunks; the
+/// id lives in one of them as `client_id:"<32+ chars>"`. It's usually in one of
+/// the later bundles, so we scan them newest-first and stop at the first hit.
+async fn scrape_client_id(http: &reqwest::Client) -> Result<String, String> {
+    let html = http
+        .get(WEB_HOST)
+        .send()
+        .await
+        .map_err(|e| format!("SoundCloud homepage HTTP: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("SoundCloud homepage HTTP: {e}"))?
+        .text()
+        .await
+        .map_err(|e| format!("SoundCloud homepage body: {e}"))?;
+
+    let mut scripts = Vec::new();
+    for chunk in html.split("<script") {
+        if let Some(src) = extract_attr(chunk, "src")
+            && src.contains("sndcdn.com/assets/")
+            && src.ends_with(".js")
+        {
+            scripts.push(src.to_string());
+        }
+    }
+
+    for src in scripts.iter().rev() {
+        if let Ok(resp) = http.get(src).send().await
+            && let Ok(js) = resp.text().await
+            && let Some(id) = find_client_id(&js)
+        {
+            return Ok(id);
+        }
+    }
+    Err("SoundCloud: couldn't extract a client_id from the web player".to_string())
+}
+
+/// Read the value of an HTML `attr="…"` from a fragment, if present.
+fn extract_attr<'a>(chunk: &'a str, attr: &str) -> Option<&'a str> {
+    let key = format!("{attr}=\"");
+    let start = chunk.find(&key)? + key.len();
+    let rest = &chunk[start..];
+    let end = rest.find('"')?;
+    Some(&rest[..end])
+}
+
+/// Locate a `client_id` literal in a JS bundle. SoundCloud emits it as
+/// `client_id:"…"` (and occasionally as a quoted JSON key); both are covered.
+fn find_client_id(js: &str) -> Option<String> {
+    for marker in ["client_id:\"", "\"client_id\":\"", "client_id=\""] {
+        if let Some(pos) = js.find(marker) {
+            let rest = &js[pos + marker.len()..];
+            let id: String = rest
+                .chars()
+                .take_while(|c| c.is_ascii_alphanumeric())
+                .collect();
+            if id.len() >= 16 {
+                return Some(id);
+            }
+        }
+    }
+    None
+}
+
+/// Bump a SoundCloud artwork URL (".../…-large.jpg", 100px) up to a
+/// display-friendly 500px. The CDN honours the `-t500x500` size token, so this
+/// is a plain string swap — falls back to the original URL otherwise.
+fn upscale_artwork(url: &str) -> String {
+    url.replace("-large.", "-t500x500.")
+}
+
+/// Hex-encode a remote artwork URL into the `urlhex_<hex>` tag the shared cover
+/// resolver decodes. Inlined here for the same reason `ytmusic` inlines its own
+/// copy: the `server` crate doesn't depend on `utils`.
+fn encode_cover_url(url: &str) -> String {
+    format!("urlhex_{}", hex::encode(url.as_bytes()))
+}
+
+/// Search the SoundCloud catalog for tracks matching `query`.
+#[tracing::instrument(name = "soundcloud.search", fields(query = %query))]
+pub async fn search_tracks(query: &str) -> Result<Vec<Track>, String> {
+    if query.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let http = http_client();
+
+    let resp = match api_search(&http, query, &client_id(&http, false).await?).await {
+        Ok(v) => v,
+        Err(_) => api_search(&http, query, &client_id(&http, true).await?).await?,
+    };
+
+    let collection = resp
+        .get("collection")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut out = Vec::with_capacity(collection.len());
+    let mut seen = HashSet::new();
+    for item in &collection {
+        if item.get("kind").and_then(|v| v.as_str()) != Some("track") {
+            continue;
+        }
+        if let Some(track) = parse_track(item) {
+            let id = track_id(&track);
+            if !id.is_empty() && seen.insert(id) {
+                out.push(track);
+            }
+        }
+    }
+    Ok(out)
+}
+
+async fn api_search(http: &reqwest::Client, query: &str, cid: &str) -> Result<Value, String> {
+    http.get(format!("{API_V2}/search/tracks"))
+        .query(&[("q", query), ("client_id", cid), ("limit", "50")])
+        .send()
+        .await
+        .map_err(|e| format!("SoundCloud search HTTP: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("SoundCloud search HTTP: {e}"))?
+        .json::<Value>()
+        .await
+        .map_err(|e| format!("SoundCloud search JSON: {e}"))
+}
+
+/// Resolve a track id to a playable progressive MP3 stream URL via the `/tracks`
+/// lookup endpoint. Called lazily at play time (the search results don't need to
+/// round-trip every stream URL through the queue).
+#[tracing::instrument(name = "soundcloud.resolve_stream", fields(track_id = %track_id))]
+pub async fn resolve_stream(track_id: &str) -> Result<String, String> {
+    let http = http_client();
+
+    let track = match lookup_track(&http, track_id, &client_id(&http, false).await?).await {
+        Ok(v) => v,
+        Err(_) => lookup_track(&http, track_id, &client_id(&http, true).await?).await?,
+    };
+
+    let transcodings = track
+        .get("media")
+        .and_then(|m| m.get("transcodings"))
+        .and_then(|t| t.as_array())
+        .ok_or("SoundCloud track exposes no media transcodings")?;
+
+    let progressive_url = transcodings
+        .iter()
+        .find(|tc| transcoding_protocol(tc) == Some("progressive"))
+        .and_then(|tc| tc.get("url"))
+        .and_then(|v| v.as_str())
+        .ok_or("SoundCloud track has no progressive (non-HLS) stream")?;
+
+    let track_auth = track.get("track_authorization").and_then(|v| v.as_str());
+    let cid = client_id(&http, false).await?;
+
+    let mut req = http.get(progressive_url).query(&[("client_id", cid.as_str())]);
+    if let Some(auth) = track_auth {
+        req = req.query(&[("track_authorization", auth)]);
+    }
+
+    let resolved = req
+        .send()
+        .await
+        .map_err(|e| format!("SoundCloud stream resolve HTTP: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("SoundCloud stream resolve HTTP: {e}"))?
+        .json::<Value>()
+        .await
+        .map_err(|e| format!("SoundCloud stream resolve JSON: {e}"))?;
+
+    resolved
+        .get("url")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .ok_or_else(|| "SoundCloud returned no stream URL for this track".to_string())
+}
+
+async fn lookup_track(http: &reqwest::Client, id: &str, cid: &str) -> Result<Value, String> {
+    http.get(format!("{API_V2}/tracks/{id}"))
+        .query(&[("client_id", cid)])
+        .send()
+        .await
+        .map_err(|e| format!("SoundCloud lookup HTTP: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("SoundCloud lookup HTTP: {e}"))?
+        .json::<Value>()
+        .await
+        .map_err(|e| format!("SoundCloud lookup JSON: {e}"))
+}
+
+fn transcoding_protocol(tc: &Value) -> Option<&str> {
+    tc.get("format")
+        .and_then(|f| f.get("protocol"))
+        .and_then(|p| p.as_str())
+}
+
+/// Pull the id segment out of a `soundcloud:<id>[:tag]` track path.
+fn track_id(t: &Track) -> String {
+    t.path
+        .to_string_lossy()
+        .split(':')
+        .nth(1)
+        .unwrap_or("")
+        .to_string()
+}
+
+fn parse_track(item: &Value) -> Option<Track> {
+    let track_id = item.get("id").and_then(|v| v.as_u64())?;
+
+    let has_progressive = item
+        .get("media")
+        .and_then(|m| m.get("transcodings"))
+        .and_then(|t| t.as_array())
+        .is_some_and(|arr| {
+            arr.iter()
+                .any(|tc| transcoding_protocol(tc) == Some("progressive"))
+        });
+    if !has_progressive {
+        return None;
+    }
+
+    let title = item
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let artist = item
+        .get("user")
+        .and_then(|u| u.get("username"))
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+
+    let artwork = item
+        .get("artwork_url")
+        .and_then(|v| v.as_str())
+        .or_else(|| {
+            item.get("user")
+                .and_then(|u| u.get("avatar_url"))
+                .and_then(|v| v.as_str())
+        })
+        .filter(|s| !s.is_empty())
+        .map(upscale_artwork);
+
+    let duration = item
+        .get("full_duration")
+        .and_then(|v| v.as_u64())
+        .or_else(|| item.get("duration").and_then(|v| v.as_u64()))
+        .map(|ms| ms / 1000)
+        .unwrap_or(0);
+
+    let cover_tag = artwork.as_ref().map(|url| encode_cover_url(url));
+    let path = match &cover_tag {
+        Some(tag) => PathBuf::from(format!("{SOURCE_PREFIX}:{track_id}:{tag}")),
+        None => PathBuf::from(format!("{SOURCE_PREFIX}:{track_id}")),
+    };
+    let album_id = match &cover_tag {
+        Some(tag) => format!("{SOURCE_PREFIX}:_:{tag}"),
+        None => format!("{SOURCE_PREFIX}:_"),
+    };
+
+    Some(Track {
+        path,
+        album_id,
+        title,
+        artist: artist.clone(),
+        album: String::new(),
+        duration,
+        khz: 0,
+        bitrate: 0,
+        track_number: None,
+        disc_number: None,
+        musicbrainz_release_id: None,
+        musicbrainz_recording_id: None,
+        musicbrainz_track_id: None,
+        playlist_item_id: None,
+        artists: if artist.is_empty() {
+            Vec::new()
+        } else {
+            vec![artist]
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_client_id_from_bundle_forms() {
+        assert_eq!(
+            find_client_id(r#"foo,client_id:"abcdefghij0123456789",bar"#).as_deref(),
+            Some("abcdefghij0123456789")
+        );
+        assert_eq!(
+            find_client_id(r#"{"client_id":"ABCDEFGHIJ0123456789"}"#).as_deref(),
+            Some("ABCDEFGHIJ0123456789")
+        );
+        assert_eq!(find_client_id(r#"client_id:"short""#), None);
+        assert_eq!(find_client_id("no id here"), None);
+    }
+
+    #[test]
+    fn extract_attr_reads_src() {
+        let chunk = r#" crossorigin src="https://a-v2.sndcdn.com/assets/0-abc.js"></script>"#;
+        assert_eq!(
+            extract_attr(chunk, "src"),
+            Some("https://a-v2.sndcdn.com/assets/0-abc.js")
+        );
+        assert_eq!(extract_attr("<div>", "src"), None);
+    }
+
+    #[test]
+    fn upscale_artwork_swaps_size_token() {
+        assert_eq!(
+            upscale_artwork("https://i1.sndcdn.com/artworks-xyz-large.jpg"),
+            "https://i1.sndcdn.com/artworks-xyz-t500x500.jpg"
+        );
+        assert_eq!(upscale_artwork("https://x/y.png"), "https://x/y.png");
+    }
+
+    #[test]
+    fn parse_track_requires_progressive_transcoding() {
+        let hls_only = serde_json::json!({
+            "id": 1, "title": "t", "kind": "track",
+            "user": {"username": "u"},
+            "media": {"transcodings": [{"url": "x", "format": {"protocol": "hls"}}]}
+        });
+        assert!(parse_track(&hls_only).is_none());
+
+        let ok = serde_json::json!({
+            "id": 42, "title": "Song", "kind": "track",
+            "duration": 215000,
+            "artwork_url": "https://i1.sndcdn.com/artworks-z-large.jpg",
+            "user": {"username": "Artist"},
+            "media": {"transcodings": [{"url": "x", "format": {"protocol": "progressive"}}]}
+        });
+        let t = parse_track(&ok).expect("progressive track parses");
+        assert_eq!(t.title, "Song");
+        assert_eq!(t.artist, "Artist");
+        assert_eq!(t.duration, 215);
+        assert_eq!(track_id(&t), "42");
+        assert!(
+            t.path
+                .to_string_lossy()
+                .starts_with("soundcloud:42:urlhex_")
+        );
+    }
+}

--- a/crates/server/src/soundcloud.rs
+++ b/crates/server/src/soundcloud.rs
@@ -630,8 +630,12 @@ pub async fn set_track_like(
 
     // Public API: POST/DELETE https://api.soundcloud.com/likes/tracks/{id}
     let url = format!("{API_V1}/likes/tracks/{track_id}");
-    let req = if like { http.post(&url) } else { http.delete(&url) }
-        .header("Accept", "application/json; charset=utf-8");
+    let req = if like {
+        http.post(&url)
+    } else {
+        http.delete(&url)
+    }
+    .header("Accept", "application/json; charset=utf-8");
     let resp = apply_auth(req, Some(token))
         .send()
         .await
@@ -640,7 +644,13 @@ pub async fn set_track_like(
         return Ok(());
     }
     let pub_status = resp.status();
-    let pub_body: String = resp.text().await.unwrap_or_default().chars().take(200).collect();
+    let pub_body: String = resp
+        .text()
+        .await
+        .unwrap_or_default()
+        .chars()
+        .take(200)
+        .collect();
     tracing::warn!(%pub_status, pub_body = %pub_body, "soundcloud public-api like failed; trying api-v2");
 
     // Fallback: the web player's api-v2 endpoint (DataDome-gated; needs the
@@ -651,9 +661,13 @@ pub async fn set_track_like(
         .await
         .ok_or("SoundCloud: couldn't resolve the signed-in user id")?;
     let url = format!("{API_V2}/users/{uid}/track_likes/{track_id}?client_id={cid}");
-    let mut req = if like { http.put(url) } else { http.delete(url) }
-        .header("Origin", WEB_HOST)
-        .header("Referer", format!("{WEB_HOST}/"));
+    let mut req = if like {
+        http.put(url)
+    } else {
+        http.delete(url)
+    }
+    .header("Origin", WEB_HOST)
+    .header("Referer", format!("{WEB_HOST}/"));
     if let Some(dd) = datadome.filter(|s| !s.is_empty()) {
         req = req.header("Cookie", format!("datadome={dd}"));
     }

--- a/crates/server/src/soundcloud.rs
+++ b/crates/server/src/soundcloud.rs
@@ -464,8 +464,13 @@ pub async fn stream_liked_tracks<F: FnMut(Vec<Track>)>(
 ) -> Result<(), String> {
     let http = http_client();
     let cid = client_id(&http, false).await?;
+    // `/me/likes/tracks` 404s; the web player reads likes from
+    // `/users/{id}/track_likes` (same base the like-write endpoint uses).
+    let uid = derive_user_id(token)
+        .await
+        .ok_or("SoundCloud: couldn't resolve the signed-in user id")?;
     let mut next = Some(format!(
-        "{API_V2}/me/likes/tracks?client_id={cid}&limit=200&linked_partitioning=1"
+        "{API_V2}/users/{uid}/track_likes?client_id={cid}&limit=200&linked_partitioning=1"
     ));
     let mut pages = 0;
     while let Some(url) = next.take() {
@@ -481,7 +486,16 @@ pub async fn stream_liked_tracks<F: FnMut(Vec<Track>)>(
         let page: Vec<Track> = json
             .get("collection")
             .and_then(|v| v.as_array())
-            .map(|arr| arr.iter().filter_map(parse_track).collect())
+            .map(|arr| {
+                arr.iter()
+                    // `/me/likes/tracks` wraps each entry as
+                    // `{created_at, kind:"like", track:{…}}`; the actual
+                    // track object is nested under "track". Fall back to the
+                    // item itself for endpoints that return bare tracks.
+                    .map(|item| item.get("track").unwrap_or(item))
+                    .filter_map(parse_track)
+                    .collect()
+            })
             .unwrap_or_default();
         if !page.is_empty() {
             on_page(page);
@@ -650,6 +664,16 @@ pub async fn set_track_like(
     let status = resp.status();
     if !status.is_success() {
         let body = resp.text().await.unwrap_or_default();
+        // DataDome answers blocked writes with a captcha-challenge redirect
+        // (HTTP 403 + a geo.captcha-delivery.com URL). Surface a readable
+        // reason instead of dumping the raw challenge payload.
+        if status.as_u16() == 403 || body.contains("captcha-delivery.com") {
+            return Err(
+                "SoundCloud blocks likes outside its web player (DataDome bot \
+                 protection). Like this track in the SoundCloud app or website."
+                    .to_string(),
+            );
+        }
         let body: String = body.chars().take(300).collect();
         return Err(format!("SoundCloud like HTTP {status}: {body}"));
     }

--- a/crates/server/src/ytmusic/isolated_profile.rs
+++ b/crates/server/src/ytmusic/isolated_profile.rs
@@ -41,7 +41,7 @@ pub fn profile_dir(server_id: &str) -> PathBuf {
         .unwrap_or_else(|| PathBuf::from(format!("./{leaf}")))
 }
 
-fn browser_candidates(browser: Browser) -> &'static [&'static str] {
+pub(crate) fn browser_candidates(browser: Browser) -> &'static [&'static str] {
     match browser {
         Browser::Brave => &["brave", "brave-browser"],
         Browser::Chrome => &["google-chrome", "google-chrome-stable", "chrome"],
@@ -109,7 +109,7 @@ fn windows_install_paths(browser: Browser) -> Vec<PathBuf> {
     out
 }
 
-fn find_browser_bin(browser: Browser) -> Option<String> {
+pub(crate) fn find_browser_bin(browser: Browser) -> Option<String> {
     let env_key = format!(
         "KOPUZ_{}_BIN",
         browser.id().to_uppercase().replace('-', "_")
@@ -147,13 +147,13 @@ fn find_browser_bin(browser: Browser) -> Option<String> {
 /// True when running inside a flatpak sandbox. The host browser binary isn't
 /// reachable from the sandbox `/usr`, so launches are proxied to the host via
 /// `flatpak-spawn --host` (which the runtime provides at `/usr/bin`).
-fn in_flatpak() -> bool {
+pub(crate) fn in_flatpak() -> bool {
     std::path::Path::new("/.flatpak-info").exists()
 }
 
 /// Resolve the browser command on the *host* PATH (the sandbox can't stat host
 /// binaries). Probes each candidate with `flatpak-spawn --host command -v`.
-async fn find_host_browser_bin(browser: Browser) -> Option<String> {
+pub(crate) async fn find_host_browser_bin(browser: Browser) -> Option<String> {
     // Honour an explicit override (e.g. a non-standard host install path) — same
     // escape hatch as the native `find_browser_bin`. `flatpak-spawn --host` runs
     // it in the host environment, so an absolute host path works.
@@ -187,7 +187,7 @@ async fn find_host_browser_bin(browser: Browser) -> Option<String> {
 /// `flatpak-spawn --host` when packaged, a plain `Command` natively.
 /// `--watch-bus` ties the host browser's lifetime to ours, so `child.kill()`
 /// (and `kill_on_drop`) still tears it down.
-fn browser_command(bin: &str) -> Command {
+pub(crate) fn browser_command(bin: &str) -> Command {
     if in_flatpak() {
         let mut c = Command::new("flatpak-spawn");
         c.args(["--host", "--watch-bus", bin]);

--- a/crates/utils/src/hls_source.rs
+++ b/crates/utils/src/hls_source.rs
@@ -1,0 +1,156 @@
+//! Minimal HLS assembler for SoundCloud Go+ AAC streams.
+//!
+//! SoundCloud's high-quality (256 kbps AAC) transcoding is delivered as an HLS
+//! media playlist of fragmented-MP4 segments rather than one progressive file.
+//! Symphonia has no HLS demuxer, but a CMAF/fMP4 HLS stream is just an optional
+//! init segment (`#EXT-X-MAP`) followed by media fragments — concatenating them
+//! in order yields a single valid fMP4 byte stream the `isomp4` reader decodes.
+//!
+//! This downloads the playlist and all its segments synchronously and returns
+//! the assembled bytes. It's blocking (built for the player's `spawn_blocking`
+//! decode thread, beside `range_source`) and trades a short up-front download
+//! for dead-simple, fully-seekable in-memory playback.
+
+use std::io::{Error, ErrorKind, Result};
+use std::time::Duration;
+
+fn client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap_or_default()
+}
+
+/// Fetch an HLS media-playlist URL and concatenate its init + media segments
+/// into one contiguous (fMP4) byte buffer.
+pub fn assemble(playlist_url: &str, user_agent: Option<&str>) -> Result<Vec<u8>> {
+    let http = client();
+
+    let mut playlist_req = http.get(playlist_url);
+    if let Some(ua) = user_agent {
+        playlist_req = playlist_req.header("User-Agent", ua);
+    }
+    let playlist = playlist_req
+        .send()
+        .and_then(|r| r.error_for_status())
+        .and_then(|r| r.text())
+        .map_err(|e| Error::other(format!("HLS playlist fetch: {e}")))?;
+
+    let segments = parse_segment_urls(&playlist, playlist_url);
+    if segments.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidData,
+            "HLS playlist had no segments",
+        ));
+    }
+
+    let mut out = Vec::new();
+    for url in segments {
+        let mut seg_req = http.get(&url);
+        if let Some(ua) = user_agent {
+            seg_req = seg_req.header("User-Agent", ua);
+        }
+        let bytes = seg_req
+            .send()
+            .and_then(|r| r.error_for_status())
+            .and_then(|r| r.bytes())
+            .map_err(|e| Error::other(format!("HLS segment fetch: {e}")))?;
+        out.extend_from_slice(&bytes);
+    }
+    Ok(out)
+}
+
+/// Extract the ordered list of absolute segment URLs from a media playlist: the
+/// optional `#EXT-X-MAP` init segment first, then each media segment line.
+fn parse_segment_urls(playlist: &str, playlist_url: &str) -> Vec<String> {
+    let mut urls = Vec::new();
+    for raw in playlist.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("#EXT-X-MAP:") {
+            if let Some(uri) = extract_attr_uri(rest) {
+                urls.push(resolve_url(playlist_url, &uri));
+            }
+            continue;
+        }
+        if line.starts_with('#') {
+            continue;
+        }
+        urls.push(resolve_url(playlist_url, line));
+    }
+    urls
+}
+
+/// Pull `URI="…"` out of an `#EXT-X-MAP` attribute list.
+fn extract_attr_uri(attrs: &str) -> Option<String> {
+    let start = attrs.find("URI=\"")? + 5;
+    let rest = &attrs[start..];
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Resolve a possibly-relative segment reference against the playlist URL.
+fn resolve_url(base: &str, reference: &str) -> String {
+    if reference.starts_with("http://") || reference.starts_with("https://") {
+        return reference.to_string();
+    }
+    if let Some(scheme_end) = base.find("://") {
+        let after_scheme = &base[scheme_end + 3..];
+        if let Some(rel) = reference.strip_prefix('/') {
+            if let Some(host_len) = after_scheme.find('/') {
+                let host = &after_scheme[..host_len];
+                return format!("{}://{host}/{rel}", &base[..scheme_end]);
+            }
+            return format!("{base}/{rel}");
+        }
+        let path_part = base.split('?').next().unwrap_or(base);
+        if let Some(slash) = path_part.rfind('/') {
+            return format!("{}/{reference}", &path_part[..slash]);
+        }
+    }
+    reference.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_map_and_segments_in_order() {
+        let playlist = "#EXTM3U\n\
+            #EXT-X-MAP:URI=\"https://cdn.sndcdn.com/init.mp4\"\n\
+            #EXTINF:6.0,\n\
+            https://cdn.sndcdn.com/seg0.mp4\n\
+            #EXTINF:6.0,\n\
+            https://cdn.sndcdn.com/seg1.mp4\n\
+            #EXT-X-ENDLIST\n";
+        let urls = parse_segment_urls(playlist, "https://api.soundcloud.com/media/x/playlist.m3u8");
+        assert_eq!(
+            urls,
+            vec![
+                "https://cdn.sndcdn.com/init.mp4",
+                "https://cdn.sndcdn.com/seg0.mp4",
+                "https://cdn.sndcdn.com/seg1.mp4",
+            ]
+        );
+    }
+
+    #[test]
+    fn resolves_relative_and_absolute_paths() {
+        let base = "https://cf.sndcdn.com/media/abc/def/playlist.m3u8?token=xyz";
+        assert_eq!(
+            resolve_url(base, "seg1.mp4"),
+            "https://cf.sndcdn.com/media/abc/def/seg1.mp4"
+        );
+        assert_eq!(
+            resolve_url(base, "/other/seg2.mp4"),
+            "https://cf.sndcdn.com/other/seg2.mp4"
+        );
+        assert_eq!(
+            resolve_url(base, "https://x.com/s.mp4"),
+            "https://x.com/s.mp4"
+        );
+    }
+}

--- a/crates/utils/src/hls_source.rs
+++ b/crates/utils/src/hls_source.rs
@@ -14,6 +14,11 @@
 use std::io::{Error, ErrorKind, Result};
 use std::time::Duration;
 
+/// Upper bound on the assembled stream size. A single track's AAC stream is a
+/// few tens of MiB; this 1 GiB cap guards against a malformed/malicious
+/// playlist driving unbounded in-memory growth.
+const MAX_TOTAL_BYTES: usize = 1024 * 1024 * 1024;
+
 fn client() -> reqwest::blocking::Client {
     reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(30))
@@ -55,6 +60,12 @@ pub fn assemble(playlist_url: &str, user_agent: Option<&str>) -> Result<Vec<u8>>
             .and_then(|r| r.error_for_status())
             .and_then(|r| r.bytes())
             .map_err(|e| Error::other(format!("HLS segment fetch: {e}")))?;
+        if out.len().saturating_add(bytes.len()) > MAX_TOTAL_BYTES {
+            return Err(Error::new(
+                ErrorKind::InvalidData,
+                "HLS stream exceeds maximum allowed size",
+            ));
+        }
         out.extend_from_slice(&bytes);
     }
     Ok(out)
@@ -106,9 +117,19 @@ fn resolve_url(base: &str, reference: &str) -> String {
             return format!("{base}/{rel}");
         }
         let path_part = base.split('?').next().unwrap_or(base);
-        if let Some(slash) = path_part.rfind('/') {
+        // Only treat a slash that lies after "scheme://host" as a path
+        // separator — rfind on the whole URL would otherwise match the slash
+        // in "https://" when the base has no path, mangling the result.
+        let after_scheme_start = scheme_end + 3;
+        if let Some(rel) = path_part
+            .get(after_scheme_start..)
+            .and_then(|host_and_path| host_and_path.rfind('/'))
+        {
+            let slash = after_scheme_start + rel;
             return format!("{}/{reference}", &path_part[..slash]);
         }
+        // Host only, no path component: append directly.
+        return format!("{path_part}/{reference}");
     }
     reference.to_string()
 }
@@ -151,6 +172,15 @@ mod tests {
         assert_eq!(
             resolve_url(base, "https://x.com/s.mp4"),
             "https://x.com/s.mp4"
+        );
+        // Base with host only (no path) must not match the scheme's slash.
+        assert_eq!(
+            resolve_url("https://host.com", "seg.mp4"),
+            "https://host.com/seg.mp4"
+        );
+        assert_eq!(
+            resolve_url("https://host.com?token=z", "seg.mp4"),
+            "https://host.com/seg.mp4"
         );
     }
 }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod color;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod hls_source;
 pub mod jellyfin_image;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod logs;


### PR DESCRIPTION
Ye adding soundcloud

<img width="999" height="103" alt="image" src="https://github.com/user-attachments/assets/1e721990-81f8-4d86-9844-e1fa01fb825d" />


<img width="1375" height="827" alt="image" src="https://github.com/user-attachments/assets/743d5d53-ccdc-4dd3-886c-3694f1d3b71f" />

currently loginless and only search and play

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SoundCloud support end-to-end (service selection, browser sign-in, search, playback, and artwork).
  * Added SoundCloud server playlist sync and favorites/likes syncing.
* **Enhancements**
  * Unified cover-art fallback behavior between SoundCloud and YouTube Music in queue and server views.
  * Improved SoundCloud playback with adaptive HLS when available.
* **UI Updates**
  * Updated server settings flow and routing across activity, albums, artists, and playlists.
* **Bug Fixes**
  * Improved SoundCloud playback error handling to prevent stuck loading.
  * SoundCloud playlist actions now respect service capabilities (e.g., reorder behavior, no “remove from playlist” attempt).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->