### PR TITLE
fix(ytmusic): suppress cmd window on windows process spawn

### DIFF
--- a/crates/server/src/ytmusic/decipher/mod.rs
+++ b/crates/server/src/ytmusic/decipher/mod.rs
@@ -40,6 +40,9 @@ use std::time::{Duration, Instant};
 use serde_json::{Value, json};
 use tokio::sync::{mpsc, oneshot};
 
+#[cfg(target_os = "windows")]
+use std::os::windows::process::CommandExt;
+
 const LIB: &str = include_str!("solver/lib.min.js");
 const CORE: &str = include_str!("solver/core.min.js");
 const WEB_UA: &str =
@@ -331,8 +334,10 @@ fn detect_runtime() -> Option<Runtime> {
             },
         ];
         CANDIDATES.iter().copied().find(|c| {
-            std::process::Command::new(c.bin)
-                .arg("--version")
+            let mut cmd = std::process::Command::new(c.bin);
+            #[cfg(target_os = "windows")]
+            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+            cmd.arg("--version")
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .status()
@@ -374,14 +379,17 @@ impl JsEngine for SubprocessEngine {
                     .await
                     .map_err(|e| format!("write solver temp: {e}"))?;
             }
-            let child = match tokio::process::Command::new(rt.bin)
-                .args(rt.args)
-                .arg(&path)
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .kill_on_drop(true)
-                .spawn()
-            {
+            let child = match {
+                let mut cmd = tokio::process::Command::new(rt.bin);
+                #[cfg(target_os = "windows")]
+                cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+                cmd.args(rt.args)
+                    .arg(&path)
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped())
+                    .kill_on_drop(true)
+                    .spawn()
+            } {
                 Ok(c) => c,
                 Err(e) => {
                     let _ = tokio::fs::remove_file(&path).await;


### PR DESCRIPTION
Prevents cmd window popups when JS runtime subprocesses are spawned for YouTube signature deciphering. Adds CREATE_NO_WINDOW flag (0x08000000) to process creation on Windows only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess handling on Windows to prevent unwanted console windows from appearing during background process execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->