### PR TITLE
feat: map Matroska audio content-types to mka decode hint

### DIFF
--- a/crates/pages/src/server/mod.rs
+++ b/crates/pages/src/server/mod.rs
@@ -67,6 +67,9 @@ pub(super) fn content_type_to_ext(content_type: &str) -> Option<&'static str> {
         "audio/mp4" | "audio/x-m4a" | "video/mp4" => Some("m4a"),
         "audio/ogg" | "audio/opus" => Some("ogg"),
         "audio/webm" | "video/webm" => Some("webm"),
+        "audio/x-matroska" | "audio/matroska" | "video/x-matroska" | "video/matroska" => {
+            Some("mka")
+        }
         "audio/aac" => Some("aac"),
         "audio/wav" | "audio/x-wav" => Some("wav"),
         "audio/aiff" | "audio/x-aiff" => Some("aiff"),
@@ -135,5 +138,39 @@ pub async fn download_tracks_batch(
                 Err(e) => tracing::warn!(%id, error = %e, "batch download failed"),
             }
         }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::content_type_to_ext;
+
+    #[test]
+    fn maps_matroska_audio_to_mka() {
+        assert_eq!(content_type_to_ext("audio/x-matroska"), Some("mka"));
+        assert_eq!(content_type_to_ext("audio/matroska"), Some("mka"));
+        assert_eq!(content_type_to_ext("video/x-matroska"), Some("mka"));
+        assert_eq!(content_type_to_ext("video/matroska"), Some("mka"));
+    }
+
+    #[test]
+    fn maps_matroska_with_codec_parameters() {
+        assert_eq!(
+            content_type_to_ext("audio/x-matroska; codecs=opus"),
+            Some("mka")
+        );
+    }
+
+    #[test]
+    fn unknown_container_returns_none() {
+        assert_eq!(content_type_to_ext("application/octet-stream"), None);
+    }
+
+    #[test]
+    fn preserves_existing_mappings() {
+        assert_eq!(content_type_to_ext("audio/mpeg"), Some("mp3"));
+        assert_eq!(content_type_to_ext("audio/flac"), Some("flac"));
+        assert_eq!(content_type_to_ext("audio/mp4"), Some("m4a"));
+        assert_eq!(content_type_to_ext("audio/ogg"), Some("ogg"));
     }
 }


### PR DESCRIPTION
## Summary

Add Matroska audio content-types to `content_type_to_ext` so MKA streamed from a media server resolves to the `mka` extension hint that symphonia's Matroska demuxer expects, instead of falling through to the default hint.

The match arm now covers `audio/x-matroska`, `audio/matroska`, `video/x-matroska`, and `video/matroska`, all of which carry Matroska audio content.

## Why this matters

Closes the streaming gap reported in #213. The local scanner already accepts `mka` files (crates/reader/src/scanner.rs:144) and the workspace builds symphonia with `features = ["all"]`, which includes the Matroska demuxer, so local MKA playback already works. The remaining gap was server streaming: `content_type_to_ext` in crates/pages/src/server/mod.rs maps an audio content-type to a file extension that is used as the symphonia decode hint (mod.rs:92, download_manager.rs:438), and it had no Matroska entry. MKA streamed from a server fell through to the default hint, so it decoded with the wrong container hint. This change makes the streamed-source path mirror the local path that already accepts `mka`.

## Testing

`cargo test -p pages --lib server::tests` (4 tests, all passing):
- maps the four Matroska content-types to `Some("mka")`
- maps a content-type carrying codec parameters (`audio/x-matroska; codecs=opus`) after the existing `split(';')` trim
- an unknown container content-type still returns `None`
- existing mp3/flac/m4a/ogg mappings are unchanged

`cargo fmt -p pages` clean.

Fixes #213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing and handling Matroska container audio and video file formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->