### PR TITLE
feat: queue failed scrobbles offline and resubmit with original timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6825,6 +6825,7 @@ version = "0.7.0"
 dependencies = [
  "config",
  "dioxus",
+ "directories",
  "md5",
  "reqwest 0.13.4",
  "serde",

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -1505,7 +1505,8 @@ impl PlayerController {
                                     if let Some(ref mbid) = scrobble_track.musicbrainz_release_id {
                                         map.insert("release_mbid", mbid.as_str());
                                     }
-                                    if let Some(ref mbid) = scrobble_track.musicbrainz_recording_id {
+                                    if let Some(ref mbid) = scrobble_track.musicbrainz_recording_id
+                                    {
                                         map.insert("recording_mbid", mbid.as_str());
                                     }
                                     if let Some(ref mbid) = scrobble_track.musicbrainz_track_id {
@@ -1722,7 +1723,10 @@ impl PlayerController {
                                                 )
                                             }
                                             Err(e) => {
-                                                tracing::warn!("MusicBrainz scrobble failed: {}", e);
+                                                tracing::warn!(
+                                                    "MusicBrainz scrobble failed: {}",
+                                                    e
+                                                );
                                                 if scrobble::queue::is_transient(&e)
                                                     && let Some(qp) = &queue_path
                                                 {
@@ -2265,14 +2269,15 @@ pub fn use_player_controller(
         let creds = {
             let cfg = config.peek();
             scrobble::queue::Credentials {
-                lastfm: (!cfg.lastfm_api_key.is_empty() && !cfg.lastfm_api_secret.is_empty())
-                    .then(|| {
+                lastfm: (!cfg.lastfm_api_key.is_empty() && !cfg.lastfm_api_secret.is_empty()).then(
+                    || {
                         (
                             cfg.lastfm_api_key.clone(),
                             cfg.lastfm_api_secret.clone(),
                             cfg.lastfm_session_key.clone(),
                         )
-                    }),
+                    },
+                ),
                 librefm_session_key: (!cfg.librefm_session_key.is_empty())
                     .then(|| cfg.librefm_session_key.clone()),
                 listenbrainz_token: (!cfg.musicbrainz_token.is_empty())

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -998,12 +998,24 @@ impl PlayerController {
                                             }
                                         }
 
+                                        // Offline queue bookkeeping (issue #335): scrobbles
+                                        // that fail with a transient error are queued with
+                                        // this listen timestamp and resubmitted later; one
+                                        // success means we're online, so drain the backlog.
+                                        let listened_at = std::time::SystemTime::now()
+                                            .duration_since(std::time::UNIX_EPOCH)
+                                            .map(|d| d.as_secs() as i64)
+                                            .unwrap_or(0);
+                                        let queue_path = scrobble::queue::default_queue_path();
+                                        let mut scrobble_ok = false;
+
                                         // Last.fm scrobble
                                         if has_lastfm {
-                                            let scrobble = scrobble::lastfm::make_scrobble(
+                                            let scrobble = scrobble::lastfm::make_scrobble_at(
                                                 &scrobble_track.artist,
                                                 &scrobble_track.title,
                                                 Some(&scrobble_track.album),
+                                                listened_at,
                                             );
                                             match scrobble::lastfm::submit_scrobble(
                                                 &lastfm_api_key,
@@ -1013,23 +1025,40 @@ impl PlayerController {
                                             )
                                             .await
                                             {
-                                                Ok(_) => tracing::info!(
-                                                    "Last.fm scrobbled: {} - {}",
-                                                    scrobble_track.artist,
-                                                    scrobble_track.title
-                                                ),
+                                                Ok(_) => {
+                                                    scrobble_ok = true;
+                                                    tracing::info!(
+                                                        "Last.fm scrobbled: {} - {}",
+                                                        scrobble_track.artist,
+                                                        scrobble_track.title
+                                                    )
+                                                }
                                                 Err(e) => {
-                                                    tracing::warn!("Last.fm scrobble failed: {}", e)
+                                                    tracing::warn!("Last.fm scrobble failed: {}", e);
+                                                    if scrobble::queue::is_transient(&e)
+                                                        && let Some(qp) = &queue_path
+                                                    {
+                                                        scrobble::queue::enqueue(
+                                                            qp,
+                                                            scrobble::queue::Service::LastFm,
+                                                            &scrobble_track.artist,
+                                                            &scrobble_track.title,
+                                                            Some(&scrobble_track.album),
+                                                            listened_at,
+                                                        )
+                                                        .await;
+                                                    }
                                                 }
                                             }
                                         }
 
                                         // Libre.fm scrobble
                                         if has_librefm {
-                                            let scrobble = scrobble::librefm::make_scrobble(
+                                            let scrobble = scrobble::librefm::make_scrobble_at(
                                                 &scrobble_track.artist,
                                                 &scrobble_track.title,
                                                 Some(&scrobble_track.album),
+                                                listened_at,
                                             );
                                             match scrobble::librefm::submit_scrobble(
                                                 scrobble::librefm::API_KEY,
@@ -1039,16 +1068,32 @@ impl PlayerController {
                                             )
                                             .await
                                             {
-                                                Ok(_) => tracing::info!(
-                                                    "Libre.fm scrobbled: {} - {}",
-                                                    scrobble_track.artist,
-                                                    scrobble_track.title
-                                                ),
+                                                Ok(_) => {
+                                                    scrobble_ok = true;
+                                                    tracing::info!(
+                                                        "Libre.fm scrobbled: {} - {}",
+                                                        scrobble_track.artist,
+                                                        scrobble_track.title
+                                                    )
+                                                }
                                                 Err(e) => {
                                                     tracing::warn!(
                                                         "Libre.fm scrobble failed: {}",
                                                         e
-                                                    )
+                                                    );
+                                                    if scrobble::queue::is_transient(&e)
+                                                        && let Some(qp) = &queue_path
+                                                    {
+                                                        scrobble::queue::enqueue(
+                                                            qp,
+                                                            scrobble::queue::Service::LibreFm,
+                                                            &scrobble_track.artist,
+                                                            &scrobble_track.title,
+                                                            Some(&scrobble_track.album),
+                                                            listened_at,
+                                                        )
+                                                        .await;
+                                                    }
                                                 }
                                             }
                                         }
@@ -1058,15 +1103,16 @@ impl PlayerController {
                                             scrobble_cfg.read().musicbrainz_token.clone();
                                         if !token_raw.is_empty() {
                                             let auth = if token_raw.contains(' ') {
-                                                token_raw
+                                                token_raw.clone()
                                             } else {
                                                 format!("Token {}", token_raw)
                                             };
-                                            let listen = scrobble::musicbrainz::make_listen(
+                                            let listen = scrobble::musicbrainz::make_listen_at(
                                                 &scrobble_track.artist,
                                                 &scrobble_track.title,
                                                 Some(&scrobble_track.album),
                                                 None,
+                                                listened_at,
                                             );
                                             match scrobble::musicbrainz::submit_listens(
                                                 &auth,
@@ -1075,18 +1121,58 @@ impl PlayerController {
                                             )
                                             .await
                                             {
-                                                Ok(_) => tracing::info!(
-                                                    "MusicBrainz scrobbled: {} - {}",
-                                                    scrobble_track.artist,
-                                                    scrobble_track.title
-                                                ),
+                                                Ok(_) => {
+                                                    scrobble_ok = true;
+                                                    tracing::info!(
+                                                        "MusicBrainz scrobbled: {} - {}",
+                                                        scrobble_track.artist,
+                                                        scrobble_track.title
+                                                    )
+                                                }
                                                 Err(e) => {
                                                     tracing::warn!(
                                                         "MusicBrainz scrobble failed: {}",
                                                         e
-                                                    )
+                                                    );
+                                                    if scrobble::queue::is_transient(&e)
+                                                        && let Some(qp) = &queue_path
+                                                    {
+                                                        scrobble::queue::enqueue(
+                                                            qp,
+                                                            scrobble::queue::Service::ListenBrainz,
+                                                            &scrobble_track.artist,
+                                                            &scrobble_track.title,
+                                                            Some(&scrobble_track.album),
+                                                            listened_at,
+                                                        )
+                                                        .await;
+                                                    }
                                                 }
                                             }
+                                        }
+
+                                        // One success means we're online again: flush any
+                                        // scrobbles queued while offline.
+                                        if scrobble_ok && let Some(qp) = &queue_path {
+                                            let creds = scrobble::queue::Credentials {
+                                                lastfm: has_lastfm.then(|| {
+                                                    (
+                                                        lastfm_api_key.clone(),
+                                                        lastfm_api_secret.clone(),
+                                                        lastfm_session_key.clone(),
+                                                    )
+                                                }),
+                                                librefm_session_key: has_librefm
+                                                    .then(|| librefm_session_key.clone()),
+                                                listenbrainz_token: (!scrobble_cfg
+                                                    .read()
+                                                    .musicbrainz_token
+                                                    .is_empty())
+                                                .then(|| {
+                                                    scrobble_cfg.read().musicbrainz_token.clone()
+                                                }),
+                                            };
+                                            scrobble::queue::drain(qp, &creds).await;
                                         }
                                     }.instrument(scrobble_span));
 
@@ -1419,12 +1505,34 @@ impl PlayerController {
                                     if let Some(ref mbid) = scrobble_track.musicbrainz_release_id {
                                         map.insert("release_mbid", mbid.as_str());
                                     }
-                                    if let Some(ref mbid) = scrobble_track.musicbrainz_recording_id
-                                    {
+                                    if let Some(ref mbid) = scrobble_track.musicbrainz_recording_id {
                                         map.insert("recording_mbid", mbid.as_str());
                                     }
                                     if let Some(ref mbid) = scrobble_track.musicbrainz_track_id {
                                         map.insert("track_mbid", mbid.as_str());
+                                    }
+
+                                    // Libre.fm now-playing
+                                    let librefm_session_key =
+                                        cfg_signal.read().librefm_session_key.clone();
+                                    let has_librefm = !librefm_session_key.is_empty();
+
+                                    if has_librefm {
+                                        let playing_now = scrobble::librefm::make_playing_now(
+                                            &scrobble_track.artist,
+                                            &scrobble_track.title,
+                                            Some(&scrobble_track.album),
+                                        );
+                                        if let Err(e) = scrobble::librefm::submit_now_playing(
+                                            scrobble::librefm::API_KEY,
+                                            scrobble::librefm::API_SECRET,
+                                            &librefm_session_key,
+                                            &playing_now,
+                                        )
+                                        .await
+                                        {
+                                            tracing::warn!("Libre.fm now playing failed: {}", e);
+                                        }
                                     }
 
                                     // Last.fm now-playing
@@ -1488,11 +1596,23 @@ impl PlayerController {
                                         return;
                                     }
 
+                                    // Offline queue bookkeeping (issue #335): scrobbles that
+                                    // fail with a transient error are queued with this listen
+                                    // timestamp and resubmitted later; one success means we're
+                                    // online, so drain the backlog.
+                                    let listened_at = std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map(|d| d.as_secs() as i64)
+                                        .unwrap_or(0);
+                                    let queue_path = scrobble::queue::default_queue_path();
+                                    let mut scrobble_ok = false;
+
                                     if has_lastfm {
-                                        let scrobble = scrobble::lastfm::make_scrobble(
+                                        let scrobble = scrobble::lastfm::make_scrobble_at(
                                             &scrobble_track.artist,
                                             &scrobble_track.title,
                                             Some(&scrobble_track.album),
+                                            listened_at,
                                         );
                                         match scrobble::lastfm::submit_scrobble(
                                             &lastfm_api_key,
@@ -1502,13 +1622,72 @@ impl PlayerController {
                                         )
                                         .await
                                         {
-                                            Ok(_) => tracing::info!(
-                                                "Last.fm scrobbled: {} - {}",
-                                                scrobble_track.artist,
-                                                scrobble_track.title
-                                            ),
+                                            Ok(_) => {
+                                                scrobble_ok = true;
+                                                tracing::info!(
+                                                    "Last.fm scrobbled: {} - {}",
+                                                    scrobble_track.artist,
+                                                    scrobble_track.title
+                                                )
+                                            }
                                             Err(e) => {
-                                                tracing::warn!("Last.fm scrobble failed: {}", e)
+                                                tracing::warn!("Last.fm scrobble failed: {}", e);
+                                                if scrobble::queue::is_transient(&e)
+                                                    && let Some(qp) = &queue_path
+                                                {
+                                                    scrobble::queue::enqueue(
+                                                        qp,
+                                                        scrobble::queue::Service::LastFm,
+                                                        &scrobble_track.artist,
+                                                        &scrobble_track.title,
+                                                        Some(&scrobble_track.album),
+                                                        listened_at,
+                                                    )
+                                                    .await;
+                                                }
+                                            }
+                                        }
+                                    }
+
+                                    // Libre.fm scrobble
+                                    if has_librefm {
+                                        let scrobble = scrobble::librefm::make_scrobble_at(
+                                            &scrobble_track.artist,
+                                            &scrobble_track.title,
+                                            Some(&scrobble_track.album),
+                                            listened_at,
+                                        );
+                                        match scrobble::librefm::submit_scrobble(
+                                            scrobble::librefm::API_KEY,
+                                            scrobble::librefm::API_SECRET,
+                                            &librefm_session_key,
+                                            &scrobble,
+                                        )
+                                        .await
+                                        {
+                                            Ok(_) => {
+                                                scrobble_ok = true;
+                                                tracing::info!(
+                                                    "Libre.fm scrobbled: {} - {}",
+                                                    scrobble_track.artist,
+                                                    scrobble_track.title
+                                                )
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!("Libre.fm scrobble failed: {}", e);
+                                                if scrobble::queue::is_transient(&e)
+                                                    && let Some(qp) = &queue_path
+                                                {
+                                                    scrobble::queue::enqueue(
+                                                        qp,
+                                                        scrobble::queue::Service::LibreFm,
+                                                        &scrobble_track.artist,
+                                                        &scrobble_track.title,
+                                                        Some(&scrobble_track.album),
+                                                        listened_at,
+                                                    )
+                                                    .await;
+                                                }
                                             }
                                         }
                                     }
@@ -1516,15 +1695,16 @@ impl PlayerController {
                                     let token_raw = cfg_signal.read().musicbrainz_token.clone();
                                     if !token_raw.is_empty() {
                                         let auth = if token_raw.contains(' ') {
-                                            token_raw
+                                            token_raw.clone()
                                         } else {
                                             format!("Token {}", token_raw)
                                         };
-                                        let listen = scrobble::musicbrainz::make_listen(
+                                        let listen = scrobble::musicbrainz::make_listen_at(
                                             &scrobble_track.artist,
                                             &scrobble_track.title,
                                             Some(&scrobble_track.album),
                                             Some(map.clone()),
+                                            listened_at,
                                         );
                                         match scrobble::musicbrainz::submit_listens(
                                             &auth,
@@ -1533,15 +1713,52 @@ impl PlayerController {
                                         )
                                         .await
                                         {
-                                            Ok(_) => tracing::info!(
-                                                "MusicBrainz scrobbled: {} - {}",
-                                                scrobble_track.artist,
-                                                scrobble_track.title
-                                            ),
+                                            Ok(_) => {
+                                                scrobble_ok = true;
+                                                tracing::info!(
+                                                    "MusicBrainz scrobbled: {} - {}",
+                                                    scrobble_track.artist,
+                                                    scrobble_track.title
+                                                )
+                                            }
                                             Err(e) => {
-                                                tracing::warn!("MusicBrainz scrobble failed: {}", e)
+                                                tracing::warn!("MusicBrainz scrobble failed: {}", e);
+                                                if scrobble::queue::is_transient(&e)
+                                                    && let Some(qp) = &queue_path
+                                                {
+                                                    scrobble::queue::enqueue(
+                                                        qp,
+                                                        scrobble::queue::Service::ListenBrainz,
+                                                        &scrobble_track.artist,
+                                                        &scrobble_track.title,
+                                                        Some(&scrobble_track.album),
+                                                        listened_at,
+                                                    )
+                                                    .await;
+                                                }
                                             }
                                         }
+                                    }
+
+                                    // One success means we're online again: flush queued scrobbles.
+                                    if scrobble_ok && let Some(qp) = &queue_path {
+                                        let creds = scrobble::queue::Credentials {
+                                            lastfm: has_lastfm.then(|| {
+                                                (
+                                                    lastfm_api_key.clone(),
+                                                    lastfm_api_secret.clone(),
+                                                    lastfm_session_key.clone(),
+                                                )
+                                            }),
+                                            librefm_session_key: has_librefm
+                                                .then(|| librefm_session_key.clone()),
+                                            listenbrainz_token: (!cfg_signal
+                                                .read()
+                                                .musicbrainz_token
+                                                .is_empty())
+                                            .then(|| cfg_signal.read().musicbrainz_token.clone()),
+                                        };
+                                        scrobble::queue::drain(qp, &creds).await;
                                     }
                                 }
                                 .instrument(tracing::info_span!("scrobble.submit")),
@@ -2037,6 +2254,33 @@ pub fn use_player_controller(
     let playback_error = use_signal(|| None::<String>);
     let db = use_signal(move || db_handle);
     let active_source = use_context::<Signal<::server::source::ActiveSource>>();
+
+    // Scrobbles queued while offline (issue #335): retry once on startup, in
+    // case connectivity came back between sessions.
+    #[cfg(not(target_arch = "wasm32"))]
+    use_future(move || async move {
+        let Some(queue_path) = scrobble::queue::default_queue_path() else {
+            return;
+        };
+        let creds = {
+            let cfg = config.peek();
+            scrobble::queue::Credentials {
+                lastfm: (!cfg.lastfm_api_key.is_empty() && !cfg.lastfm_api_secret.is_empty())
+                    .then(|| {
+                        (
+                            cfg.lastfm_api_key.clone(),
+                            cfg.lastfm_api_secret.clone(),
+                            cfg.lastfm_session_key.clone(),
+                        )
+                    }),
+                librefm_session_key: (!cfg.librefm_session_key.is_empty())
+                    .then(|| cfg.librefm_session_key.clone()),
+                listenbrainz_token: (!cfg.musicbrainz_token.is_empty())
+                    .then(|| cfg.musicbrainz_token.clone()),
+            }
+        };
+        scrobble::queue::drain(&queue_path, &creds).await;
+    });
 
     PlayerController {
         player,

--- a/crates/scrobble/Cargo.toml
+++ b/crates/scrobble/Cargo.toml
@@ -9,9 +9,12 @@ workspace = true
 [dependencies]
 md5 = "0.8"
 tracing = "0.1"
-reqwest.workspace = true
+reqwest = { workspace = true, features = ["json"] }
 config.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 dioxus.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+directories = { workspace = true }

--- a/crates/scrobble/src/lastfm.rs
+++ b/crates/scrobble/src/lastfm.rs
@@ -221,8 +221,19 @@ pub fn make_scrobble<'a>(
         .unwrap()
         .as_secs() as i64;
 
+    make_scrobble_at(artist, track, release, now_unix)
+}
+
+/// Like [`make_scrobble`], but with an explicit listen timestamp. Used when
+/// resubmitting queued offline scrobbles so they keep their original time.
+pub fn make_scrobble_at<'a>(
+    artist: &'a str,
+    track: &'a str,
+    release: Option<&'a str>,
+    timestamp: i64,
+) -> Scrobble<'a> {
     Scrobble {
-        timestamp: now_unix,
+        timestamp,
         track_metadata: TrackMetadata {
             artist_name: artist,
             track_name: track,

--- a/crates/scrobble/src/lib.rs
+++ b/crates/scrobble/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod lastfm;
 pub mod librefm;
 pub mod musicbrainz;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod queue;

--- a/crates/scrobble/src/librefm.rs
+++ b/crates/scrobble/src/librefm.rs
@@ -227,8 +227,19 @@ pub fn make_scrobble<'a>(
         .unwrap()
         .as_secs() as i64;
 
+    make_scrobble_at(artist, track, release, now_unix)
+}
+
+/// Like [`make_scrobble`], but with an explicit listen timestamp. Used when
+/// resubmitting queued offline scrobbles so they keep their original time.
+pub fn make_scrobble_at<'a>(
+    artist: &'a str,
+    track: &'a str,
+    release: Option<&'a str>,
+    timestamp: i64,
+) -> Scrobble<'a> {
     Scrobble {
-        timestamp: now_unix,
+        timestamp,
         track_metadata: TrackMetadata {
             artist_name: artist,
             track_name: track,

--- a/crates/scrobble/src/musicbrainz.rs
+++ b/crates/scrobble/src/musicbrainz.rs
@@ -88,8 +88,20 @@ pub fn make_listen<'a>(
         .unwrap()
         .as_secs() as i64;
 
+    make_listen_at(artist, track, release, additional_info, now_unix)
+}
+
+/// Like [`make_listen`], but with an explicit listen timestamp. Used when
+/// resubmitting queued offline scrobbles so they keep their original time.
+pub fn make_listen_at<'a>(
+    artist: &'a str,
+    track: &'a str,
+    release: Option<&'a str>,
+    additional_info: Option<HashMap<&'a str, &'a str>>,
+    listened_at: i64,
+) -> Listen<'a> {
     Listen {
-        listened_at: Some(now_unix),
+        listened_at: Some(listened_at),
         track_metadata: TrackMetadata {
             artist_name: artist,
             track_name: track,

--- a/crates/scrobble/src/queue.rs
+++ b/crates/scrobble/src/queue.rs
@@ -62,12 +62,17 @@ impl ScrobbleQueue {
             .unwrap_or_default()
     }
 
+    /// Write-to-temp-then-rename so an interrupted write can't leave a
+    /// truncated file behind; `load` treats corrupt JSON as an empty queue,
+    /// which would silently drop the whole backlog.
     pub fn save(&self, path: &Path) -> Result<(), String> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         }
         let json = serde_json::to_string(self).map_err(|e| e.to_string())?;
-        std::fs::write(path, json).map_err(|e| e.to_string())
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, json).map_err(|e| e.to_string())?;
+        std::fs::rename(&tmp, path).map_err(|e| e.to_string())
     }
 
     /// Append a scrobble, dropping the oldest entries beyond the cap.
@@ -156,8 +161,9 @@ pub async fn enqueue(
 
 /// Resubmit queued scrobbles. Per service, the first transient failure skips
 /// that service for the rest of this run (still unreachable); a permanent
-/// failure drops the service from that entry. The queue is saved after every
-/// change so an interrupted drain loses at most nothing.
+/// failure drops the service from that entry. Progress is checkpointed to
+/// disk after every entry, so an interrupted drain re-sends at most the one
+/// in-flight item instead of replaying everything already delivered.
 pub async fn drain(path: &Path, creds: &Credentials) {
     let _guard = QUEUE_LOCK.lock().await;
     let mut queue = ScrobbleQueue::load(path);
@@ -168,13 +174,14 @@ pub async fn drain(path: &Path, creds: &Credentials) {
 
     let mut give_up: Vec<Service> = Vec::new();
 
-    for item in &mut queue.items {
+    for idx in 0..queue.items.len() {
+        let item = queue.items[idx].clone();
         let mut done: Vec<Service> = Vec::new();
         for &service in &item.pending {
             if give_up.contains(&service) {
                 continue;
             }
-            match submit_one(service, item, creds).await {
+            match submit_one(service, &item, creds).await {
                 Outcome::Sent => {
                     tracing::info!(
                         service = service.label(),
@@ -203,7 +210,12 @@ pub async fn drain(path: &Path, creds: &Credentials) {
                 }
             }
         }
-        item.pending.retain(|s| !done.contains(s));
+        if !done.is_empty() {
+            queue.items[idx].pending.retain(|s| !done.contains(s));
+            if let Err(e) = queue.save(path) {
+                tracing::warn!(error = %e, "failed to checkpoint scrobble queue");
+            }
+        }
     }
 
     queue.items.retain(|i| !i.pending.is_empty());
@@ -226,7 +238,8 @@ async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials
             let Some((key, secret, session)) = &creds.lastfm else {
                 return Outcome::NoCredentials;
             };
-            let scrobble = lastfm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
+            let scrobble =
+                lastfm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
             lastfm::submit_scrobble(key, secret, session, &scrobble)
                 .await
                 .map(|_| ())
@@ -235,7 +248,8 @@ async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials
             let Some(session) = &creds.librefm_session_key else {
                 return Outcome::NoCredentials;
             };
-            let scrobble = librefm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
+            let scrobble =
+                librefm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
             librefm::submit_scrobble(librefm::API_KEY, librefm::API_SECRET, session, &scrobble)
                 .await
                 .map(|_| ())
@@ -249,13 +263,8 @@ async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials
             } else {
                 format!("Token {token}")
             };
-            let listen = musicbrainz::make_listen_at(
-                &item.artist,
-                &item.title,
-                album,
-                None,
-                item.timestamp,
-            );
+            let listen =
+                musicbrainz::make_listen_at(&item.artist, &item.title, album, None, item.timestamp);
             musicbrainz::submit_listens(&auth, vec![listen], "import")
                 .await
                 .map(|_| ())
@@ -302,7 +311,11 @@ mod tests {
     fn save_and_load_roundtrip() {
         let path = temp_path("roundtrip.json");
         let mut q = ScrobbleQueue::default();
-        q.push(entry("song", 1700000000, vec![Service::LibreFm, Service::ListenBrainz]));
+        q.push(entry(
+            "song",
+            1700000000,
+            vec![Service::LibreFm, Service::ListenBrainz],
+        ));
         q.save(&path).unwrap();
 
         let loaded = ScrobbleQueue::load(&path);
@@ -332,7 +345,15 @@ mod tests {
         let _ = std::fs::remove_file(&path);
 
         enqueue(&path, Service::LastFm, "Artist", "Song", Some("Album"), 42).await;
-        enqueue(&path, Service::ListenBrainz, "Artist", "Song", Some("Album"), 42).await;
+        enqueue(
+            &path,
+            Service::ListenBrainz,
+            "Artist",
+            "Song",
+            Some("Album"),
+            42,
+        )
+        .await;
         // Duplicate service on the same listen must not double up.
         enqueue(&path, Service::LastFm, "Artist", "Song", Some("Album"), 42).await;
 

--- a/crates/scrobble/src/queue.rs
+++ b/crates/scrobble/src/queue.rs
@@ -1,0 +1,361 @@
+//! Offline scrobble queue (issue #335).
+//!
+//! A scrobble that fails with a transient error (no response or a 5xx) is
+//! persisted here and resubmitted later with its original listen timestamp.
+//! Both protocols support backdated submissions: Last.fm/Libre.fm
+//! `track.scrobble` takes a `timestamp`, ListenBrainz takes `listened_at`.
+//! Permanent failures (4xx, e.g. bad credentials) are never queued, retrying
+//! them can't succeed.
+
+use crate::{lastfm, librefm, musicbrainz};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tokio::sync::Mutex;
+
+/// Queue size cap; the oldest entries are dropped first.
+const MAX_QUEUED: usize = 500;
+
+/// Serializes all queue file access so two finished tracks can't race on the
+/// load-modify-save cycle.
+static QUEUE_LOCK: Mutex<()> = Mutex::const_new(());
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Service {
+    LastFm,
+    LibreFm,
+    ListenBrainz,
+}
+
+impl Service {
+    pub fn label(self) -> &'static str {
+        match self {
+            Service::LastFm => "Last.fm",
+            Service::LibreFm => "Libre.fm",
+            Service::ListenBrainz => "ListenBrainz",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueuedScrobble {
+    pub artist: String,
+    pub title: String,
+    pub album: Option<String>,
+    /// Unix timestamp of the original listen.
+    pub timestamp: i64,
+    /// Services this scrobble is still owed to.
+    pub pending: Vec<Service>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ScrobbleQueue {
+    pub items: Vec<QueuedScrobble>,
+}
+
+impl ScrobbleQueue {
+    /// Load the queue; a missing or unreadable file is an empty queue
+    /// (same forgiving pattern as the app config).
+    pub fn load(path: &Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let json = serde_json::to_string(self).map_err(|e| e.to_string())?;
+        std::fs::write(path, json).map_err(|e| e.to_string())
+    }
+
+    /// Append a scrobble, dropping the oldest entries beyond the cap.
+    pub fn push(&mut self, item: QueuedScrobble) {
+        self.items.push(item);
+        if self.items.len() > MAX_QUEUED {
+            let overflow = self.items.len() - MAX_QUEUED;
+            self.items.drain(..overflow);
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+/// Default queue location, next to config.json.
+pub fn default_queue_path() -> Option<PathBuf> {
+    directories::ProjectDirs::from("com", "temidaradev", "kopuz")
+        .map(|dirs| dirs.config_dir().join("scrobble_queue.json"))
+}
+
+/// Whether a failed request is worth retrying later: no response at all
+/// (offline, DNS, timeout) or a server-side 5xx. A 4xx means the server
+/// understood and refused (bad credentials etc.), retrying can't help.
+pub fn is_transient(error: &reqwest::Error) -> bool {
+    match error.status() {
+        Some(status) => status.is_server_error(),
+        None => true,
+    }
+}
+
+/// Credentials snapshot for draining; `None` skips that service.
+#[derive(Debug, Clone, Default)]
+pub struct Credentials {
+    /// (api_key, api_secret, session_key)
+    pub lastfm: Option<(String, String, String)>,
+    pub librefm_session_key: Option<String>,
+    /// Raw token as stored in config; "Token " prefix added when missing.
+    pub listenbrainz_token: Option<String>,
+}
+
+/// Enqueue a failed scrobble for the given service, merging with an existing
+/// entry for the same listen so one track failing on two services stays one
+/// queue item with two pending services.
+pub async fn enqueue(
+    path: &Path,
+    service: Service,
+    artist: &str,
+    title: &str,
+    album: Option<&str>,
+    timestamp: i64,
+) {
+    let _guard = QUEUE_LOCK.lock().await;
+    let mut queue = ScrobbleQueue::load(path);
+
+    if let Some(existing) = queue
+        .items
+        .iter_mut()
+        .find(|i| i.timestamp == timestamp && i.artist == artist && i.title == title)
+    {
+        if !existing.pending.contains(&service) {
+            existing.pending.push(service);
+        }
+    } else {
+        queue.push(QueuedScrobble {
+            artist: artist.to_string(),
+            title: title.to_string(),
+            album: album.map(|s| s.to_string()),
+            timestamp,
+            pending: vec![service],
+        });
+    }
+
+    if let Err(e) = queue.save(path) {
+        tracing::warn!(error = %e, "failed to persist scrobble queue");
+    } else {
+        tracing::info!(
+            service = service.label(),
+            "queued offline scrobble: {} - {}",
+            artist,
+            title
+        );
+    }
+}
+
+/// Resubmit queued scrobbles. Per service, the first transient failure skips
+/// that service for the rest of this run (still unreachable); a permanent
+/// failure drops the service from that entry. The queue is saved after every
+/// change so an interrupted drain loses at most nothing.
+pub async fn drain(path: &Path, creds: &Credentials) {
+    let _guard = QUEUE_LOCK.lock().await;
+    let mut queue = ScrobbleQueue::load(path);
+    if queue.is_empty() {
+        return;
+    }
+    tracing::info!("draining scrobble queue ({} items)", queue.items.len());
+
+    let mut give_up: Vec<Service> = Vec::new();
+
+    for item in &mut queue.items {
+        let mut done: Vec<Service> = Vec::new();
+        for &service in &item.pending {
+            if give_up.contains(&service) {
+                continue;
+            }
+            match submit_one(service, item, creds).await {
+                Outcome::Sent => {
+                    tracing::info!(
+                        service = service.label(),
+                        "resubmitted queued scrobble: {} - {}",
+                        item.artist,
+                        item.title
+                    );
+                    done.push(service);
+                }
+                Outcome::NoCredentials => {
+                    // Not configured (anymore); nothing to deliver to.
+                    done.push(service);
+                }
+                Outcome::Transient => {
+                    give_up.push(service);
+                }
+                Outcome::Permanent(e) => {
+                    tracing::warn!(
+                        service = service.label(),
+                        error = %e,
+                        "dropping queued scrobble after permanent error: {} - {}",
+                        item.artist,
+                        item.title
+                    );
+                    done.push(service);
+                }
+            }
+        }
+        item.pending.retain(|s| !done.contains(s));
+    }
+
+    queue.items.retain(|i| !i.pending.is_empty());
+    if let Err(e) = queue.save(path) {
+        tracing::warn!(error = %e, "failed to persist scrobble queue");
+    }
+}
+
+enum Outcome {
+    Sent,
+    Transient,
+    Permanent(reqwest::Error),
+    NoCredentials,
+}
+
+async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials) -> Outcome {
+    let album = item.album.as_deref();
+    let result = match service {
+        Service::LastFm => {
+            let Some((key, secret, session)) = &creds.lastfm else {
+                return Outcome::NoCredentials;
+            };
+            let scrobble = lastfm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
+            lastfm::submit_scrobble(key, secret, session, &scrobble)
+                .await
+                .map(|_| ())
+        }
+        Service::LibreFm => {
+            let Some(session) = &creds.librefm_session_key else {
+                return Outcome::NoCredentials;
+            };
+            let scrobble = librefm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
+            librefm::submit_scrobble(librefm::API_KEY, librefm::API_SECRET, session, &scrobble)
+                .await
+                .map(|_| ())
+        }
+        Service::ListenBrainz => {
+            let Some(token) = &creds.listenbrainz_token else {
+                return Outcome::NoCredentials;
+            };
+            let auth = if token.contains(' ') {
+                token.clone()
+            } else {
+                format!("Token {token}")
+            };
+            let listen = musicbrainz::make_listen_at(
+                &item.artist,
+                &item.title,
+                album,
+                None,
+                item.timestamp,
+            );
+            musicbrainz::submit_listens(&auth, vec![listen], "import")
+                .await
+                .map(|_| ())
+        }
+    };
+
+    match result {
+        Ok(()) => Outcome::Sent,
+        Err(e) if is_transient(&e) => Outcome::Transient,
+        Err(e) => Outcome::Permanent(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(title: &str, ts: i64, pending: Vec<Service>) -> QueuedScrobble {
+        QueuedScrobble {
+            artist: "Artist".into(),
+            title: title.into(),
+            album: None,
+            timestamp: ts,
+            pending,
+        }
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("kopuz-queue-test-{}-{name}", std::process::id()))
+    }
+
+    #[test]
+    fn push_caps_queue_and_drops_oldest() {
+        let mut q = ScrobbleQueue::default();
+        for i in 0..(MAX_QUEUED + 10) {
+            q.push(entry(&format!("t{i}"), i as i64, vec![Service::LastFm]));
+        }
+        assert_eq!(q.items.len(), MAX_QUEUED);
+        // The 10 oldest entries were dropped.
+        assert_eq!(q.items.first().unwrap().title, "t10");
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let path = temp_path("roundtrip.json");
+        let mut q = ScrobbleQueue::default();
+        q.push(entry("song", 1700000000, vec![Service::LibreFm, Service::ListenBrainz]));
+        q.save(&path).unwrap();
+
+        let loaded = ScrobbleQueue::load(&path);
+        assert_eq!(loaded.items.len(), 1);
+        assert_eq!(loaded.items[0].title, "song");
+        assert_eq!(
+            loaded.items[0].pending,
+            vec![Service::LibreFm, Service::ListenBrainz]
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn corrupt_or_missing_file_loads_empty() {
+        let missing = temp_path("missing.json");
+        assert!(ScrobbleQueue::load(&missing).is_empty());
+
+        let corrupt = temp_path("corrupt.json");
+        std::fs::write(&corrupt, "not json at all").unwrap();
+        assert!(ScrobbleQueue::load(&corrupt).is_empty());
+        let _ = std::fs::remove_file(&corrupt);
+    }
+
+    #[tokio::test]
+    async fn enqueue_merges_same_listen_across_services() {
+        let path = temp_path("merge.json");
+        let _ = std::fs::remove_file(&path);
+
+        enqueue(&path, Service::LastFm, "Artist", "Song", Some("Album"), 42).await;
+        enqueue(&path, Service::ListenBrainz, "Artist", "Song", Some("Album"), 42).await;
+        // Duplicate service on the same listen must not double up.
+        enqueue(&path, Service::LastFm, "Artist", "Song", Some("Album"), 42).await;
+
+        let q = ScrobbleQueue::load(&path);
+        assert_eq!(q.items.len(), 1);
+        assert_eq!(
+            q.items[0].pending,
+            vec![Service::LastFm, Service::ListenBrainz]
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn drain_without_credentials_clears_queue() {
+        // No credentials configured: nothing to deliver to, entries are
+        // released instead of sitting in the queue forever.
+        let path = temp_path("nocreds.json");
+        let _ = std::fs::remove_file(&path);
+        enqueue(&path, Service::LastFm, "Artist", "Song", None, 42).await;
+
+        drain(&path, &Credentials::default()).await;
+
+        assert!(ScrobbleQueue::load(&path).is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/scrobble/src/queue.rs
+++ b/crates/scrobble/src/queue.rs
@@ -164,9 +164,16 @@ pub async fn enqueue(
 /// failure drops the service from that entry. Progress is checkpointed to
 /// disk after every entry, so an interrupted drain re-sends at most the one
 /// in-flight item instead of replaying everything already delivered.
+///
+/// The mutex is held only around file I/O; network submissions run outside
+/// the lock so concurrent `enqueue()` calls are never blocked by the wire.
+/// Each checkpoint re-loads the on-disk queue and merges progress into it,
+/// preserving any entries added by `enqueue()` while drain was in flight.
 pub async fn drain(path: &Path, creds: &Credentials) {
-    let _guard = QUEUE_LOCK.lock().await;
-    let mut queue = ScrobbleQueue::load(path);
+    let queue = {
+        let _guard = QUEUE_LOCK.lock().await;
+        ScrobbleQueue::load(path)
+    };
     if queue.is_empty() {
         return;
     }
@@ -174,14 +181,13 @@ pub async fn drain(path: &Path, creds: &Credentials) {
 
     let mut give_up: Vec<Service> = Vec::new();
 
-    for idx in 0..queue.items.len() {
-        let item = queue.items[idx].clone();
+    for item in &queue.items {
         let mut done: Vec<Service> = Vec::new();
         for &service in &item.pending {
             if give_up.contains(&service) {
                 continue;
             }
-            match submit_one(service, &item, creds).await {
+            match submit_one(service, item, creds).await {
                 Outcome::Sent => {
                     tracing::info!(
                         service = service.label(),
@@ -211,16 +217,21 @@ pub async fn drain(path: &Path, creds: &Credentials) {
             }
         }
         if !done.is_empty() {
-            queue.items[idx].pending.retain(|s| !done.contains(s));
-            if let Err(e) = queue.save(path) {
+            // Re-acquire the lock only for the checkpoint write. Reload the
+            // on-disk queue to merge any enqueue() calls that arrived while
+            // we were on the wire, then remove the services we just delivered.
+            let _guard = QUEUE_LOCK.lock().await;
+            let mut on_disk = ScrobbleQueue::load(path);
+            if let Some(disk_item) = on_disk.items.iter_mut().find(|i| {
+                i.timestamp == item.timestamp && i.artist == item.artist && i.title == item.title
+            }) {
+                disk_item.pending.retain(|s| !done.contains(s));
+            }
+            on_disk.items.retain(|i| !i.pending.is_empty());
+            if let Err(e) = on_disk.save(path) {
                 tracing::warn!(error = %e, "failed to checkpoint scrobble queue");
             }
         }
-    }
-
-    queue.items.retain(|i| !i.pending.is_empty());
-    if let Err(e) = queue.save(path) {
-        tracing::warn!(error = %e, "failed to persist scrobble queue");
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #335. Scrobbles that failed (no network, server hiccup) were logged and lost, so offline listening never reached Last.fm / Libre.fm / ListenBrainz. Both protocols support backdated submissions (Last.fm `track.scrobble` takes a `timestamp`, ListenBrainz takes `listened_at`), so this adds an offline queue that resubmits them with their **original listen time**.

## How it works

New `scrobble::queue` module:

* A scrobble that fails with a **transient** error (no response at all, or a 5xx) is persisted to `scrobble_queue.json` next to `config.json`, with its original timestamp and the services it's still owed to (one listen failing on two services stays one entry with two pending services).
* **Permanent** errors (4xx, e.g. revoked credentials) are never queued, retrying can't succeed.
* The queue is drained on startup and whenever a scrobble succeeds again (a success means we're online). During a drain, the first transient failure for a service skips that service for the rest of the run instead of hammering an unreachable host.
* Capped at 500 entries (oldest dropped first); a corrupt or missing file loads as an empty queue; file access is serialized behind a mutex.
* Now-playing is deliberately not queued, it's only meaningful live.

## Also in this PR

The local-playback path was missing the Libre.fm now-playing/scrobble submission entirely (#378 only added it to the server-stream path), so local plays never scrobbled to Libre.fm. It's wired up now, and the queue covers it.

## Tests

Unit tests in `scrobble::queue`: queue cap and oldest-first dropping, save/load roundtrip, corrupt/missing file loads empty, cross-service merge of the same listen, credential-less drain releases entries.

## Verified end to end

```
08:17:02  Libre.fm scrobble failed: error sending request
08:17:02  queued offline scrobble: Kero Kero Bonito - Bonito Intro service="Libre.fm"
08:18:52  Libre.fm scrobbled: Kero Kero Bonito - Intro Bonito
08:18:52  draining scrobble queue (1 items)
08:18:54  resubmitted queued scrobble: Kero Kero Bonito - Bonito Intro service="Libre.fm"
```

Queue file emptied afterwards and the resubmitted listen kept its original timestamp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent offline scrobble queue with automatic retry for failed submissions across Last.fm, Libre.fm, and MusicBrainz.
* **Bug Fixes**
  * Retried scrobbles/listens now preserve the original listen time via explicit timestamps.
  * Offline queued items are retried later: the queue drains after successful submissions and is processed once on startup (non-wasm).
  * Improved local-track scrobbling metadata for MusicBrainz (additional recording ID) and improved Libre.fm “now playing” gating/initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->