### PR TITLE
fix: store now-playing cover artwork in app cache dir instead of system temp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3192,6 +3192,7 @@ version = "0.6.7"
 dependencies = [
  "config",
  "dioxus",
+ "directories",
  "discord-presence",
  "player",
  "radio",

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -25,4 +25,5 @@ tokio = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 discord-presence = { workspace = true }
+directories = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -1255,6 +1255,26 @@ impl PlayerController {
                                         if let Ok(response) = reqwest::get(&cover_url).await
                                             && let Ok(bytes) = response.bytes().await
                                         {
+                                            #[cfg(target_os = "android")]
+                                            let cover_dir = {
+                                                let mut base = player::systemint::get_files_dir()
+                                                    .map(std::path::PathBuf::from)
+                                                    .unwrap_or_else(|| {
+                                                        std::path::PathBuf::from(".")
+                                                    })
+                                                    .join("cache");
+                                                if tokio::fs::create_dir_all(&base)
+                                                    .await
+                                                    .is_err()
+                                                {
+                                                    base = std::path::PathBuf::from("./cache");
+                                                }
+                                                base.join("covers")
+                                            };
+                                            #[cfg(all(
+                                                not(target_arch = "wasm32"),
+                                                not(target_os = "android")
+                                            ))]
                                             let cover_dir = directories::ProjectDirs::from(
                                                 "com",
                                                 "temidaradev",

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -1255,12 +1255,23 @@ impl PlayerController {
                                         if let Ok(response) = reqwest::get(&cover_url).await
                                             && let Ok(bytes) = response.bytes().await
                                         {
-                                            let temp_dir = std::env::temp_dir();
-                                            let random_id: u64 = rand::random();
-                                            let file_path = temp_dir
-                                                .join(format!("kopuz_cover_{}.jpg", random_id));
+                                            let cover_dir = directories::ProjectDirs::from(
+                                                "com",
+                                                "temidaradev",
+                                                "kopuz",
+                                            )
+                                            .map(|d| d.cache_dir().join("covers"))
+                                            .unwrap_or_else(std::env::temp_dir);
 
-                                            if tokio::fs::write(&file_path, bytes).await.is_ok()
+                                            let mut hasher =
+                                                std::collections::hash_map::DefaultHasher::new();
+                                            std::hash::Hash::hash(&cover_url, &mut hasher);
+                                            let cover_hash = std::hash::Hasher::finish(&hasher);
+                                            let file_path = cover_dir
+                                                .join(format!("kopuz_cover_{cover_hash:x}.jpg"));
+
+                                            if tokio::fs::create_dir_all(&cover_dir).await.is_ok()
+                                                && tokio::fs::write(&file_path, bytes).await.is_ok()
                                                 && *play_generation.read() == current_gen
                                             {
                                                 let path_str =


### PR DESCRIPTION
## Summary
Now-playing cover artwork is now written into the dedicated kopuz cache directory (`.../com.temidaradev.kopuz/cache/covers/`) instead of the system temp dir, and the filename is keyed on a stable hash of the cover URL so repeated plays of the same track reuse one file rather than leaking a new `kopuz_cover_<random>.jpg` into Temp on every track.

## Why this matters
Reported in #208: fetched cover images were landing in `AppData\Local\Temp` mixed with unrelated OS files, and because each track wrote a fresh random-id file, the temp directory grew without bound. This moves the artwork into the same app cache location the rest of the project already uses (mirroring `offline_cache_dir` in `crates/pages/src/server/mod.rs` and the `ProjectDirs` cache pattern in `crates/components/src/album_details.rs`). On Android, where `ProjectDirs` paths are not writable, it uses the app-internal files dir via `player::systemint::get_files_dir()` exactly like the `cache_dir` memo in `crates/kopuz/src/main.rs`. If the cache location is unavailable it falls back to the previous temp-dir behavior, so behavior is never worse than today.

## Testing
- `cargo build -p hooks`
- `cargo test -p hooks`
- `cargo fmt -p hooks --check`

Fixes #208


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cover art caching with platform-aware storage directories and persistent file naming, ensuring cover images are reliably cached across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->