### PR TITLE
feat(local): add local file type tag

### DIFF
--- a/crates/components/src/track_row.rs
+++ b/crates/components/src/track_row.rs
@@ -252,6 +252,20 @@ pub fn TrackRow(
     let fmt_dur = |s: u64| format!("{}:{:02}", s / 60, s % 60);
     let duration_str = fmt_dur(track.duration);
 
+    // File-type tag (MP3, FLAC, …) for local tracks. Server/YT tracks use
+    // "service:id" pseudo-paths with no extension, so they get no badge.
+    let file_type = track
+        .path
+        .extension()
+        .and_then(|e| e.to_str())
+        .filter(|e| {
+            matches!(
+                e.to_ascii_lowercase().as_str(),
+                "mp3" | "flac" | "m4a" | "wav" | "ogg" | "opus" | "mp4" | "mka"
+            )
+        })
+        .map(|e| e.to_uppercase());
+
     let columns_modern = if is_album {
         COLUMNS_MODERN_ALBUM
     } else {
@@ -416,6 +430,13 @@ pub fn TrackRow(
                         i {
                             class: "fa-solid fa-arrow-down-to-line text-[9px] shrink-0",
                             style: "color: var(--color-indigo-500); opacity: 0.7;"
+                        }
+                    }
+                    if let Some(ref ft) = file_type {
+                        span {
+                            class: "shrink-0 text-[9px] font-semibold uppercase px-1 py-0.5 rounded leading-none tracking-wide",
+                            style: "background: rgba(255,255,255,0.08); color: var(--color-white); opacity: 0.5;",
+                            "{ft}"
                         }
                     }
                 }
@@ -692,6 +713,13 @@ pub fn TrackRow(
                     },
                     ondoubleclick: move |evt| evt.stop_propagation(),
                     "{track.title}"
+                }
+                if let Some(ref ft) = file_type {
+                    span {
+                        class: "shrink-0 ml-2 text-[9px] font-semibold uppercase px-1 py-0.5 rounded leading-none tracking-wide",
+                        style: "background: rgba(255,255,255,0.08); color: var(--color-white); opacity: 0.5;",
+                        "{ft}"
+                    }
                 }
             }
 

--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -89,6 +89,7 @@
     --tracking-wider: 0.05em;
     --tracking-widest: 0.1em;
     --leading-tight: 1.25;
+    --leading-snug: 1.375;
     --leading-relaxed: 1.625;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
@@ -410,6 +411,9 @@
   }
   .my-4 {
     margin-block: calc(var(--spacing) * 4);
+  }
+  .-mt-2 {
+    margin-top: calc(var(--spacing) * -2);
   }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
@@ -1597,6 +1601,9 @@
   .pr-4 {
     padding-right: calc(var(--spacing) * 4);
   }
+  .pr-6 {
+    padding-right: calc(var(--spacing) * 6);
+  }
   .pr-10 {
     padding-right: calc(var(--spacing) * 10);
   }
@@ -1635,6 +1642,12 @@
   }
   .pl-2 {
     padding-left: calc(var(--spacing) * 2);
+  }
+  .pl-4 {
+    padding-left: calc(var(--spacing) * 4);
+  }
+  .pl-6 {
+    padding-left: calc(var(--spacing) * 6);
   }
   .pl-12 {
     padding-left: calc(var(--spacing) * 12);
@@ -1717,6 +1730,10 @@
     --tw-leading: var(--leading-relaxed);
     line-height: var(--leading-relaxed);
   }
+  .leading-snug {
+    --tw-leading: var(--leading-snug);
+    line-height: var(--leading-snug);
+  }
   .leading-tight {
     --tw-leading: var(--leading-tight);
     line-height: var(--leading-tight);
@@ -1785,6 +1802,12 @@
   }
   .text-amber-400 {
     color: var(--color-amber-400);
+  }
+  .text-amber-400\/80 {
+    color: color-mix(in srgb, oklch(82.8% 0.189 84.429) 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-amber-400) 80%, transparent);
+    }
   }
   .text-black {
     color: var(--color-black);


### PR DESCRIPTION
Local file type tags added

<img width="543" height="720" alt="image" src="https://github.com/user-attachments/assets/d0156b1c-703a-4522-94a4-371537ec3965" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Track rows now display file type badges showing audio/video format (MP3, FLAC, M4A, WAV, OGG, OPUS, MP4, MKA)

* **Style**
  * Added styling improvements including spacing and layout utilities for better visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->