### PR TITLE
feat(yt-music): yt-music general showcase refactor

### DIFF
--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -1158,12 +1158,6 @@
   .border-indigo-400 {
     border-color: var(--color-indigo-400);
   }
-  .border-indigo-400\/40 {
-    border-color: color-mix(in srgb, oklch(67.3% 0.182 276.935) 40%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      border-color: color-mix(in oklab, var(--color-indigo-400) 40%, transparent);
-    }
-  }
   .border-red-500\/20 {
     border-color: color-mix(in srgb, oklch(63.7% 0.237 25.331) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -1319,12 +1313,6 @@
   }
   .bg-indigo-500 {
     background-color: var(--color-indigo-500);
-  }
-  .bg-indigo-500\/10 {
-    background-color: color-mix(in srgb, oklch(58.5% 0.233 277.117) 10%, transparent);
-    @supports (color: color-mix(in lab, red, red)) {
-      background-color: color-mix(in oklab, var(--color-indigo-500) 10%, transparent);
-    }
   }
   .bg-indigo-500\/20 {
     background-color: color-mix(in srgb, oklch(58.5% 0.233 277.117) 20%, transparent);

--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -2303,13 +2303,6 @@
       }
     }
   }
-  .group-hover\:inline-block {
-    &:is(:where(.group):hover *) {
-      @media (hover: hover) {
-        display: inline-block;
-      }
-    }
-  }
   .group-hover\:h-4 {
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
@@ -2851,11 +2844,6 @@
   .active\:cursor-grabbing {
     &:active {
       cursor: grabbing;
-    }
-  }
-  .disabled\:cursor-default {
-    &:disabled {
-      cursor: default;
     }
   }
   .disabled\:cursor-not-allowed {

--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -775,6 +775,9 @@
   .max-w-\[40\%\] {
     max-width: 40%;
   }
+  .max-w-\[300px\] {
+    max-width: 300px;
+  }
   .max-w-\[1600px\] {
     max-width: 1600px;
   }
@@ -951,6 +954,9 @@
   .gap-8 {
     gap: calc(var(--spacing) * 8);
   }
+  .gap-10 {
+    gap: calc(var(--spacing) * 10);
+  }
   .space-y-1 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
@@ -1045,6 +1051,9 @@
   }
   .gap-y-3 {
     row-gap: calc(var(--spacing) * 3);
+  }
+  .self-center {
+    align-self: center;
   }
   .self-start {
     align-self: flex-start;
@@ -1149,6 +1158,12 @@
   .border-indigo-400 {
     border-color: var(--color-indigo-400);
   }
+  .border-indigo-400\/40 {
+    border-color: color-mix(in srgb, oklch(67.3% 0.182 276.935) 40%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-indigo-400) 40%, transparent);
+    }
+  }
   .border-red-500\/20 {
     border-color: color-mix(in srgb, oklch(63.7% 0.237 25.331) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -1207,6 +1222,12 @@
     border-color: color-mix(in srgb, #fff 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       border-color: color-mix(in oklab, var(--color-white) 20%, transparent);
+    }
+  }
+  .border-white\/30 {
+    border-color: color-mix(in srgb, #fff 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      border-color: color-mix(in oklab, var(--color-white) 30%, transparent);
     }
   }
   .border-white\/40 {
@@ -1298,6 +1319,12 @@
   }
   .bg-indigo-500 {
     background-color: var(--color-indigo-500);
+  }
+  .bg-indigo-500\/10 {
+    background-color: color-mix(in srgb, oklch(58.5% 0.233 277.117) 10%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-indigo-500) 10%, transparent);
+    }
   }
   .bg-indigo-500\/20 {
     background-color: color-mix(in srgb, oklch(58.5% 0.233 277.117) 20%, transparent);
@@ -1760,6 +1787,10 @@
     font-size: var(--text-6xl);
     line-height: var(--tw-leading, var(--text-6xl--line-height));
   }
+  .text-7xl {
+    font-size: var(--text-7xl);
+    line-height: var(--tw-leading, var(--text-7xl--line-height));
+  }
   .text-base {
     font-size: var(--text-base);
     line-height: var(--tw-leading, var(--text-base--line-height));
@@ -1800,6 +1831,10 @@
   }
   .text-\[15px\] {
     font-size: 15px;
+  }
+  .leading-\[1\.1\] {
+    --tw-leading: 1.1;
+    line-height: 1.1;
   }
   .leading-none {
     --tw-leading: 1;
@@ -2129,6 +2164,12 @@
   .ring-1 {
     --tw-ring-shadow: var(--tw-ring-inset,) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+  .shadow-black\/30 {
+    --tw-shadow-color: color-mix(in srgb, #000 30%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      --tw-shadow-color: color-mix(in oklab, color-mix(in oklab, var(--color-black) 30%, transparent) var(--tw-shadow-alpha), transparent);
+    }
   }
   .shadow-black\/40 {
     --tw-shadow-color: color-mix(in srgb, #000 40%, transparent);
@@ -2894,6 +2935,11 @@
       width: calc(var(--spacing) * 48);
     }
   }
+  .md\:w-\[320px\] {
+    @media (width >= 48rem) {
+      width: 320px;
+    }
+  }
   .md\:grid-cols-3 {
     @media (width >= 48rem) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -2909,6 +2955,21 @@
       flex-direction: row;
     }
   }
+  .md\:items-start {
+    @media (width >= 48rem) {
+      align-items: flex-start;
+    }
+  }
+  .md\:justify-start {
+    @media (width >= 48rem) {
+      justify-content: flex-start;
+    }
+  }
+  .md\:self-start {
+    @media (width >= 48rem) {
+      align-self: flex-start;
+    }
+  }
   .md\:p-10 {
     @media (width >= 48rem) {
       padding: calc(var(--spacing) * 10);
@@ -2922,6 +2983,16 @@
   .md\:px-10 {
     @media (width >= 48rem) {
       padding-inline: calc(var(--spacing) * 10);
+    }
+  }
+  .md\:pt-2 {
+    @media (width >= 48rem) {
+      padding-top: calc(var(--spacing) * 2);
+    }
+  }
+  .md\:text-left {
+    @media (width >= 48rem) {
+      text-align: left;
     }
   }
   .md\:text-3xl {

--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -1710,6 +1710,9 @@
   .pb-6 {
     padding-bottom: calc(var(--spacing) * 6);
   }
+  .pb-8 {
+    padding-bottom: calc(var(--spacing) * 8);
+  }
   .pb-10 {
     padding-bottom: calc(var(--spacing) * 10);
   }

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -405,9 +405,9 @@ fn AlbumDetail(
     // local DB until saved. When the DB has no row for the id, fetch the album
     // straight from the catalog remote by that browse id so every searched /
     // discovered album renders (header + full track list) instead of "not found".
-    let direct_remote_res: Resource<Option<::server::ytmusic::discover::YtAlbum>> = {
+    let direct_remote_res: Resource<Option<::server::source::RemoteAlbum>> = {
         use_resource(move || {
-            let want = caps().discover && !*is_offline.read();
+            let want = caps().albums == ::server::source::AlbumType::YtMusic && !*is_offline.read();
             let db_has = album_res.read().clone().flatten().is_some();
             let id = album_id_memo();
             let src = active_source.peek().clone();
@@ -495,9 +495,9 @@ fn AlbumDetail(
     // demand and fetch the full album (header + every track), the way YT Music
     // shows it. `None` for local/other sources (gated on `discover`) and while
     // offline; drives both the full track list and the YT-styled header.
-    let remote_album_res: Resource<Option<::server::ytmusic::discover::YtAlbum>> = {
+    let remote_album_res: Resource<Option<::server::source::RemoteAlbum>> = {
         use_resource(move || {
-            let want = caps().discover && !*is_offline.read();
+            let want = caps().albums == ::server::source::AlbumType::YtMusic && !*is_offline.read();
             let album = album_res.read().clone().flatten();
             let src = active_source.peek().clone();
             async move {
@@ -637,7 +637,7 @@ fn AlbumDetail(
 
     rsx! {
         div { class: "absolute inset-0 flex flex-col overflow-hidden p-8",
-            if cap.discover {
+            if cap.albums == ::server::source::AlbumType::YtMusic {
                 YtAlbumDetail {
                     config,
                     title: yt_title,

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -410,9 +410,57 @@ fn AlbumDetail(
         })
     };
 
+    // Catalog remotes (YT) store albums under a title+artist hash with no
+    // browse id, so the library only ever holds the few tracks the user saved —
+    // an album page would show 1 of 18 songs. Resolve the album's browse id on
+    // demand and fetch its full track list, the way YT Music shows it. Empty for
+    // local/other sources (gated on `discover`) and while offline.
+    let remote_album_res = {
+        let active_source = active_source;
+        use_resource(move || {
+            let want = caps().discover && !*is_offline.read();
+            let album = album_res.read().clone().flatten();
+            let src = active_source.peek().clone();
+            async move {
+                let Some(album) = album else {
+                    return Vec::new();
+                };
+                if !want || album.title.trim().is_empty() {
+                    return Vec::new();
+                }
+                let Ok(Some(browse_id)) =
+                    src.resolve_album_browse_id(&album.title, &album.artist).await
+                else {
+                    return Vec::new();
+                };
+                src.fetch_album_tracks(&browse_id).await.unwrap_or_default()
+            }
+        })
+    };
+
     let tracks = use_memo(move || {
         let offline = caps().downloads && *is_offline.read();
         let conf = config.read();
+
+        // Full album from the catalog remote (already in album order). Used
+        // whenever it resolved; the locally-saved subset is the fallback.
+        if !offline {
+            let mut remote = remote_album_res.read().clone().unwrap_or_default();
+            if !remote.is_empty() {
+                remote.sort_by(|a, b| {
+                    a.disc_number
+                        .unwrap_or(1)
+                        .cmp(&b.disc_number.unwrap_or(1))
+                        .then_with(|| {
+                            a.track_number
+                                .unwrap_or(0)
+                                .cmp(&b.track_number.unwrap_or(0))
+                        })
+                });
+                return remote;
+            }
+        }
+
         let mut tracks: Vec<reader::models::Track> = tracks_res
             .read()
             .clone()

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -465,9 +465,7 @@ fn AlbumDetail(
 
         // Full album from the catalog remote (already in album order). Used
         // whenever it resolved; the locally-saved subset is the fallback.
-        if !offline
-            && let Some(remote) = remote_album_res.read().clone().flatten()
-        {
+        if !offline && let Some(remote) = remote_album_res.read().clone().flatten() {
             let mut remote = remote.tracks;
             remote.sort_by(|a, b| {
                 a.disc_number

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -12,7 +12,6 @@ use hooks::db_reactivity::Table;
 use hooks::use_db_queries::{
     use_active_source, use_album, use_album_tracks, use_albums, use_tracks_by_keys,
 };
-use server::source::TrackFavorite;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
@@ -736,8 +735,13 @@ fn YtAlbumDetail(
     let artist_name = artist;
     let artist_for_nav = artist_name.clone();
 
-    // Current track for the row highlight (id match against the live queue).
-    let current_id = ctrl.current_track().map(|t| t.id);
+    // Current track for the row highlight. Read `current_queue_index`
+    // *reactively* (`current_track()` peeks, so the page wouldn't re-render on a
+    // skip) so the highlighted row follows next/prev.
+    let current_id = {
+        let idx = *ctrl.current_queue_index.read();
+        ctrl.get_track_at(idx).map(|t| t.id)
+    };
     let offline_tracks = config.read().offline_tracks.clone();
 
     // Whether every album track is downloaded for offline — drives the download
@@ -751,33 +755,9 @@ fn YtAlbumDetail(
                 .unwrap_or(false)
         });
 
-    // "Saved" = every track favorited (YT Music's album-save has no direct
-    // analog here; the closest truth is the per-track like the heart already
-    // toggles). Re-checked on any favorites bump.
-    let album_saved = {
-        let tracks = tracks.clone();
-        use_resource(move || {
-            let _ = gens.generation(Table::Favorites);
-            let src = active_source.read().clone();
-            let tracks = tracks.clone();
-            async move {
-                if tracks.is_empty() {
-                    return false;
-                }
-                for t in &tracks {
-                    if !t.is_favorite(&src).await {
-                        return false;
-                    }
-                }
-                true
-            }
-        })
-    };
-    let is_saved = album_saved.read().clone().unwrap_or(false);
-
     let tracks_play_all = tracks.clone();
     let tracks_download_all = tracks.clone();
-    let tracks_save = tracks.clone();
+    let artist_for_nav_btn = artist_name.clone();
     // Share target: the album's YT browse link when resolved, else the first
     // track's web url so the button still does something before the fetch lands.
     let share_url = browse_id
@@ -852,29 +832,12 @@ fn YtAlbumDetail(
                             },
                             i { class: if all_downloaded { "fa-solid fa-trash" } else { "fa-solid fa-download" } }
                         }
-                        // Save (favorite all tracks).
+                        // Go to artist.
                         button {
-                            class: format!("w-11 h-11 rounded-full border flex items-center justify-center transition-colors {}", if is_saved { "text-indigo-400 border-indigo-400/40 bg-indigo-500/10" } else { "text-slate-300 border-white/15 hover:text-white hover:border-white/30" }),
-                            title: if is_saved { "Saved".to_string() } else { i18n::t("save").to_string() },
-                            onclick: move |_| {
-                                let want = !is_saved;
-                                let tracks = tracks_save.clone();
-                                let src = active_source.peek().clone();
-                                spawn(async move {
-                                    for t in &tracks {
-                                        if want {
-                                            let _ = src.upsert_tracks(std::slice::from_ref(t)).await;
-                                        }
-                                        let _ = t.set_favorite(&src, want).await;
-                                    }
-                                    gens.bump(Table::Favorites);
-                                    gens.bump(Table::Tracks);
-                                    if src.capabilities().sync {
-                                        hooks::use_sync_task::nudge();
-                                    }
-                                });
-                            },
-                            i { class: if is_saved { "fa-solid fa-bookmark" } else { "fa-regular fa-bookmark" } }
+                            class: "w-11 h-11 rounded-full border border-white/15 flex items-center justify-center text-slate-300 hover:text-white hover:border-white/30 transition-colors",
+                            title: "Go to artist".to_string(),
+                            onclick: move |_| nav_ctrl.navigate_to_artist(artist_for_nav_btn.clone()),
+                            i { class: "fa-solid fa-user" }
                         }
                         // Play (primary).
                         button {

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -12,12 +12,31 @@ use hooks::db_reactivity::Table;
 use hooks::use_db_queries::{
     use_active_source, use_album, use_album_tracks, use_albums, use_tracks_by_keys,
 };
+use server::source::TrackFavorite;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
 use crate::server::download_manager::{
     DownloadQueue, DownloadStatus, delete_downloads, queue_downloads,
 };
+
+/// Copy a link to the clipboard and flash a small toast. Used by the YT album
+/// page's share button (the `track_row` clipboard helper is crate-private to
+/// `components`, so the page carries its own tiny copy).
+fn copy_album_link(url: String) {
+    let value = serde_json::to_string(&url).unwrap_or_else(|_| "\"\"".to_string());
+    let js = format!(
+        "navigator.clipboard.writeText({value}).then(() => {{\
+            let t = document.getElementById('kopuz-toast');\
+            if (!t) {{ t = document.createElement('div'); t.id = 'kopuz-toast';\
+                t.style.cssText = 'position:fixed;left:50%;bottom:88px;transform:translateX(-50%);background:rgba(20,20,20,0.95);color:#fff;padding:10px 18px;border-radius:8px;font:14px system-ui,sans-serif;z-index:99999;box-shadow:0 4px 16px rgba(0,0,0,0.4);pointer-events:none;border:1px solid rgba(255,255,255,0.1);';\
+                document.body.appendChild(t); }}\
+            t.textContent = 'Copied link'; t.style.opacity = '1';\
+            clearTimeout(t._h); t._h = setTimeout(() => {{ t.style.opacity = '0'; }}, 1800);\
+        }}).catch((e) => console.error('clipboard writeText failed', e));"
+    );
+    let _ = dioxus::document::eval(&js);
+}
 
 /// One album-card menu entry, tagged so dispatch survives capability gating.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -413,27 +432,29 @@ fn AlbumDetail(
     // Catalog remotes (YT) store albums under a title+artist hash with no
     // browse id, so the library only ever holds the few tracks the user saved —
     // an album page would show 1 of 18 songs. Resolve the album's browse id on
-    // demand and fetch its full track list, the way YT Music shows it. Empty for
-    // local/other sources (gated on `discover`) and while offline.
-    let remote_album_res = {
+    // demand and fetch the full album (header + every track), the way YT Music
+    // shows it. `None` for local/other sources (gated on `discover`) and while
+    // offline; drives both the full track list and the YT-styled header.
+    let remote_album_res: Resource<Option<::server::ytmusic::discover::YtAlbum>> = {
         let active_source = active_source;
         use_resource(move || {
             let want = caps().discover && !*is_offline.read();
             let album = album_res.read().clone().flatten();
             let src = active_source.peek().clone();
             async move {
-                let Some(album) = album else {
-                    return Vec::new();
-                };
+                let album = album?;
                 if !want || album.title.trim().is_empty() {
-                    return Vec::new();
+                    return None;
                 }
-                let Ok(Some(browse_id)) =
-                    src.resolve_album_browse_id(&album.title, &album.artist).await
-                else {
-                    return Vec::new();
-                };
-                src.fetch_album_tracks(&browse_id).await.unwrap_or_default()
+                let browse_id = src
+                    .resolve_album_browse_id(&album.title, &album.artist)
+                    .await
+                    .ok()
+                    .flatten()?;
+                src.fetch_album(&browse_id)
+                    .await
+                    .ok()
+                    .filter(|a| !a.tracks.is_empty())
             }
         })
     };
@@ -444,21 +465,21 @@ fn AlbumDetail(
 
         // Full album from the catalog remote (already in album order). Used
         // whenever it resolved; the locally-saved subset is the fallback.
-        if !offline {
-            let mut remote = remote_album_res.read().clone().unwrap_or_default();
-            if !remote.is_empty() {
-                remote.sort_by(|a, b| {
-                    a.disc_number
-                        .unwrap_or(1)
-                        .cmp(&b.disc_number.unwrap_or(1))
-                        .then_with(|| {
-                            a.track_number
-                                .unwrap_or(0)
-                                .cmp(&b.track_number.unwrap_or(0))
-                        })
-                });
-                return remote;
-            }
+        if !offline
+            && let Some(remote) = remote_album_res.read().clone().flatten()
+        {
+            let mut remote = remote.tracks;
+            remote.sort_by(|a, b| {
+                a.disc_number
+                    .unwrap_or(1)
+                    .cmp(&b.disc_number.unwrap_or(1))
+                    .then_with(|| {
+                        a.track_number
+                            .unwrap_or(0)
+                            .cmp(&b.track_number.unwrap_or(0))
+                    })
+            });
+            return remote;
         }
 
         let mut tracks: Vec<reader::models::Track> = tracks_res
@@ -546,8 +567,36 @@ fn AlbumDetail(
         })
     };
 
+    // YT-Music-style album page: the whole catalog-remote (YT) side renders this,
+    // from the moment the page opens — header built from the local album row so it
+    // shows instantly, track list filling from the locally-saved subset until the
+    // remote album resolves the full listing. Local / other sources keep the
+    // standard TrackListView.
+    let cover_url_yt = cover_url.clone();
+    let yt_title = album.title.clone();
+    let yt_artist = album.artist.clone();
+    // Prefer the remote album's year once resolved; fall back to the local row.
+    let yt_remote = remote_album_res.read().clone().flatten();
+    let yt_year = yt_remote
+        .as_ref()
+        .and_then(|a| a.year.clone())
+        .or_else(|| (album.year > 0).then(|| album.year.to_string()));
+    let yt_browse_id = yt_remote.as_ref().map(|a| a.browse_id.clone());
+
     rsx! {
         div { class: "absolute inset-0 flex flex-col overflow-hidden p-8",
+            if cap.discover {
+                YtAlbumDetail {
+                    config,
+                    title: yt_title,
+                    artist: yt_artist,
+                    year: yt_year,
+                    browse_id: yt_browse_id,
+                    local_cover: cover_url_yt,
+                    tracks: tracks(),
+                    on_close,
+                }
+            } else {
             TrackListView {
                 name: album_title,
                 description: album_artist,
@@ -650,6 +699,321 @@ fn AlbumDetail(
                     }).collect();
                     delete_downloads(ids, config, download_queue);
                 })),
+            }
+            }
+        }
+    }
+}
+
+/// YT-Music-style album page: a left meta column (cover, artist link, title,
+/// "Album • year", song count · duration, play / shuffle / download) beside the
+/// full track list. Shown only for the catalog remote (YT) once the album
+/// resolved; local/other sources use [`TrackListView`]. Rows reuse [`TrackRow`]
+/// so play / queue / menu / download behave exactly as everywhere else.
+#[component]
+fn YtAlbumDetail(
+    config: Signal<AppConfig>,
+    title: String,
+    artist: String,
+    year: Option<String>,
+    browse_id: Option<String>,
+    local_cover: Option<utils::CoverUrl>,
+    tracks: Vec<reader::models::Track>,
+    on_close: EventHandler<()>,
+) -> Element {
+    let mut ctrl = use_context::<hooks::use_player_controller::PlayerController>();
+    let active_source = use_context::<Signal<::server::source::ActiveSource>>();
+    let nav_ctrl = use_context::<components::NavigationController>();
+    let download_queue = use_context::<Signal<DownloadQueue>>();
+    let gens = hooks::db_reactivity::use_generations();
+    let cover_for = hooks::use_db_queries::use_cover_resolver(80);
+
+    let mut active_menu = use_signal(|| None::<reader::TrackId>);
+    let mut show_playlist_modal = use_signal(|| false);
+    let mut playlist_track = use_signal(|| None::<reader::TrackId>);
+
+    let total: u64 = tracks.iter().map(|t| t.duration).sum();
+    let dur_min = total / 60;
+    let song_count = tracks.len();
+    let artist_name = artist;
+    let artist_for_nav = artist_name.clone();
+
+    // Current track for the row highlight (id match against the live queue).
+    let current_id = ctrl.current_track().map(|t| t.id);
+    let offline_tracks = config.read().offline_tracks.clone();
+
+    // Whether every album track is downloaded for offline — drives the download
+    // button's toggle (download all ⇄ remove all).
+    let all_downloaded = !tracks.is_empty()
+        && tracks.iter().all(|t| {
+            let k = t.id.key();
+            offline_tracks
+                .get(k.as_ref())
+                .map(|p| std::path::Path::new(p).exists())
+                .unwrap_or(false)
+        });
+
+    // "Saved" = every track favorited (YT Music's album-save has no direct
+    // analog here; the closest truth is the per-track like the heart already
+    // toggles). Re-checked on any favorites bump.
+    let album_saved = {
+        let tracks = tracks.clone();
+        use_resource(move || {
+            let _ = gens.generation(Table::Favorites);
+            let src = active_source.read().clone();
+            let tracks = tracks.clone();
+            async move {
+                if tracks.is_empty() {
+                    return false;
+                }
+                for t in &tracks {
+                    if !t.is_favorite(&src).await {
+                        return false;
+                    }
+                }
+                true
+            }
+        })
+    };
+    let is_saved = album_saved.read().clone().unwrap_or(false);
+
+    let tracks_play_all = tracks.clone();
+    let tracks_download_all = tracks.clone();
+    let tracks_save = tracks.clone();
+    // Share target: the album's YT browse link when resolved, else the first
+    // track's web url so the button still does something before the fetch lands.
+    let share_url = browse_id
+        .as_ref()
+        .map(|id| format!("https://music.youtube.com/browse/{id}"))
+        .or_else(|| tracks.first().and_then(|t| active_source.peek().web_url(t)));
+
+    rsx! {
+        div { class: "w-full max-w-[1600px] mx-auto select-none flex-1 min-h-0 flex flex-col",
+            if !cfg!(target_os = "android") {
+                button {
+                    class: "flex items-center gap-2 text-slate-400 hover:text-white transition-colors mb-6 shrink-0 self-start group",
+                    onclick: move |_| on_close.call(()),
+                    i { class: "fa-solid fa-arrow-left text-sm group-hover:-translate-x-0.5 transition-transform" }
+                    span { class: "text-sm font-medium", "{i18n::t(\"back_to_albums\")}" }
+                }
+            }
+
+            div { class: "flex-1 min-h-0 flex flex-col md:flex-row gap-10 overflow-hidden",
+
+                // Left meta column.
+                div { class: "md:w-[320px] shrink-0 flex flex-col items-center md:items-start text-center md:text-left gap-5 md:pt-2",
+                    div {
+                        class: "w-full max-w-[300px] aspect-square rounded-2xl bg-stone-800 overflow-hidden relative shrink-0 shadow-2xl shadow-black/40",
+                        if let Some(url) = &local_cover {
+                            img { src: "{url.as_ref()}", class: "w-full h-full object-cover", decoding: "async" }
+                        } else {
+                            div { class: "w-full h-full flex items-center justify-center text-white/20",
+                                i { class: "fa-solid fa-compact-disc text-7xl" }
+                            }
+                        }
+                    }
+                    div { class: "flex flex-col gap-2 w-full",
+                        button {
+                            class: "text-sm font-semibold text-white/60 hover:text-white hover:underline transition-colors truncate max-w-full self-center md:self-start",
+                            onclick: move |_| nav_ctrl.navigate_to_artist(artist_for_nav.clone()),
+                            "{artist_name}"
+                        }
+                        h1 { class: "text-3xl font-bold text-white leading-[1.1] break-words", "{title}" }
+                        div { class: "text-sm text-slate-400 flex flex-wrap items-center gap-x-2 justify-center md:justify-start",
+                            if let Some(y) = year {
+                                span { class: "uppercase tracking-wide text-xs font-semibold text-white/40", "{i18n::t(\"album\")}" }
+                                span { class: "text-white/30", "•" }
+                                span { "{y}" }
+                                span { class: "text-white/30", "•" }
+                            }
+                            span { "{i18n::t_with(\"showcase_song_count\", &[(\"count\", song_count.to_string())])}" }
+                            span { class: "text-white/30", "•" }
+                            span { "{dur_min} {i18n::t(\"min\")}" }
+                        }
+                    }
+                    div { class: "flex items-center gap-3 mt-1",
+                        // Download all / remove downloads.
+                        button {
+                            class: "w-11 h-11 rounded-full border border-white/15 flex items-center justify-center text-slate-300 hover:text-white hover:border-white/30 transition-colors disabled:opacity-40",
+                            title: if all_downloaded { "Remove download".to_string() } else { "Download".to_string() },
+                            disabled: download_queue.read().is_active(),
+                            onclick: move |_| {
+                                if all_downloaded {
+                                    let ids: Vec<String> = tracks_download_all.iter().filter_map(|t| {
+                                        let k = t.id.key();
+                                        (!k.is_empty()).then(|| k.into_owned())
+                                    }).collect();
+                                    delete_downloads(ids, config, download_queue);
+                                } else {
+                                    let reqs: Vec<(String, String, String)> = tracks_download_all.iter().filter_map(|t| {
+                                        let k = t.id.key();
+                                        (!k.is_empty()).then(|| (k.into_owned(), t.title.clone(), t.artist.clone()))
+                                    }).collect();
+                                    queue_downloads(reqs, config, download_queue);
+                                }
+                            },
+                            i { class: if all_downloaded { "fa-solid fa-trash" } else { "fa-solid fa-download" } }
+                        }
+                        // Save (favorite all tracks).
+                        button {
+                            class: format!("w-11 h-11 rounded-full border flex items-center justify-center transition-colors {}", if is_saved { "text-indigo-400 border-indigo-400/40 bg-indigo-500/10" } else { "text-slate-300 border-white/15 hover:text-white hover:border-white/30" }),
+                            title: if is_saved { "Saved".to_string() } else { i18n::t("save").to_string() },
+                            onclick: move |_| {
+                                let want = !is_saved;
+                                let tracks = tracks_save.clone();
+                                let src = active_source.peek().clone();
+                                spawn(async move {
+                                    for t in &tracks {
+                                        if want {
+                                            let _ = src.upsert_tracks(std::slice::from_ref(t)).await;
+                                        }
+                                        let _ = t.set_favorite(&src, want).await;
+                                    }
+                                    gens.bump(Table::Favorites);
+                                    gens.bump(Table::Tracks);
+                                    if src.capabilities().sync {
+                                        hooks::use_sync_task::nudge();
+                                    }
+                                });
+                            },
+                            i { class: if is_saved { "fa-solid fa-bookmark" } else { "fa-regular fa-bookmark" } }
+                        }
+                        // Play (primary).
+                        button {
+                            class: "w-16 h-16 rounded-full bg-indigo-500 hover:bg-indigo-400 text-black flex items-center justify-center transition-transform hover:scale-105 shadow-lg shadow-black/30",
+                            title: i18n::t("play").to_string(),
+                            onclick: move |_| {
+                                if *ctrl.shuffle.peek() {
+                                    ctrl.play_queue_shuffled(tracks_play_all.clone());
+                                } else {
+                                    ctrl.play_queue_linear(tracks_play_all.clone());
+                                }
+                            },
+                            i { class: "fa-solid fa-play text-2xl ml-1" }
+                        }
+                        // Shuffle.
+                        button {
+                            class: format!("w-11 h-11 rounded-full border flex items-center justify-center transition-colors {}", if *ctrl.shuffle.read() { "text-white bg-white/10 border-white/30" } else { "text-slate-300 border-white/15 hover:text-white hover:border-white/30" }),
+                            title: i18n::t("shuffle").to_string(),
+                            onclick: move |_| ctrl.toggle_shuffle(),
+                            i { class: "fa-solid fa-shuffle" }
+                        }
+                        // Share.
+                        if let Some(url) = share_url {
+                            button {
+                                class: "w-11 h-11 rounded-full border border-white/15 flex items-center justify-center text-slate-300 hover:text-white hover:border-white/30 transition-colors",
+                                title: "Share".to_string(),
+                                onclick: move |_| copy_album_link(url.clone()),
+                                i { class: "fa-solid fa-arrow-up-from-bracket" }
+                            }
+                        }
+                    }
+                }
+
+                // Track list.
+                div { class: "flex-1 min-h-0 overflow-y-auto pb-24",
+                    for (idx, track) in tracks.iter().cloned().enumerate() {
+                        {
+                            let cover_url = cover_for(&track);
+                            let is_menu_open = active_menu.read().as_ref() == Some(&track.id);
+                            let is_current = current_id.as_ref() == Some(&track.id);
+                            let key = track.id.key().into_owned();
+                            let is_downloaded = offline_tracks
+                                .get(&key)
+                                .map(|p| std::path::Path::new(p).exists())
+                                .unwrap_or(false);
+                            let row_tracks = tracks.clone();
+                            let menu_id = track.id.clone();
+                            let pl_id = track.id.clone();
+                            let dl_track = track.clone();
+                            let q_track = track.clone();
+                            rsx! {
+                                components::track_row::TrackRow {
+                                    key: "{track.id.uid()}",
+                                    track: track.clone(),
+                                    cover_url,
+                                    is_album: true,
+                                    hide_delete: true,
+                                    row_num: Some(idx + 1),
+                                    is_menu_open,
+                                    is_currently_playing: is_current,
+                                    is_downloaded,
+                                    on_start_radio: components::track_row::radio_handler(track.clone()),
+                                    on_play: move |_| {
+                                        ctrl.queue.set(row_tracks.clone());
+                                        ctrl.play_track(idx);
+                                    },
+                                    on_queue: Some(EventHandler::new(move |_| {
+                                        ctrl.add_to_queue(vec![q_track.clone()]);
+                                        active_menu.set(None);
+                                    })),
+                                    on_click_menu: move |_| {
+                                        let open = active_menu.read().as_ref() == Some(&menu_id);
+                                        active_menu.set((!open).then(|| menu_id.clone()));
+                                    },
+                                    on_close_menu: move |_| active_menu.set(None),
+                                    on_add_to_playlist: move |_| {
+                                        playlist_track.set(Some(pl_id.clone()));
+                                        show_playlist_modal.set(true);
+                                        active_menu.set(None);
+                                    },
+                                    on_delete: move |_| {},
+                                    on_download: Some(EventHandler::new(move |_| {
+                                        let k = dl_track.id.key();
+                                        if k.is_empty() {
+                                            return;
+                                        }
+                                        let k = k.as_ref();
+                                        let downloaded = config.read().offline_tracks.get(k)
+                                            .map(|p| std::path::Path::new(p).exists())
+                                            .unwrap_or(false);
+                                        if downloaded {
+                                            delete_downloads(vec![k.to_string()], config, download_queue);
+                                        } else {
+                                            queue_downloads(vec![(k.to_string(), dl_track.title.clone(), dl_track.artist.clone())], config, download_queue);
+                                        }
+                                        active_menu.set(None);
+                                    })),
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if *show_playlist_modal.read() {
+                PlaylistModal {
+                    on_close: move |_| {
+                        show_playlist_modal.set(false);
+                        playlist_track.set(None);
+                    },
+                    on_add_to_playlist: move |playlist_id: String| {
+                        if let Some(id) = playlist_track.read().clone() {
+                            let refs = vec![id.key().into_owned()];
+                            let s = active_source.peek().clone();
+                            spawn(async move {
+                                if s.add_to_playlist(&playlist_id, &refs).await.is_ok() {
+                                    gens.bump(Table::Playlists);
+                                }
+                            });
+                        }
+                        show_playlist_modal.set(false);
+                        playlist_track.set(None);
+                    },
+                    on_create_playlist: move |name: String| {
+                        if let Some(id) = playlist_track.read().clone() {
+                            let refs = vec![id.key().into_owned()];
+                            let s = active_source.peek().clone();
+                            spawn(async move {
+                                if s.create_playlist(&name, &refs).await.is_ok() {
+                                    gens.bump(Table::Playlists);
+                                }
+                            });
+                        }
+                        show_playlist_modal.set(false);
+                        playlist_track.set(None);
+                    },
+                }
             }
         }
     }

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -387,11 +387,63 @@ fn AlbumDetail(
     let album_res = use_album(source, album_id_memo);
     let albums_res = use_albums(source);
 
+    // Discover albums are opened by their YT browse id (MPRE…) and aren't in the
+    // local DB until saved. When the DB has no row for the id, fetch the album
+    // straight from the catalog remote by that browse id so every searched /
+    // discovered album renders (header + full track list) instead of "not found".
+    let direct_remote_res: Resource<Option<::server::ytmusic::discover::YtAlbum>> = {
+        let active_source = active_source;
+        use_resource(move || {
+            let want = caps().discover && !*is_offline.read();
+            let db_has = album_res.read().clone().flatten().is_some();
+            let id = album_id_memo();
+            let src = active_source.peek().clone();
+            async move {
+                if !want || db_has || id.trim().is_empty() {
+                    return None;
+                }
+                src.fetch_album(&id)
+                    .await
+                    .ok()
+                    .filter(|a| !a.tracks.is_empty())
+            }
+        })
+    };
+
     let album_loading = album_res.read().is_none();
     let album = match album_res.read().clone().flatten() {
         Some(a) => a,
         None => {
-            if album_loading {
+            // Not saved locally — render the remote album directly if it resolved.
+            if let Some(remote) = direct_remote_res.read().clone().flatten() {
+                let mut tracks = remote.tracks;
+                tracks.sort_by(|a, b| {
+                    a.disc_number
+                        .unwrap_or(1)
+                        .cmp(&b.disc_number.unwrap_or(1))
+                        .then_with(|| {
+                            a.track_number
+                                .unwrap_or(0)
+                                .cmp(&b.track_number.unwrap_or(0))
+                        })
+                });
+                return rsx! {
+                    div { class: "absolute inset-0 flex flex-col overflow-hidden p-8",
+                        YtAlbumDetail {
+                            config,
+                            title: remote.title,
+                            artist: remote.artist.unwrap_or_default(),
+                            year: remote.year,
+                            browse_id: Some(remote.browse_id),
+                            local_cover: remote.thumbnail.map(utils::cover_url_from_string),
+                            tracks,
+                            on_close,
+                        }
+                    }
+                };
+            }
+            // Still resolving (DB miss not yet confirmed, or remote in flight).
+            if album_loading || direct_remote_res.read().is_none() {
                 return rsx! { div {} };
             }
             return rsx! { div { "{i18n::t(\"album_not_found\")}" } };

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -415,27 +415,7 @@ fn AlbumDetail(
                 if !want || db_has || id.trim().is_empty() {
                     return None;
                 }
-                // The id can be a raw browse id (Discover), a
-                // `ytmusic:album:MPRE…` (search rows with an album link), or a
-                // synthesized `ytmusic:album:<hash>` (search rows without one).
-                // Resolve each to a real browse id before fetching.
-                let browse_id = if let Some(bid) = ::server::ytmusic::search::album_browse_id(&id) {
-                    Some(bid)
-                } else if let Some((album, artist)) =
-                    ::server::ytmusic::search::synth_album_parts(&id)
-                {
-                    src.resolve_album_browse_id(&album, &artist)
-                        .await
-                        .ok()
-                        .flatten()
-                } else {
-                    None
-                };
-                let browse_id = browse_id?;
-                src.fetch_album(&browse_id)
-                    .await
-                    .ok()
-                    .filter(|a| !a.tracks.is_empty())
+                src.fetch_album_by_ref(&id).await.ok().flatten()
             }
         })
     };
@@ -525,15 +505,10 @@ fn AlbumDetail(
                 if !want || album.title.trim().is_empty() {
                     return None;
                 }
-                let browse_id = src
-                    .resolve_album_browse_id(&album.title, &album.artist)
+                src.fetch_album_by_meta(&album.title, &album.artist)
                     .await
                     .ok()
-                    .flatten()?;
-                src.fetch_album(&browse_id)
-                    .await
-                    .ok()
-                    .filter(|a| !a.tracks.is_empty())
+                    .flatten()
             }
         })
     };

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -409,7 +409,6 @@ fn AlbumDetail(
     // straight from the catalog remote by that browse id so every searched /
     // discovered album renders (header + full track list) instead of "not found".
     let direct_remote_res: Resource<Option<::server::ytmusic::discover::YtAlbum>> = {
-        let active_source = active_source;
         use_resource(move || {
             let want = caps().discover && !*is_offline.read();
             let db_has = album_res.read().clone().flatten().is_some();
@@ -521,7 +520,6 @@ fn AlbumDetail(
     // shows it. `None` for local/other sources (gated on `discover`) and while
     // offline; drives both the full track list and the YT-styled header.
     let remote_album_res: Resource<Option<::server::ytmusic::discover::YtAlbum>> = {
-        let active_source = active_source;
         use_resource(move || {
             let want = caps().discover && !*is_offline.read();
             let album = album_res.read().clone().flatten();

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -402,7 +402,24 @@ fn AlbumDetail(
                 if !want || db_has || id.trim().is_empty() {
                     return None;
                 }
-                src.fetch_album(&id)
+                // The id can be a raw browse id (Discover), a
+                // `ytmusic:album:MPRE…` (search rows with an album link), or a
+                // synthesized `ytmusic:album:<hash>` (search rows without one).
+                // Resolve each to a real browse id before fetching.
+                let browse_id = if let Some(bid) = ::server::ytmusic::search::album_browse_id(&id) {
+                    Some(bid)
+                } else if let Some((album, artist)) =
+                    ::server::ytmusic::search::synth_album_parts(&id)
+                {
+                    src.resolve_album_browse_id(&album, &artist)
+                        .await
+                        .ok()
+                        .flatten()
+                } else {
+                    None
+                };
+                let browse_id = browse_id?;
+                src.fetch_album(&browse_id)
                     .await
                     .ok()
                     .filter(|a| !a.tracks.is_empty())

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -91,12 +91,12 @@ pub fn Album(
 
     rsx! {
         div {
-            class: if cfg!(target_os = "android") { "px-4 pt-2 pb-28 absolute inset-0 flex flex-col" } else { "p-8 pb-24 absolute inset-0 flex flex-col" },
+            class: if cfg!(target_os = "android") { "px-4 pt-2 pb-28 absolute inset-0 flex flex-col" } else { "px-8 pt-8 absolute inset-0 flex flex-col" },
 
             if album_id.read().is_empty() {
-                div {
+                div { class: "flex-1 min-h-0 flex flex-col",
                     if !cfg!(target_os = "android") {
-                        h1 { class: "text-3xl font-bold text-white mb-6", "{i18n::t(\"all_albums\")}" }
+                        h1 { class: "text-3xl font-bold text-white mb-6 shrink-0", "{i18n::t(\"all_albums\")}" }
                     }
 
                     AlbumGrid {
@@ -229,8 +229,25 @@ fn AlbumGrid(
             .collect::<Vec<_>>()
     });
 
+    // Restore the grid scroll once after the albums first render; guarded so DB
+    // reactivity re-runs don't keep snapping the view back to the saved offset.
+    let mut scroll_restored = use_signal(|| false);
+    use_effect(move || {
+        if *scroll_restored.read() || albums().is_empty() {
+            return;
+        }
+        scroll_restored.set(true);
+        let _ = dioxus::document::eval(&crate::scroll_persist::restore_eval(
+            "album-grid-scroll",
+            "albums",
+        ));
+    });
+
     rsx! {
         div {
+            id: "album-grid-scroll",
+            class: "flex-1 min-h-0 overflow-y-auto pb-8",
+            onscroll: move |e| crate::scroll_persist::save("albums", e.scroll_top()),
             if albums().is_empty() {
                 p { class: "text-slate-500", "{i18n::t(\"no_albums_found\")}" }
             } else {

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -321,11 +321,10 @@ fn AlbumGrid(
                                                     let Some(tag) = tags.get(idx).copied() else { return };
                                                     match tag {
                                                         AlbumAction::Queue => {
-                                                            let s_src = source.peek().clone();
-                                                            let read_db = consume_context::<hooks::ReadDb>();
+                                                            let album_src = active_source.peek().clone();
                                                             let album_id = id.clone();
                                                             spawn(async move {
-                                                                let mut tracks = read_db.album_tracks(&s_src, &album_id).await.unwrap_or_default();
+                                                                let mut tracks = album_src.album_tracks(&album_id).await.unwrap_or_default();
                                                                 tracks.sort_by(|a, b| {
                                                                     a.track_number.cmp(&b.track_number)
                                                                         .then_with(|| a.title.cmp(&b.title))
@@ -339,12 +338,10 @@ fn AlbumGrid(
                                                         }
                                                         AlbumAction::Remove => {
                                                             if cap.delete_from_disk {
-                                                                let s_src = source.peek().clone();
-                                                                let read_db = consume_context::<hooks::ReadDb>();
                                                                 let album_src = active_source.peek().clone();
                                                                 let album_id = id.clone();
                                                                 spawn(async move {
-                                                                    let to_delete = read_db.album_tracks(&s_src, &album_id).await.unwrap_or_default();
+                                                                    let to_delete = album_src.album_tracks(&album_id).await.unwrap_or_default();
                                                                     for track in &to_delete {
                                                                         if let Some(path) = track.id.local_path() {
                                                                             let _ = std::fs::remove_file(path);
@@ -499,14 +496,13 @@ fn AlbumDetail(
         ids
     });
     let tracks_res = {
-        let read_db = use_context::<hooks::ReadDb>();
         use_resource(move || {
             let _ = gens.generation(Table::Tracks);
-            let (read_db, s, ids) = (read_db.clone(), source(), matching_ids());
+            let (src, ids) = (active_source(), matching_ids());
             async move {
                 let mut out = Vec::new();
                 for id in &ids {
-                    out.extend(read_db.album_tracks(&s, id).await.unwrap_or_default());
+                    out.extend(src.album_tracks(id).await.unwrap_or_default());
                 }
                 out
             }

--- a/crates/pages/src/artist.rs
+++ b/crates/pages/src/artist.rs
@@ -242,7 +242,11 @@ pub fn Artist(
                         // instead of re-searching YT.
                         if !url.is_empty() {
                             let _ = source
-                                .set_artist_image(&normalize_artist_key(&name), "server", Some(&url))
+                                .set_artist_image(
+                                    &normalize_artist_key(&name),
+                                    "server",
+                                    Some(&url),
+                                )
                                 .await;
                         }
                         fetched_artist_images.write().insert(name, url);

--- a/crates/pages/src/artist.rs
+++ b/crates/pages/src/artist.rs
@@ -123,7 +123,9 @@ pub fn Artist(
     // image resolution reads. Gated on `sync` so local never runs it; YT yields
     // nothing. The per-service fetch lives behind the facade.
     use_effect(move || {
-        if !caps().sync {
+        // YT resolves its avatars per-artist below; this server path would yield
+        // nothing for it anyway.
+        if !caps().sync || caps().discover {
             return;
         }
         if config.read().artist_photo_source != ArtistPhotoSource::ArtistPhoto {
@@ -153,6 +155,68 @@ pub fn Artist(
         );
     });
 
+    // YT Music: the Artists grid shows real YT artist photos and nothing else.
+    // There's no bulk endpoint, so resolve each library artist's avatar from the
+    // YT "Artists" search, a few in flight at a time, writing results in as they
+    // land so the grid fills progressively. Keyed by display name (the grid reads
+    // `fetched.get(&display)`).
+    use_effect(move || {
+        if !caps().discover {
+            return;
+        }
+        if *images_fetch_done.read() || *is_fetching_images.read() {
+            return;
+        }
+        let albums = albums_res.read().clone().unwrap_or_default();
+        let sample = sample_tracks_res.read().clone().unwrap_or_default();
+        if albums.is_empty() && sample.is_empty() {
+            // Library not loaded yet — wait for a real artist set.
+            return;
+        }
+        let mut names: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for album in &albums {
+            if !album.artist.trim().is_empty() {
+                names.insert(album.artist.clone());
+            }
+        }
+        for track in &sample {
+            for artist in &track.artists {
+                if !artist.trim().is_empty() {
+                    names.insert(artist.clone());
+                }
+            }
+        }
+        if names.is_empty() {
+            return;
+        }
+        // Mark done up front so the effect doesn't respawn as the workers write
+        // partial results back into the map.
+        is_fetching_images.set(true);
+        images_fetch_done.set(true);
+
+        let names: Vec<String> = names.into_iter().collect();
+        let workers = 6usize;
+        let shared = std::sync::Arc::new(std::sync::Mutex::new(names.into_iter()));
+        for _ in 0..workers {
+            let source = active_source.peek().clone();
+            let shared = shared.clone();
+            spawn(
+                async move {
+                    loop {
+                        let Some(name) = shared.lock().ok().and_then(|mut it| it.next()) else {
+                            break;
+                        };
+                        if let Ok(Some(url)) = source.fetch_artist_image(&name).await {
+                            fetched_artist_images.write().insert(name, url);
+                        }
+                    }
+                }
+                .instrument(tracing::info_span!("artist.fetch_yt_images")),
+            );
+        }
+        is_fetching_images.set(false);
+    });
+
     // The artist grid: every artist with a resolved avatar. Avatar precedence is
     // source-agnostic — custom photo, then (when "artist photo" is on) a fetched
     // remote / local-DB photo, then the album cover via the source cover seam.
@@ -162,7 +226,10 @@ pub fn Artist(
         let (overrides, photos) = artist_images_res.read().clone().unwrap_or_default();
         let fetched = fetched_artist_images.read();
         let conf = config.read();
-        let use_photo = conf.artist_photo_source == ArtistPhotoSource::ArtistPhoto;
+        // YT Music: photos are exactly the YT artist avatars — force the photo
+        // path on and drop the album-cover fallback (handled per-artist below).
+        let is_yt = caps().discover;
+        let use_photo = is_yt || conf.artist_photo_source == ArtistPhotoSource::ArtistPhoto;
         let offline = caps().downloads && *is_offline.read();
 
         // norm → (display name, first album cover-path).
@@ -200,6 +267,9 @@ pub fn Artist(
             .into_iter()
             .filter(|(_, (display, _))| !offline || downloaded.contains(&display.to_lowercase()))
             .map(|(norm, (display, album_cover))| {
+                // YT: no album-cover fallback — only the resolved YT photo (None
+                // until it lands → placeholder icon, never an album cover).
+                let album_cover = if is_yt { None } else { album_cover };
                 let cover = ::server::cover::artist(
                     &conf,
                     overrides.get(&norm).map(|p| p.as_path()),

--- a/crates/pages/src/artist.rs
+++ b/crates/pages/src/artist.rs
@@ -204,7 +204,7 @@ pub fn Artist(
         let names: Vec<String> = names
             .into_iter()
             .filter(|n| {
-                !already.contains_key(n) && db_photos.get(&normalize_artist_key(n)).is_none()
+                !already.contains_key(n) && !db_photos.contains_key(&normalize_artist_key(n))
             })
             .collect();
         drop(already);
@@ -224,10 +224,7 @@ pub fn Artist(
             let shared = shared.clone();
             spawn(
                 async move {
-                    loop {
-                        let Some(name) = shared.lock().ok().and_then(|mut it| it.next()) else {
-                            break;
-                        };
+                    while let Some(name) = shared.lock().ok().and_then(|mut it| it.next()) {
                         // Always record an outcome so the grid can tell "resolved,
                         // no photo" (→ album fallback) from "still loading"
                         // (→ placeholder). "" is the no-photo sentinel.
@@ -315,8 +312,8 @@ pub fn Artist(
                 if is_yt
                     && use_photo
                     && !fetched.contains_key(&display)
-                    && overrides.get(&norm).is_none()
-                    && photos.get(&norm).is_none()
+                    && !overrides.contains_key(&norm)
+                    && !photos.contains_key(&norm)
                 {
                     return (display, None);
                 }

--- a/crates/pages/src/artist.rs
+++ b/crates/pages/src/artist.rs
@@ -164,9 +164,21 @@ pub fn Artist(
         if !caps().discover {
             return;
         }
+        if config.read().artist_photo_source != ArtistPhotoSource::ArtistPhoto {
+            return;
+        }
         if *images_fetch_done.read() || *is_fetching_images.read() {
             return;
         }
+        // Wait for the DB artist-image cache to load so we can skip artists whose
+        // photo was persisted on a previous run (otherwise we'd refetch every
+        // time the page opens).
+        let db_imgs = artist_images_res.read();
+        let Some((_, db_photos)) = db_imgs.clone() else {
+            return;
+        };
+        drop(db_imgs);
+
         let albums = albums_res.read().clone().unwrap_or_default();
         let sample = sample_tracks_res.read().clone().unwrap_or_default();
         if albums.is_empty() && sample.is_empty() {
@@ -186,7 +198,18 @@ pub fn Artist(
                 }
             }
         }
+        // Skip artists already resolved this session (context map) or persisted
+        // to the DB on a previous run (keyed by normalized name).
+        let already = fetched_artist_images.read();
+        let names: Vec<String> = names
+            .into_iter()
+            .filter(|n| {
+                !already.contains_key(n) && db_photos.get(&normalize_artist_key(n)).is_none()
+            })
+            .collect();
+        drop(already);
         if names.is_empty() {
+            images_fetch_done.set(true);
             return;
         }
         // Mark done up front so the effect doesn't respawn as the workers write
@@ -194,7 +217,6 @@ pub fn Artist(
         is_fetching_images.set(true);
         images_fetch_done.set(true);
 
-        let names: Vec<String> = names.into_iter().collect();
         let workers = 6usize;
         let shared = std::sync::Arc::new(std::sync::Mutex::new(names.into_iter()));
         for _ in 0..workers {
@@ -206,9 +228,24 @@ pub fn Artist(
                         let Some(name) = shared.lock().ok().and_then(|mut it| it.next()) else {
                             break;
                         };
-                        if let Ok(Some(url)) = source.fetch_artist_image(&name).await {
-                            fetched_artist_images.write().insert(name, url);
+                        // Always record an outcome so the grid can tell "resolved,
+                        // no photo" (→ album fallback) from "still loading"
+                        // (→ placeholder). "" is the no-photo sentinel.
+                        let url = source
+                            .fetch_artist_image(&name)
+                            .await
+                            .ok()
+                            .flatten()
+                            .unwrap_or_default();
+                        // Persist found photos to the DB (kind "server" → the
+                        // grid's `photos` map) so future opens load them instantly
+                        // instead of re-searching YT.
+                        if !url.is_empty() {
+                            let _ = source
+                                .set_artist_image(&normalize_artist_key(&name), "server", Some(&url))
+                                .await;
                         }
+                        fetched_artist_images.write().insert(name, url);
                     }
                 }
                 .instrument(tracing::info_span!("artist.fetch_yt_images")),
@@ -226,10 +263,12 @@ pub fn Artist(
         let (overrides, photos) = artist_images_res.read().clone().unwrap_or_default();
         let fetched = fetched_artist_images.read();
         let conf = config.read();
-        // YT Music: photos are exactly the YT artist avatars — force the photo
-        // path on and drop the album-cover fallback (handled per-artist below).
+        let use_photo = conf.artist_photo_source == ArtistPhotoSource::ArtistPhoto;
+        // YT resolves photos one artist at a time. Until an artist resolves we
+        // render a placeholder rather than its album cover, so the card doesn't
+        // visibly swap album→photo (which read as a loading glitch). The map
+        // carries a "" sentinel for "resolved, no photo" → album fallback.
         let is_yt = caps().discover;
-        let use_photo = is_yt || conf.artist_photo_source == ArtistPhotoSource::ArtistPhoto;
         let offline = caps().downloads && *is_offline.read();
 
         // norm → (display name, first album cover-path).
@@ -267,14 +306,26 @@ pub fn Artist(
             .into_iter()
             .filter(|(_, (display, _))| !offline || downloaded.contains(&display.to_lowercase()))
             .map(|(norm, (display, album_cover))| {
-                // YT: no album-cover fallback — only the resolved YT photo (None
-                // until it lands → placeholder icon, never an album cover).
-                let album_cover = if is_yt { None } else { album_cover };
+                // YT + photos on, artist not resolved yet → placeholder (no album
+                // flash). Unless the user set a custom override / DB photo exists.
+                if is_yt
+                    && use_photo
+                    && !fetched.contains_key(&display)
+                    && overrides.get(&norm).is_none()
+                    && photos.get(&norm).is_none()
+                {
+                    return (display, None);
+                }
+                // "" sentinel = resolved with no photo → fall back to album cover.
+                let fetched_url = fetched
+                    .get(&display)
+                    .map(|u| u.as_str())
+                    .filter(|u| !u.is_empty());
                 let cover = ::server::cover::artist(
                     &conf,
                     overrides.get(&norm).map(|p| p.as_path()),
                     photos.get(&norm),
-                    fetched.get(&display).map(|u| u.as_str()),
+                    fetched_url,
                     album_cover.as_deref(),
                     use_photo,
                     320,
@@ -284,6 +335,24 @@ pub fn Artist(
             .collect();
         out.sort_by_key(|a| a.0.to_lowercase());
         out
+    });
+
+    // Restore the grid's scroll position once, after the artist list first
+    // renders. Guarded so the incremental photo loads (which re-run the memo)
+    // don't keep yanking the view back to the saved offset.
+    let mut scroll_restored = use_signal(|| false);
+    use_effect(move || {
+        if *scroll_restored.read() || !artist_name.peek().is_empty() {
+            return;
+        }
+        if artists().is_empty() {
+            return;
+        }
+        scroll_restored.set(true);
+        let _ = dioxus::document::eval(&crate::scroll_persist::restore_eval(
+            "artist-grid-scroll",
+            "artists",
+        ));
     });
 
     let artist_tracks = use_memo(move || {
@@ -393,7 +462,10 @@ pub fn Artist(
                     if !cfg!(target_os = "android") {
                         h1 { class: "text-3xl font-bold text-white mb-6 shrink-0", "{i18n::t(\"artists\")}" }
                     }
-                    div { class: "flex-1 min-h-0 overflow-y-auto pb-20",
+                    div {
+                        id: "artist-grid-scroll",
+                        class: "flex-1 min-h-0 overflow-y-auto pb-20",
+                        onscroll: move |e| crate::scroll_persist::save("artists", e.scroll_top()),
                         div { class: "grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-8",
                             for (artist , cover_url) in artists() {
                                 {

--- a/crates/pages/src/artist.rs
+++ b/crates/pages/src/artist.rs
@@ -666,12 +666,10 @@ pub fn Artist(
                                     on_close: move |_| show_album_playlist_modal.set(false),
                                     on_add_to_playlist: move |playlist_id: String| {
                                         if let Some(album_id) = pending_album_id_for_playlist.read().clone() {
-                                            let s_src = source.peek().clone();
-                                            let read_db = consume_context::<hooks::ReadDb>();
                                             let s = active_source.peek().clone();
                                             spawn(async move {
-                                                let refs: Vec<String> = read_db
-                                                    .album_tracks(&s_src, &album_id)
+                                                let refs: Vec<String> = s
+                                                    .album_tracks(&album_id)
                                                     .await
                                                     .unwrap_or_default()
                                                     .iter()
@@ -692,13 +690,11 @@ pub fn Artist(
                                     },
                                     on_create_playlist: move |playlist_name: String| {
                                         let album_id = pending_album_id_for_playlist.read().clone();
-                                        let s_src = source.peek().clone();
-                                        let read_db = consume_context::<hooks::ReadDb>();
                                         let s = active_source.peek().clone();
                                         spawn(async move {
                                             let refs: Vec<String> = match album_id {
-                                                Some(id) => read_db
-                                                    .album_tracks(&s_src, &id)
+                                                Some(id) => s
+                                                    .album_tracks(&id)
                                                     .await
                                                     .unwrap_or_default()
                                                     .iter()
@@ -821,11 +817,10 @@ pub fn Artist(
                                                                     let Some(tag) = tags.get(idx).copied() else { return };
                                                                     match tag {
                                                                         AlbumAction::Queue => {
-                                                                            let s_src = source.peek().clone();
-                                                                            let read_db = consume_context::<hooks::ReadDb>();
+                                                                            let album_src = active_source.peek().clone();
                                                                             let album_id = id.clone();
                                                                             spawn(async move {
-                                                                                let mut tracks = read_db.album_tracks(&s_src, &album_id).await.unwrap_or_default();
+                                                                                let mut tracks = album_src.album_tracks(&album_id).await.unwrap_or_default();
                                                                                 tracks.sort_by(|a, b| {
                                                                                     a.track_number.cmp(&b.track_number)
                                                                                         .then_with(|| a.title.cmp(&b.title))
@@ -839,12 +834,10 @@ pub fn Artist(
                                                                             show_album_playlist_modal.set(true);
                                                                         }
                                                                         AlbumAction::DeleteAlbum => {
-                                                                            let read_db = consume_context::<hooks::ReadDb>();
                                                                             let s = active_source.peek().clone();
-                                                                            let s_src = source.peek().clone();
                                                                             let album_id = id.clone();
                                                                             spawn(async move {
-                                                                                let to_delete = read_db.album_tracks(&s_src, &album_id).await.unwrap_or_default();
+                                                                                let to_delete = s.album_tracks(&album_id).await.unwrap_or_default();
                                                                                 for track in &to_delete {
                                                                                     if let Some(path) = track.id.local_path() {
                                                                                         let _ = std::fs::remove_file(path);
@@ -857,11 +850,10 @@ pub fn Artist(
                                                                             });
                                                                         }
                                                                         AlbumAction::Download { downloaded } => {
-                                                                            let s_src = source.peek().clone();
-                                                                            let read_db = consume_context::<hooks::ReadDb>();
+                                                                            let album_src = active_source.peek().clone();
                                                                             let album_id = id.clone();
                                                                             spawn(async move {
-                                                                                let tracks = read_db.album_tracks(&s_src, &album_id).await.unwrap_or_default();
+                                                                                let tracks = album_src.album_tracks(&album_id).await.unwrap_or_default();
                                                                                 if downloaded {
                                                                                     let ids: Vec<String> = tracks.iter().filter_map(|t| {
                                                                                         let k = t.id.key();

--- a/crates/pages/src/lib.rs
+++ b/crates/pages/src/lib.rs
@@ -9,6 +9,7 @@ pub mod layout;
 pub mod library;
 pub mod playlists;
 pub mod radio;
+pub mod scroll_persist;
 pub mod search;
 pub mod server;
 pub mod settings;

--- a/crates/pages/src/scroll_persist.rs
+++ b/crates/pages/src/scroll_persist.rs
@@ -1,0 +1,37 @@
+//! Per-view scroll-position memory for pages whose list scrolls inside their own
+//! inner container (Artists, Albums) rather than the shell's `main-scroll-area`.
+//! The shell only persists scroll for elements it owns, so those inner scrollers
+//! reset to the top every visit. This keeps the last position per string key,
+//! process-lifetime, restored once after the list first renders.
+//!
+//! UI runs single-threaded, so a `thread_local` map is enough — no locking, no
+//! cross-crate context plumbing.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+
+thread_local! {
+    static POSITIONS: RefCell<HashMap<String, f64>> = RefCell::new(HashMap::new());
+}
+
+/// Remember `top` as the scroll offset for `key` (called from `onscroll`).
+pub fn save(key: &str, top: f64) {
+    POSITIONS.with(|m| {
+        m.borrow_mut().insert(key.to_string(), top);
+    });
+}
+
+/// Last saved offset for `key`, or 0.0 if none.
+pub fn get(key: &str) -> f64 {
+    POSITIONS.with(|m| m.borrow().get(key).copied().unwrap_or(0.0))
+}
+
+/// JS that restores element `el_id`'s `scrollTop` to the saved offset for `key`
+/// on the next frame (after the list has painted). No-op when nothing saved.
+pub fn restore_eval(el_id: &str, key: &str) -> String {
+    let pos = get(key);
+    format!(
+        "requestAnimationFrame(() => {{ let el = document.getElementById('{el_id}'); \
+         if (el) el.scrollTop = {pos}; }});"
+    )
+}

--- a/crates/pages/src/server/discover.rs
+++ b/crates/pages/src/server/discover.rs
@@ -414,7 +414,7 @@ fn DiscoverTile(
             subtitle,
             thumbnail,
         } => {
-            let title_for_click = title.clone();
+            let bid_for_click = browse_id.clone();
             let bid_for_play = browse_id.clone();
             let bid_for_source = browse_id.clone();
             rsx! {
@@ -424,7 +424,7 @@ fn DiscoverTile(
                     thumbnail: thumbnail,
                     rounded_full: false,
                     onclick: move |_| {
-                        on_select_playlist.call((browse_id.clone(), title_for_click.clone()))
+                        on_select_album.call(bid_for_click.clone())
                     },
                     on_play: EventHandler::new(move |_| {
                         play_playlist_async(bid_for_play.clone(), ctrl, now_playing, cache);
@@ -678,7 +678,7 @@ fn Card(
                 }
                 if let Some(play) = on_play {
                     button {
-                        class: "absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 bg-black/40 transition-opacity duration-200 cursor-pointer",
+                        class: "absolute right-3 bottom-3 w-10 h-10 bg-white text-black rounded-full flex items-center justify-center shadow-lg translate-y-4 opacity-0 group-hover:translate-y-0 group-hover:opacity-100 transition-all duration-300 cursor-pointer",
                         onclick: move |e: MouseEvent| {
                             e.stop_propagation();
                             if show_loading {
@@ -692,11 +692,11 @@ fn Card(
                         },
                         i {
                             class: if show_loading {
-                                "fa-solid fa-arrows-rotate fa-spin text-white text-2xl"
+                                "fa-solid fa-arrows-rotate fa-spin text-sm"
                             } else if show_pause {
-                                "fa-solid fa-pause text-white text-2xl"
+                                "fa-solid fa-pause text-sm"
                             } else {
-                                "fa-solid fa-play text-white text-2xl"
+                                "fa-solid fa-play ml-0.5 text-sm"
                             }
                         }
                     }
@@ -929,11 +929,10 @@ pub fn DiscoverPlaylistDetail(
 ) -> Element {
     let config = use_context::<Signal<AppConfig>>();
     let active_source = use_context::<Signal<::server::source::ActiveSource>>();
-    let mut ctrl = use_context::<hooks::use_player_controller::PlayerController>();
-    let mut now_playing = use_context::<DiscoverNowPlaying>().0;
     let mut tracks = use_signal(Vec::<Track>::new);
     let mut loading = use_signal(|| true);
     let mut error = use_signal(|| None::<String>);
+    let cover_for = hooks::use_db_queries::use_cover_resolver(512);
 
     let playlist_id = selected_playlist_id.read().clone();
     let header_title = selected_playlist_title
@@ -1011,110 +1010,56 @@ pub fn DiscoverPlaylistDetail(
         };
     }
 
-    rsx! {
-        div { class: "p-6 md:p-10 max-w-[1600px] mx-auto",
-            button {
-                class: "inline-flex items-center gap-2 text-white/70 hover:text-white text-sm cursor-pointer mb-6 group",
-                onclick: move |_| on_back.call(()),
-                i { class: "fa-solid fa-chevron-left text-xs transition-transform group-hover:-translate-x-0.5" }
-                span { "{i18n::t(\"back\")}" }
-            }
-            div { class: "flex items-end gap-6 mb-8",
-                div { class: "min-w-0",
-                    p { class: "text-[10px] font-bold tracking-widest uppercase text-white/40 mb-2", "{i18n::t(\"playlist\")}" }
-                    h1 { class: "text-3xl md:text-5xl font-black text-white break-words", "{header_title}" }
-                    if !*loading.read() {
-                        p { class: "text-sm text-white/50 mt-3",
-                            "{i18n::t_with(\"playlist_track_count\", &[(\"count\", tracks.read().len().to_string())])}"
-                        }
-                    }
-                }
-                button {
-                    class: "shrink-0 inline-flex items-center gap-3 bg-white text-black px-8 py-3 rounded-full font-bold hover:bg-white/90 hover:scale-105 active:scale-95 transition-all cursor-pointer disabled:opacity-40 disabled:cursor-default",
-                    disabled: *loading.read() || tracks.read().is_empty(),
-                    onclick: move |_| {
-                        let all = tracks.read().clone();
-                        if !all.is_empty() {
-                            if let Some(pid) = selected_playlist_id.read().clone() {
-                                now_playing.set(Some(pid));
-                            }
-                            ctrl.play_queue_linear(all);
-                        }
-                    },
-                    i { class: "fa-solid fa-play text-[10px]" }
-                    span { class: "text-sm", "{i18n::t(\"start_listening\")}" }
-                }
-            }
-
-            if *loading.read() {
+    // Loading / error keep a lightweight header + back button; the loaded state
+    // hands off to the shared modern TrackListView (same look as the local
+    // playlist / album pages) so Discover playlists match everywhere else.
+    if *loading.read() {
+        return rsx! {
+            div { class: "p-6 md:p-10 max-w-[1600px] mx-auto",
+                BackButton { on_back }
                 div { class: "flex justify-center py-24",
                     i { class: "fa-solid fa-arrows-rotate fa-spin text-2xl text-white/60" }
                 }
-            } else if let Some(err) = error.read().clone() {
+            }
+        };
+    }
+    if let Some(err) = error.read().clone() {
+        return rsx! {
+            div { class: "p-6 md:p-10 max-w-[1600px] mx-auto",
+                BackButton { on_back }
                 div { class: "py-12 text-rose-400 text-sm",
                     "{i18n::t_with(\"discover_failed\", &[(\"error\", err.clone())])}"
                 }
-            } else {
-                div { class: "flex flex-col",
-                    for (idx, track) in tracks.read().iter().enumerate() {
-                        DiscoverPlaylistRow {
-                            key: "{idx}",
-                            track: track.clone(),
-                            index: idx + 1,
-                            on_play: move |t: Track| {
-                                let mut queue = tracks.read().clone();
-                                let start_idx = queue
-                                    .iter()
-                                    .position(|x| x.id == t.id)
-                                    .unwrap_or(0);
-                                queue.rotate_left(start_idx);
-                                if let Some(pid) = selected_playlist_id.read().clone() {
-                                    now_playing.set(Some(pid));
-                                }
-                                ctrl.play_queue_linear(queue);
-                            },
-                        }
-                    }
-                }
+            }
+        };
+    }
+
+    let track_list = tracks.read().clone();
+    let cover_url = track_list.first().and_then(&cover_for);
+
+    rsx! {
+        div { class: "absolute inset-0 flex flex-col overflow-hidden p-8",
+            components::track_list_view::TrackListView {
+                name: header_title.clone(),
+                description: String::new(),
+                cover_url,
+                back_label: i18n::t("back").to_string(),
+                tracks: track_list,
+                is_album: false,
+                on_close: move |_| on_back.call(()),
             }
         }
     }
 }
 
 #[component]
-fn DiscoverPlaylistRow(track: Track, index: usize, on_play: EventHandler<Track>) -> Element {
-    let thumbnail = utils::jellyfin_image::resolve_track_cover(
-        track.cover.as_deref(),
-        &track.id.key(),
-        &track.album_id,
-        "",
-        None,
-        96,
-        80,
-    );
-    let title = track.title.clone();
-    let artist = track.artist.clone();
-    let track_for_click = track.clone();
+fn BackButton(on_back: EventHandler<()>) -> Element {
     rsx! {
         button {
-            class: "group flex items-center gap-4 px-3 py-2 rounded-lg hover:bg-white/5 transition-colors text-left cursor-pointer w-full",
-            onclick: move |_| on_play.call(track_for_click.clone()),
-            span { class: "w-8 text-right text-white/40 text-xs tabular-nums group-hover:hidden", "{index}" }
-            i { class: "w-8 text-center fa-solid fa-play text-white text-xs hidden group-hover:inline-block" }
-            if let Some(url) = thumbnail {
-                img {
-                    src: "{url}",
-                    class: "w-11 h-11 object-cover rounded bg-white/5",
-                    loading: "lazy",
-                    decoding: "async",
-                }
-            } else {
-                div { class: "w-11 h-11 rounded bg-white/5" }
-            }
-            div { class: "min-w-0 flex-1",
-                p { class: "text-sm text-white font-medium truncate", "{title}" }
-                p { class: "text-xs text-white/50 truncate", "{artist}" }
-            }
+            class: "inline-flex items-center gap-2 text-white/70 hover:text-white text-sm cursor-pointer mb-6 group",
+            onclick: move |_| on_back.call(()),
+            i { class: "fa-solid fa-chevron-left text-xs transition-transform group-hover:-translate-x-0.5" }
+            span { "{i18n::t(\"back\")}" }
         }
     }
 }

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -126,6 +126,19 @@ pub enum FavoritesSync {
     Paginated,
 }
 
+/// How the album page renders, routed on this instead of hardcoding a service.
+/// `Standard` is the library-driven [`TrackListView`]; `YtMusic` is the rich
+/// catalog-remote page (header + on-demand full track list resolved from the
+/// remote). Catalog remotes that store albums by a title+artist hash with no
+/// full local track list select `YtMusic`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlbumType {
+    /// Standard album page from the local/library tracks.
+    Standard,
+    /// YT-Music-style page: instant header, full track list pulled on demand.
+    YtMusic,
+}
+
 /// One page of paginated favorites: the tracks plus the cursor for the next page
 /// (`None` once exhausted). Cross-page dedup is the caller's job.
 pub struct FavoritesPage {
@@ -177,6 +190,8 @@ pub struct Capabilities {
     pub playlists: PlaylistOps,
     /// How the artists tab renders a selected artist.
     pub artist_view: ArtistView,
+    /// How the album page renders.
+    pub albums: AlbumType,
     /// How favorites sync — one shot vs paginated (streamed with progress).
     pub favorites_sync: FavoritesSync,
 }
@@ -211,6 +226,36 @@ pub struct PlaylistMeta {
     pub id: String,
     pub name: String,
     pub image_tag: Option<String>,
+}
+
+/// A full remote album — header metadata + every track — for the YT-Music-style
+/// album page, transformed into the generic model types. Source-agnostic: the
+/// album page renders this without reaching into any per-service catalog struct.
+/// `browse_id`/`audio_playlist_id` are opaque remote ids (the catalog uses them
+/// to re-fetch / start the album radio); `None` where the source has none.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RemoteAlbum {
+    pub browse_id: String,
+    pub title: String,
+    pub artist: Option<String>,
+    pub year: Option<String>,
+    pub thumbnail: Option<String>,
+    pub audio_playlist_id: Option<String>,
+    pub tracks: Vec<reader::Track>,
+}
+
+impl From<crate::ytmusic::discover::YtAlbum> for RemoteAlbum {
+    fn from(a: crate::ytmusic::discover::YtAlbum) -> Self {
+        Self {
+            browse_id: a.browse_id,
+            title: a.title,
+            artist: a.artist,
+            year: a.year,
+            thumbnail: a.thumbnail,
+            audio_playlist_id: a.audio_playlist_id,
+            tracks: a.tracks,
+        }
+    }
 }
 
 /// The source-agnostic backend the app drives. Impls supply
@@ -349,10 +394,7 @@ pub trait MediaSource: Send + Sync {
 
     /// The full remote album (header metadata + tracks) for the YT-Music-style
     /// album page. Default unsupported; only catalog remotes (YT) override.
-    async fn fetch_album(
-        &self,
-        _browse_id: &str,
-    ) -> Result<crate::ytmusic::discover::YtAlbum, SourceError> {
+    async fn fetch_album(&self, _browse_id: &str) -> Result<RemoteAlbum, SourceError> {
         Err(SourceError::unsupported("album"))
     }
 
@@ -362,10 +404,7 @@ pub trait MediaSource: Send + Sync {
     /// be resolved or has no tracks. The id→browse-id→album dance lives here so the
     /// UI never reaches into the per-service catalog. Default unsupported; only
     /// catalog remotes (YT) override.
-    async fn fetch_album_by_ref(
-        &self,
-        _id: &str,
-    ) -> Result<Option<crate::ytmusic::discover::YtAlbum>, SourceError> {
+    async fn fetch_album_by_ref(&self, _id: &str) -> Result<Option<RemoteAlbum>, SourceError> {
         Err(SourceError::unsupported("album by ref"))
     }
 
@@ -378,7 +417,7 @@ pub trait MediaSource: Send + Sync {
         &self,
         _title: &str,
         _artist: &str,
-    ) -> Result<Option<crate::ytmusic::discover::YtAlbum>, SourceError> {
+    ) -> Result<Option<RemoteAlbum>, SourceError> {
         Err(SourceError::unsupported("album by meta"))
     }
 
@@ -948,6 +987,7 @@ impl MediaSource for LocalSource {
             radio: false,
             playlists: PlaylistOps::Reorder,
             artist_view: ArtistView::Library,
+            albums: AlbumType::Standard,
             favorites_sync: FavoritesSync::Instant,
         }
     }
@@ -1055,6 +1095,7 @@ impl MediaSource for OfflineServerSource {
             radio: false,
             playlists: PlaylistOps::None,
             artist_view: ArtistView::Library,
+            albums: AlbumType::Standard,
             favorites_sync: FavoritesSync::Instant,
         }
     }
@@ -1307,6 +1348,7 @@ impl MediaSource for JellyfinSource {
             radio: false,
             playlists: PlaylistOps::Reorder,
             artist_view: ArtistView::Library,
+            albums: AlbumType::Standard,
             favorites_sync: FavoritesSync::Instant,
         }
     }
@@ -1651,6 +1693,7 @@ impl MediaSource for SubsonicSource {
             radio: false,
             playlists: PlaylistOps::Reorder,
             artist_view: ArtistView::Library,
+            albums: AlbumType::Standard,
             favorites_sync: FavoritesSync::Instant,
         }
     }
@@ -1863,6 +1906,7 @@ impl MediaSource for YtSource {
             radio: true,
             playlists: PlaylistOps::AddRemove,
             artist_view: ArtistView::Remote,
+            albums: AlbumType::YtMusic,
             favorites_sync: FavoritesSync::Paginated,
         }
     }
@@ -1915,20 +1959,15 @@ impl MediaSource for YtSource {
             .map_err(SourceError::from)
     }
 
-    async fn fetch_album(
-        &self,
-        browse_id: &str,
-    ) -> Result<crate::ytmusic::discover::YtAlbum, SourceError> {
+    async fn fetch_album(&self, browse_id: &str) -> Result<RemoteAlbum, SourceError> {
         self.client
             .fetch_album(browse_id)
             .await
+            .map(RemoteAlbum::from)
             .map_err(SourceError::from)
     }
 
-    async fn fetch_album_by_ref(
-        &self,
-        id: &str,
-    ) -> Result<Option<crate::ytmusic::discover::YtAlbum>, SourceError> {
+    async fn fetch_album_by_ref(&self, id: &str) -> Result<Option<RemoteAlbum>, SourceError> {
         // Resolve the id (raw browse id, `ytmusic:album:MPRE…`, or a synthesized
         // `ytmusic:album:<hash>`) to a real browse id before fetching.
         let browse_id = if let Some(bid) = crate::ytmusic::search::album_browse_id(id) {
@@ -1952,7 +1991,7 @@ impl MediaSource for YtSource {
         &self,
         title: &str,
         artist: &str,
-    ) -> Result<Option<crate::ytmusic::discover::YtAlbum>, SourceError> {
+    ) -> Result<Option<RemoteAlbum>, SourceError> {
         let Some(browse_id) = self.resolve_album_browse_id(title, artist).await? else {
             return Ok(None);
         };
@@ -2294,6 +2333,7 @@ impl MediaSource for SoundcloudSource {
             // No write side wired (api-v2 playlist mutation is DataDome-gated).
             playlists: PlaylistOps::None,
             artist_view: ArtistView::Library,
+            albums: AlbumType::Standard,
             favorites_sync: FavoritesSync::Paginated,
         }
     }

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -366,6 +366,18 @@ pub trait MediaSource: Send + Sync {
         Err(SourceError::unsupported("artist channel"))
     }
 
+    /// Resolve a saved album's title + artist to a remote album browse id, so
+    /// the album page can fetch the album's full track list (the local library
+    /// stores YT albums by hash, with no browse id). Default unsupported; only
+    /// catalog remotes (YT) override.
+    async fn resolve_album_browse_id(
+        &self,
+        _album: &str,
+        _artist: &str,
+    ) -> Result<Option<String>, SourceError> {
+        Err(SourceError::unsupported("album browse id"))
+    }
+
     /// A remote artist profile (banner, top songs, albums, related) by channel
     /// id. Default unsupported; only catalog remotes (YT) override.
     async fn fetch_artist(
@@ -1866,6 +1878,17 @@ impl MediaSource for YtSource {
     async fn resolve_artist_channel_id(&self, query: &str) -> Result<Option<String>, SourceError> {
         self.client
             .resolve_artist_channel_id(query)
+            .await
+            .map_err(SourceError::from)
+    }
+
+    async fn resolve_album_browse_id(
+        &self,
+        album: &str,
+        artist: &str,
+    ) -> Result<Option<String>, SourceError> {
+        self.client
+            .resolve_album_browse_id(album, artist)
             .await
             .map_err(SourceError::from)
     }

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -442,6 +442,12 @@ pub trait MediaSource: Send + Sync {
         Ok(Vec::new())
     }
 
+    /// Resolve a single artist's photo URL by name. Default None; the catalog
+    /// remote (YT) implements it so the Artists grid can show real YT photos.
+    async fn fetch_artist_image(&self, _name: &str) -> Result<Option<String>, SourceError> {
+        Ok(None)
+    }
+
     /// One page of favorites — for [`FavoritesSync::Paginated`] sources (YT). The
     /// caller passes `None` then each returned cursor; default is a single empty
     /// page (instant sources use [`fetch_favorites`] instead).
@@ -1918,6 +1924,13 @@ impl MediaSource for YtSource {
     ) -> Result<crate::ytmusic::discover::YtArtist, SourceError> {
         self.client
             .fetch_artist(channel_id)
+            .await
+            .map_err(SourceError::from)
+    }
+
+    async fn fetch_artist_image(&self, name: &str) -> Result<Option<String>, SourceError> {
+        self.client
+            .resolve_artist_image(name)
             .await
             .map_err(SourceError::from)
     }

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -347,6 +347,15 @@ pub trait MediaSource: Send + Sync {
         Err(SourceError::unsupported("album tracks"))
     }
 
+    /// The full remote album (header metadata + tracks) for the YT-Music-style
+    /// album page. Default unsupported; only catalog remotes (YT) override.
+    async fn fetch_album(
+        &self,
+        _browse_id: &str,
+    ) -> Result<crate::ytmusic::discover::YtAlbum, SourceError> {
+        Err(SourceError::unsupported("album"))
+    }
+
     /// One page of a remote playlist: `cursor = None` for the first page, then
     /// the returned cursor for each next (`None` once exhausted). Lets a UI loop
     /// stream a long playlist (play page 1 instantly, queue the rest) without a
@@ -1860,6 +1869,16 @@ impl MediaSource for YtSource {
     async fn fetch_album_tracks(&self, browse_id: &str) -> Result<Vec<reader::Track>, SourceError> {
         self.client
             .fetch_album_tracks(browse_id)
+            .await
+            .map_err(SourceError::from)
+    }
+
+    async fn fetch_album(
+        &self,
+        browse_id: &str,
+    ) -> Result<crate::ytmusic::discover::YtAlbum, SourceError> {
+        self.client
+            .fetch_album(browse_id)
             .await
             .map_err(SourceError::from)
     }

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -461,7 +461,17 @@ pub trait MediaSource: Send + Sync {
         })
     }
 
-    // --- uniform ops (default): a plain source-scoped DB write --------------
+    // --- uniform ops (default): a plain source-scoped DB read/write ---------
+
+    /// One album's tracks (disc/track-ordered), read from this source's library
+    /// cache. Uniform across sources — the UI goes through the source rather than
+    /// touching the DB directly.
+    async fn album_tracks(&self, album_id: &str) -> Result<Vec<reader::Track>, SourceError> {
+        self.db()
+            .album_tracks(self.source(), album_id)
+            .await
+            .map_err(SourceError::from)
+    }
 
     /// This source's favorite refs — its partition of the favorites table. The
     /// partition key is the source's own identity, so callers never compute it.

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -356,6 +356,32 @@ pub trait MediaSource: Send + Sync {
         Err(SourceError::unsupported("album"))
     }
 
+    /// Resolve an opened album reference — a raw browse id, a `ytmusic:album:MPRE…`
+    /// (search rows with an album link), or a synthesized `ytmusic:album:<hash>`
+    /// (search rows without one) — to its full remote album. `None` when it can't
+    /// be resolved or has no tracks. The id→browse-id→album dance lives here so the
+    /// UI never reaches into the per-service catalog. Default unsupported; only
+    /// catalog remotes (YT) override.
+    async fn fetch_album_by_ref(
+        &self,
+        _id: &str,
+    ) -> Result<Option<crate::ytmusic::discover::YtAlbum>, SourceError> {
+        Err(SourceError::unsupported("album by ref"))
+    }
+
+    /// Resolve a saved album's title + artist to its full remote album (header +
+    /// every track) for the YT-Music-style album page — the local library stores
+    /// YT albums by hash with no browse id, so the page needs the remote listing.
+    /// `None` when it can't be resolved or has no tracks. Default unsupported; only
+    /// catalog remotes (YT) override.
+    async fn fetch_album_by_meta(
+        &self,
+        _title: &str,
+        _artist: &str,
+    ) -> Result<Option<crate::ytmusic::discover::YtAlbum>, SourceError> {
+        Err(SourceError::unsupported("album by meta"))
+    }
+
     /// One page of a remote playlist: `cursor = None` for the first page, then
     /// the returned cursor for each next (`None` once exhausted). Lets a UI loop
     /// stream a long playlist (play page 1 instantly, queue the rest) without a
@@ -1897,6 +1923,44 @@ impl MediaSource for YtSource {
             .fetch_album(browse_id)
             .await
             .map_err(SourceError::from)
+    }
+
+    async fn fetch_album_by_ref(
+        &self,
+        id: &str,
+    ) -> Result<Option<crate::ytmusic::discover::YtAlbum>, SourceError> {
+        // Resolve the id (raw browse id, `ytmusic:album:MPRE…`, or a synthesized
+        // `ytmusic:album:<hash>`) to a real browse id before fetching.
+        let browse_id = if let Some(bid) = crate::ytmusic::search::album_browse_id(id) {
+            Some(bid)
+        } else if let Some((album, artist)) = crate::ytmusic::search::synth_album_parts(id) {
+            self.resolve_album_browse_id(&album, &artist).await?
+        } else {
+            None
+        };
+        let Some(browse_id) = browse_id else {
+            return Ok(None);
+        };
+        Ok(self
+            .fetch_album(&browse_id)
+            .await
+            .ok()
+            .filter(|a| !a.tracks.is_empty()))
+    }
+
+    async fn fetch_album_by_meta(
+        &self,
+        title: &str,
+        artist: &str,
+    ) -> Result<Option<crate::ytmusic::discover::YtAlbum>, SourceError> {
+        let Some(browse_id) = self.resolve_album_browse_id(title, artist).await? else {
+            return Ok(None);
+        };
+        Ok(self
+            .fetch_album(&browse_id)
+            .await
+            .ok()
+            .filter(|a| !a.tracks.is_empty()))
     }
 
     async fn fetch_playlist_page(

--- a/crates/server/src/ytmusic/discover.rs
+++ b/crates/server/src/ytmusic/discover.rs
@@ -95,6 +95,7 @@ pub async fn fetch_home(cookies: &str) -> Result<DiscoverHome, String> {
 ///
 /// Track rows carry no thumbnail of their own, so we stamp the header
 /// cover onto every track for jellyfin_image to pick up.
+#[derive(Debug, Clone, PartialEq)]
 pub struct YtAlbum {
     pub browse_id: String,
     pub title: String,

--- a/crates/server/src/ytmusic/mod.rs
+++ b/crates/server/src/ytmusic/mod.rs
@@ -80,6 +80,18 @@ impl YouTubeMusicClient {
         search::resolve_artist_channel_id(query, self.cookies.as_deref()).await
     }
 
+    /// Resolve a saved album (title + artist) back to its YT album browse id
+    /// (`MPRE…`). Library YT albums carry no browse id, so the album page calls
+    /// this on demand before [`fetch_album_tracks`](Self::fetch_album_tracks)
+    /// to show the album's complete track list.
+    pub async fn resolve_album_browse_id(
+        &self,
+        album: &str,
+        artist: &str,
+    ) -> Result<Option<String>, String> {
+        search::resolve_album_browse_id(album, artist, self.cookies.as_deref()).await
+    }
+
     /// List the user's saved playlists (everything under Library →
     /// Playlists, minus the Liked Music auto-playlist). Returns summary
     /// rows; call [`get_playlist_entries`] for the tracks of any given

--- a/crates/server/src/ytmusic/mod.rs
+++ b/crates/server/src/ytmusic/mod.rs
@@ -271,6 +271,14 @@ impl YouTubeMusicClient {
         discover::fetch_album_tracks(browse_id, self.cookies.as_deref().unwrap_or("")).await
     }
 
+    /// The full album (header metadata — title, artist, year, cover — plus every
+    /// track). The album page uses this for its YT-Music-style header; the
+    /// thinner [`fetch_album_tracks`](Self::fetch_album_tracks) is for callers
+    /// that only queue the tracks.
+    pub async fn fetch_album(&self, browse_id: &str) -> Result<discover::YtAlbum, String> {
+        discover::fetch_album(browse_id, self.cookies.as_deref().unwrap_or("")).await
+    }
+
     pub async fn fetch_artist(&self, channel_id: &str) -> Result<discover::YtArtist, String> {
         discover::fetch_artist(channel_id, self.cookies.as_deref().unwrap_or("")).await
     }

--- a/crates/server/src/ytmusic/mod.rs
+++ b/crates/server/src/ytmusic/mod.rs
@@ -80,6 +80,12 @@ impl YouTubeMusicClient {
         search::resolve_artist_channel_id(query, self.cookies.as_deref()).await
     }
 
+    /// Top YT Music artist-search avatar for `name` — the Artists grid uses this
+    /// so its photos are real YT artist images.
+    pub async fn resolve_artist_image(&self, name: &str) -> Result<Option<String>, String> {
+        search::resolve_artist_image(name, self.cookies.as_deref()).await
+    }
+
     /// Resolve a saved album (title + artist) back to its YT album browse id
     /// (`MPRE…`). Library YT albums carry no browse id, so the album page calls
     /// this on demand before [`fetch_album_tracks`](Self::fetch_album_tracks)

--- a/crates/server/src/ytmusic/search.rs
+++ b/crates/server/src/ytmusic/search.rs
@@ -12,6 +12,10 @@ const VIDEOS_FILTER: &str = "EgWKAQIQAWoMEAMQBBAJEAoQDhAV";
 // to musicResponsiveListItemRenderer rows whose nav endpoint browseId
 // begins with `UC…`, exactly what we need for name → channel resolve.
 const ARTISTS_FILTER: &str = "EgWKAQIgAWoMEAMQBBAJEAoQDhAV";
+// `params` value for the "Albums" tab. Restricts hits to album rows whose
+// nav endpoint browseId begins with `MPRE…`, what we need to resolve a
+// title+artist back to its album browse id (see `resolve_album_browse_id`).
+const ALBUMS_FILTER: &str = "EgWKAQIYAWoMEAMQBBAJEAoQDhAV";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MusicVideoType {
@@ -107,6 +111,55 @@ pub async fn resolve_artist_channel_id(
     let http = super::innertube::http_client();
     let resp = do_search_raw(http, query, Some(ARTISTS_FILTER), cookies).await?;
     Ok(walk_first_artist_browse_id(&resp))
+}
+
+/// Resolve an album title + artist to its YT Music album browse id
+/// (`MPRE…`). The local library stores YT albums under a title+artist hash
+/// with no browse id, so the album page resolves it on demand to fetch the
+/// album's full track list (see [`fetch_album`](super::discover::fetch_album)).
+/// Searches the Albums tab for "<album> <artist>" and takes the first
+/// `MPRE…` browseId — the top-ranked match. Returns None if nothing matched.
+#[tracing::instrument(name = "yt.resolve_album", skip(cookies), fields(album = %album))]
+pub async fn resolve_album_browse_id(
+    album: &str,
+    artist: &str,
+    cookies: Option<&str>,
+) -> Result<Option<String>, String> {
+    if album.trim().is_empty() {
+        return Ok(None);
+    }
+    let query = if artist.trim().is_empty() {
+        album.to_string()
+    } else {
+        format!("{album} {artist}")
+    };
+    let http = super::innertube::http_client();
+    let resp = do_search_raw(http, &query, Some(ALBUMS_FILTER), cookies).await?;
+    Ok(walk_first_album_browse_id(&resp))
+}
+
+/// Recursively walk the JSON for the first browseEndpoint pointing at an
+/// `MPRE…` album. The albums filter restricts results to album rows so the
+/// first hit is the top-ranked match.
+fn walk_first_album_browse_id(v: &Value) -> Option<String> {
+    match v {
+        Value::Object(map) => {
+            if let Some(ep) = map.get("browseEndpoint")
+                && let Some(bid) = ep.get("browseId").and_then(|x| x.as_str())
+                && bid.starts_with("MPRE")
+            {
+                return Some(bid.to_string());
+            }
+            for child in map.values() {
+                if let Some(found) = walk_first_album_browse_id(child) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        Value::Array(arr) => arr.iter().find_map(walk_first_album_browse_id),
+        _ => None,
+    }
 }
 
 /// Recursively walk the JSON for the first browseEndpoint pointing at

--- a/crates/server/src/ytmusic/search.rs
+++ b/crates/server/src/ytmusic/search.rs
@@ -787,9 +787,7 @@ pub fn synth_album_parts(id: &str) -> Option<(String, String)> {
     }
     let bytes = hex::decode(token).ok()?;
     let decoded = String::from_utf8(bytes).ok()?;
-    let (album, artist) = decoded
-        .split_once('|')
-        .unwrap_or((decoded.as_str(), ""));
+    let (album, artist) = decoded.split_once('|').unwrap_or((decoded.as_str(), ""));
     (!album.is_empty()).then(|| (album.to_string(), artist.to_string()))
 }
 

--- a/crates/server/src/ytmusic/search.rs
+++ b/crates/server/src/ytmusic/search.rs
@@ -162,6 +162,41 @@ fn walk_first_album_browse_id(v: &Value) -> Option<String> {
     }
 }
 
+/// The top artist result's avatar URL for `name` from the YT Music "Artists"
+/// tab. Powers the Artists grid so its circular photos are the real YT artist
+/// images and nothing else. Returns None when no artist row matched.
+#[tracing::instrument(name = "yt.artist_image", skip(cookies), fields(name = %name))]
+pub async fn resolve_artist_image(
+    name: &str,
+    cookies: Option<&str>,
+) -> Result<Option<String>, String> {
+    if name.trim().is_empty() {
+        return Ok(None);
+    }
+    let http = super::innertube::http_client();
+    let resp = do_search_raw(http, name, Some(ARTISTS_FILTER), cookies).await?;
+    Ok(walk_first_artist_thumbnail(&resp))
+}
+
+/// First artist row (`musicResponsiveListItemRenderer` that links a `UC…`
+/// channel) → its best thumbnail. The artists filter keeps results to artist
+/// rows so the first such hit is the top-ranked match.
+fn walk_first_artist_thumbnail(v: &Value) -> Option<String> {
+    match v {
+        Value::Object(map) => {
+            if let Some(row) = map.get("musicResponsiveListItemRenderer")
+                && walk_first_artist_browse_id(row).is_some()
+                && let Some(thumb) = best_thumbnail(row)
+            {
+                return Some(thumb);
+            }
+            map.values().find_map(walk_first_artist_thumbnail)
+        }
+        Value::Array(arr) => arr.iter().find_map(walk_first_artist_thumbnail),
+        _ => None,
+    }
+}
+
 /// Recursively walk the JSON for the first browseEndpoint pointing at
 /// a `UC…` channel. The artists filter restricts results to artist
 /// rows so the first hit is the top-ranked match.

--- a/crates/server/src/ytmusic/search.rs
+++ b/crates/server/src/ytmusic/search.rs
@@ -299,7 +299,9 @@ fn parse_card_shelf(card: &Value) -> Option<ParsedRow> {
         .get("videoId")
         .and_then(|v| v.as_str())?
         .to_string();
-    let mvt = endpoint
+    // Validate it's a music card (skip non-music results) — the value itself is
+    // no longer needed now that fields are slotted by link.
+    endpoint
         .pointer("/watchEndpointMusicSupportedConfigs/watchEndpointMusicConfig/musicVideoType")
         .and_then(|v| v.as_str())
         .and_then(MusicVideoType::from_str)?;
@@ -310,30 +312,22 @@ fn parse_card_shelf(card: &Value) -> Option<ParsedRow> {
         .unwrap_or("")
         .to_string();
 
-    // Subtitle is "Kind • Artist • [Album|Views|Year] • [...]". First token is
-    // the kind label which mvt already encodes; skip it and take the next as
-    // the primary artist. For songs the third slot is the album; for videos
-    // it's view count which we drop.
-    let mut subtitle: Vec<String> = card
-        .pointer("/subtitle/runs")
-        .and_then(|v| v.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|r| r.get("text").and_then(|t| t.as_str()))
-                .filter(|s| !is_separator(s))
-                .map(|s| s.to_string())
-                .collect()
-        })
+    // Subtitle is "Kind • Artist • [Album|Views|Year] • [...]". Slot it by link
+    // (artist → UC, album → MPRE) instead of position: the kind label and an
+    // absent album otherwise shift "Views"/"Year" into the album field.
+    let subtitle = runs_with_browse(card.pointer("/subtitle/runs"));
+    let (album, album_browse_id) = subtitle
+        .iter()
+        .find(|(_, b)| b.as_deref().is_some_and(|b| b.starts_with("MPRE")))
+        .map(|(t, b)| (Some(t.clone()), b.clone()))
+        .unwrap_or((None, None));
+    let artist = subtitle
+        .iter()
+        .find(|(_, b)| b.as_deref().is_some_and(|b| b.starts_with("UC")))
+        .map(|(t, _)| t.clone())
+        // No channel link: skip the leading kind label, take the next token.
+        .or_else(|| subtitle.get(1).map(|(t, _)| t.clone()))
         .unwrap_or_default();
-    if !subtitle.is_empty() {
-        subtitle.remove(0);
-    }
-    let artist = subtitle.first().cloned().unwrap_or_default();
-    let album = if mvt.has_album() {
-        subtitle.get(1).cloned()
-    } else {
-        None
-    };
 
     let thumbnail_url = card
         .pointer("/thumbnail/musicThumbnailRenderer/thumbnail/thumbnails")
@@ -355,7 +349,7 @@ fn parse_card_shelf(card: &Value) -> Option<ParsedRow> {
             vec![artist]
         },
         album,
-        album_browse_id: None,
+        album_browse_id,
         duration: 0,
         thumbnail_url,
     })
@@ -384,7 +378,7 @@ fn parse_row(item: &Value) -> Option<ParsedRow> {
             thumbnail_url,
         ))
     } else {
-        Some(parse_search_row(row, video_id, title, mvt, thumbnail_url))
+        Some(parse_search_row(row, video_id, title, thumbnail_url))
     }
 }
 
@@ -437,35 +431,89 @@ fn parse_search_row(
     row: &Value,
     video_id: String,
     title: String,
-    mvt: MusicVideoType,
     thumbnail_url: Option<String>,
 ) -> ParsedRow {
-    // flex[1] runs, separators filtered:
-    //   has_album: [artist..., album, duration]
-    //   else:      [artist..., view-count, duration]
-    // duration is always last; the slot before it is album OR view-count
-    // depending on mvt. We dispatch on mvt — no view-count text sniffing.
-    let mut tokens = pick_all_runs(row, 1);
-    let duration = tokens.pop().as_deref().and_then(parse_mm_ss).unwrap_or(0);
-    let second_last = tokens.pop();
-    let (album, artists) = if mvt.has_album() {
-        let album = second_last.filter(|s| !s.is_empty());
-        (album, tokens)
-    } else {
-        // second_last is the view count; drop it, the remaining tokens
-        // are artists.
-        (None, tokens)
-    };
+    // flex[1] packs "artist[s] • [album|view-count] • duration" but the slots
+    // are NOT positionally stable: some rows omit the album, some shelves (the
+    // unfiltered "top" results) append a trailing run, and `mvt.has_album()`
+    // lies for album-typed tracks that carry no album. Positional popping
+    // therefore mis-slotted fields (duration landing in album, duration 0).
+    //
+    // Classify by each run's link instead: an album run links to an `MPRE…`
+    // browse id, an artist run to a `UC…` channel. Duration is the m:ss run.
+    let runs = pick_runs_with_browse(row, 1);
+    let duration = runs
+        .iter()
+        .find(|(t, _)| looks_like_duration(t))
+        .and_then(|(t, _)| parse_mm_ss(t))
+        .unwrap_or(0);
+    let (album, album_browse_id) = runs
+        .iter()
+        .find(|(_, b)| b.as_deref().is_some_and(|b| b.starts_with("MPRE")))
+        .map(|(t, b)| (Some(t.clone()), b.clone()))
+        .unwrap_or((None, None));
+    let mut artists: Vec<String> = runs
+        .iter()
+        .filter(|(_, b)| b.as_deref().is_some_and(|b| b.starts_with("UC")))
+        .map(|(t, _)| t.clone())
+        .collect();
+    if artists.is_empty() {
+        // Unlinked artist text (no channel run). Fall back to the first run
+        // that isn't the duration, album, or — for albumless rows — the
+        // view-count tail. The leading run is the artist in every observed
+        // shape.
+        artists = runs
+            .iter()
+            .map(|(t, _)| t.clone())
+            .filter(|t| !looks_like_duration(t))
+            .filter(|t| Some(t) != album.as_ref())
+            .take(1)
+            .collect();
+    }
 
     ParsedRow {
         video_id,
         title,
         artists,
         album,
-        album_browse_id: None,
+        album_browse_id,
         duration,
         thumbnail_url,
     }
+}
+
+/// flex-column runs paired with their `navigationEndpoint` browse id (album →
+/// `MPRE…`, artist → `UC…`), separators and empty runs dropped. Lets the row
+/// parser slot fields by link rather than by fragile position.
+fn pick_runs_with_browse(row: &Value, col: usize) -> Vec<(String, Option<String>)> {
+    runs_with_browse(
+        row.get("flexColumns")
+            .and_then(|c| c.as_array())
+            .and_then(|cs| cs.get(col))
+            .and_then(|c| c.pointer("/musicResponsiveListItemFlexColumnRenderer/text/runs")),
+    )
+}
+
+/// A `text/runs` array → `(text, browse_id)` pairs, separators and empty runs
+/// dropped. Shared by the flex-column rows and the top-result card subtitle.
+fn runs_with_browse(runs: Option<&Value>) -> Vec<(String, Option<String>)> {
+    runs.and_then(|v| v.as_array())
+        .map(|runs| {
+            runs.iter()
+                .filter_map(|r| {
+                    let text = r.get("text").and_then(|t| t.as_str())?;
+                    if is_separator(text) || text.trim().is_empty() {
+                        return None;
+                    }
+                    let browse_id = r
+                        .pointer("/navigationEndpoint/browseEndpoint/browseId")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    Some((text.to_string(), browse_id))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn parsed_to_track(p: ParsedRow) -> Track {
@@ -511,20 +559,10 @@ fn pick_run(row: &Value, col: usize, run: usize) -> String {
         .to_string()
 }
 
-fn pick_all_runs(row: &Value, col: usize) -> Vec<String> {
-    row.get("flexColumns")
-        .and_then(|c| c.as_array())
-        .and_then(|cs| cs.get(col))
-        .and_then(|c| c.pointer("/musicResponsiveListItemFlexColumnRenderer/text/runs"))
-        .and_then(|v| v.as_array())
-        .map(|runs| {
-            runs.iter()
-                .filter_map(|r| r.get("text").and_then(|t| t.as_str()))
-                .filter(|s| !is_separator(s))
-                .map(|s| s.to_string())
-                .collect()
-        })
-        .unwrap_or_default()
+/// A duration cell looks like `m:ss` / `h:mm:ss` — must contain a colon so a
+/// bare year ("2009") or numeric token can't masquerade as a duration.
+fn looks_like_duration(s: &str) -> bool {
+    s.contains(':') && parse_mm_ss(s).is_some()
 }
 
 fn is_separator(s: &str) -> bool {
@@ -692,6 +730,32 @@ pub(crate) fn synthesize_album_id(album: &str, artist: &str) -> String {
         key.push_str(&artist.to_lowercase());
     }
     format!("{SOURCE_PREFIX}:album:{}", hex::encode(key.as_bytes()))
+}
+
+/// The real `MPRE…` album browse id carried by an album id, if any. Handles
+/// both the raw `MPRE…` form (Discover passes that straight to navigation) and
+/// the `ytmusic:album:MPRE…` form synthesized for search/track rows. Returns
+/// None for synthesized hash ids and the `singles` bucket.
+pub fn album_browse_id(id: &str) -> Option<String> {
+    let token = id.rsplit(':').next().unwrap_or(id);
+    token.starts_with("MPRE").then(|| token.to_string())
+}
+
+/// `(album, artist)` recovered from a synthesized album id
+/// (`ytmusic:album:<hex(album|artist)>`). Lets the album page resolve a browse
+/// id on demand for albums that came back from search without an `MPRE` link.
+/// None for browse-id ids and the `singles` bucket.
+pub fn synth_album_parts(id: &str) -> Option<(String, String)> {
+    let token = id.rsplit(':').next()?;
+    if token.starts_with("MPRE") || token == "singles" {
+        return None;
+    }
+    let bytes = hex::decode(token).ok()?;
+    let decoded = String::from_utf8(bytes).ok()?;
+    let (album, artist) = decoded
+        .split_once('|')
+        .unwrap_or((decoded.as_str(), ""));
+    (!album.is_empty()).then(|| (album.to_string(), artist.to_string()))
 }
 
 fn parse_mm_ss(s: &str) -> Option<u64> {


### PR DESCRIPTION
yeah now i will fetch all the music in the album instead of only saved ones also will make the look more like yt music original look .d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added YouTube Music–style discover album support with remote album lookup and track hydration.
  * Added one-tap album link sharing with a confirmation toast.

* **Improvements**
  * Improved album/artist discover sourcing with better remote fallback and offline behavior.
  * Preserved scroll positions in album and artist grids across navigation.
  * Refined discover tile/playlist selection and playback/queue behavior.

* **UI Updates**
  * Refreshed discover card/play button layout and discover playlist detail states.

* **Chores**
  * Updated Tailwind-generated utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->