### PR TITLE
refactor: add MediaSource::cleanup_signin() for per-service credential teardown

### DIFF
--- a/crates/pages/src/settings.rs
+++ b/crates/pages/src/settings.rs
@@ -445,6 +445,7 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
     };
 
     let db_for_switch = use_context::<hooks::ReadDb>();
+    let active_source_for_cleanup = use_context::<Signal<::server::source::ActiveSource>>();
     let handle_switch_server = move |id: String| {
         let db = db_for_switch.clone();
         spawn(async move {
@@ -474,15 +475,12 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
     let handle_delete_saved = move |id: String| {
         let service = config.peek().find_saved_server(&id).map(|s| s.service);
         config.write().remove_saved_server(&id);
-        // Wipe the isolated browser-profile dir of browser-sign-in backends.
-        match service {
-            Some(MusicService::YtMusic) => {
-                let _ = ::server::ytmusic::isolated_profile::delete_profile(&id);
-            }
-            Some(MusicService::SoundCloud) => {
-                let _ = ::server::soundcloud::signin::delete_profile(&id);
-            }
-            _ => {}
+        if let Some(service) = service {
+            let db = active_source_for_cleanup.peek().db().clone();
+            spawn(async move {
+                let source = ::server::source::signin_cleanup(db, &id, service);
+                let _ = source.cleanup_signin().await;
+            });
         }
     };
 

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -528,6 +528,16 @@ pub trait MediaSource: Send + Sync {
 
     // --- uniform ops (default): a plain source-scoped DB read/write ---------
 
+    /// Tear down any per-source sign-in state on sign-out / saved-server
+    /// removal: stored creds (already removed from config by the caller) plus
+    /// any on-disk webview profile or cached data dir. The default is a no-op —
+    /// services whose only sign-in state is the stored cred need nothing here.
+    /// Browser-sign-in sources (YT Music, SoundCloud) override this to wipe
+    /// their isolated profile directory.
+    async fn cleanup_signin(&self) -> Result<(), SourceError> {
+        Ok(())
+    }
+
     /// One album's tracks (disc/track-ordered), read from this source's library
     /// cache. Uniform across sources — the UI goes through the source rather than
     /// touching the DB directly.
@@ -1911,6 +1921,14 @@ impl MediaSource for YtSource {
         }
     }
 
+    async fn cleanup_signin(&self) -> Result<(), SourceError> {
+        if let Source::Server(id) = self.source() {
+            crate::ytmusic::isolated_profile::delete_profile(id)
+                .map_err(|e| SourceError::Backend(e.to_string()))?;
+        }
+        Ok(())
+    }
+
     async fn start_radio(&self, seed_ref: &str) -> Result<Vec<reader::Track>, SourceError> {
         if seed_ref.trim().is_empty() {
             return Err(SourceError::InvalidInput("track has no video id".into()));
@@ -2301,6 +2319,28 @@ pub fn active(db: Db, config: &AppConfig) -> Box<dyn MediaSource> {
     resolve(db, config, &config.active_source)
 }
 
+/// Build a [`MediaSource`] for a saved server purely to run
+/// [`cleanup_signin`](MediaSource::cleanup_signin) on sign-out / removal —
+/// no live creds needed, since teardown only touches local on-disk state.
+/// Used by Settings so the delete path goes through the trait instead of
+/// branching on the concrete service.
+pub fn signin_cleanup(db: Db, id: &str, service: MusicService) -> Box<dyn MediaSource> {
+    let source = Source::Server(id.to_string());
+    match service {
+        MusicService::YtMusic => Box::new(YtSource {
+            db,
+            source,
+            client: YouTubeMusicClient::with_cookies(String::new()),
+        }),
+        MusicService::SoundCloud => Box::new(SoundcloudSource {
+            db,
+            source,
+            token: None,
+        }),
+        _ => Box::new(OfflineServerSource { db, source }),
+    }
+}
+
 // ============================ SoundCloud ===============================
 
 struct SoundcloudSource {
@@ -2336,6 +2376,14 @@ impl MediaSource for SoundcloudSource {
             albums: AlbumType::Standard,
             favorites_sync: FavoritesSync::Paginated,
         }
+    }
+
+    async fn cleanup_signin(&self) -> Result<(), SourceError> {
+        if let Source::Server(id) = self.source() {
+            crate::soundcloud::signin::delete_profile(id)
+                .map_err(|e| SourceError::Backend(e.to_string()))?;
+        }
+        Ok(())
     }
 
     async fn resolve_stream(&self, item_id: &str) -> Result<StreamInfo, SourceError> {

--- a/crates/server/tests/source.rs
+++ b/crates/server/tests/source.rs
@@ -6,17 +6,28 @@
 
 use std::path::PathBuf;
 
+use config::MusicService;
 use db::Source;
 use server::source;
 
-fn unique_db() -> PathBuf {
+fn unique_suffix() -> String {
+    static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let dir = std::env::temp_dir().join(format!("kopuz-source-{nanos}"));
+    format!("{nanos}-{n}")
+}
+
+fn unique_db() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("kopuz-source-{}", unique_suffix()));
     std::fs::create_dir_all(&dir).unwrap();
     dir.join("kopuz.db")
+}
+
+fn unique_server_id(prefix: &str) -> String {
+    format!("{prefix}-{}", unique_suffix())
 }
 
 #[tokio::test]
@@ -73,4 +84,58 @@ async fn local_favorite_round_trips() {
 
     src.set_favorite("/music/x.flac", false).await.unwrap();
     assert!(!src.is_favorite("/music/x.flac").await);
+}
+
+#[tokio::test]
+async fn signin_cleanup_jellyfin_is_noop() {
+    let db = db::init(&unique_db()).await.unwrap();
+    let id = unique_server_id("jellyfin-cleanup");
+    let yt_profile = server::ytmusic::isolated_profile::profile_dir(&id);
+    let sc_profile = server::soundcloud::signin::profile_dir(&id);
+    assert!(!yt_profile.exists());
+    assert!(!sc_profile.exists());
+
+    let src = source::signin_cleanup(db, &id, MusicService::Jellyfin);
+
+    assert!(src.cleanup_signin().await.is_ok());
+    assert!(!yt_profile.exists());
+    assert!(!sc_profile.exists());
+}
+
+#[tokio::test]
+async fn signin_cleanup_ytmusic_removes_profile_dir() {
+    let db = db::init(&unique_db()).await.unwrap();
+    let id = unique_server_id("yt-cleanup");
+    let profile = server::ytmusic::isolated_profile::profile_dir(&id);
+    let _ = std::fs::remove_dir_all(&profile);
+
+    let src = source::signin_cleanup(db.clone(), &id, MusicService::YtMusic);
+    assert!(src.cleanup_signin().await.is_ok());
+    assert!(!profile.exists());
+
+    std::fs::create_dir_all(&profile).unwrap();
+    assert!(profile.is_dir());
+
+    let src = source::signin_cleanup(db, &id, MusicService::YtMusic);
+    assert!(src.cleanup_signin().await.is_ok());
+    assert!(!profile.exists());
+}
+
+#[tokio::test]
+async fn signin_cleanup_soundcloud_removes_profile_dir() {
+    let db = db::init(&unique_db()).await.unwrap();
+    let id = unique_server_id("sc-cleanup");
+    let profile = server::soundcloud::signin::profile_dir(&id);
+    let _ = std::fs::remove_dir_all(&profile);
+
+    let src = source::signin_cleanup(db.clone(), &id, MusicService::SoundCloud);
+    assert!(src.cleanup_signin().await.is_ok());
+    assert!(!profile.exists());
+
+    std::fs::create_dir_all(&profile).unwrap();
+    assert!(profile.is_dir());
+
+    let src = source::signin_cleanup(db, &id, MusicService::SoundCloud);
+    assert!(src.cleanup_signin().await.is_ok());
+    assert!(!profile.exists());
 }


### PR DESCRIPTION
## Summary

This moves per-service sign-out and credential teardown behind the `MediaSource` trait, so the Settings delete path no longer has to know which concrete service it is dealing with.

## Why this matters

Closes #428. When a saved server is removed or signed out in Settings, the credential and profile teardown was done ad-hoc per service at the call site. The `handle_delete_saved` closure in `crates/pages/src/settings.rs` matched on `MusicService` to decide whether to wipe an isolated webview profile directory: YT Music and SoundCloud each keep one that must be cleaned on sign-out, while other services only need their stored cred removed. That made the delete path the one remaining place still branching on the concrete service instead of going through the source abstraction the rest of the `MediaSource` refactor already adopted. As more services are added, that branch is exactly the coupling this work is meant to remove, and it was explicitly deferred during the SQLite/MediaSource refactor.

## Changes

The trait gains a default-implemented async method, `MediaSource::cleanup_signin(&self) -> Result<(), SourceError>`. Its default is a no-op, because services whose only sign-in state is a stored credential (Jellyfin, Subsonic, Local) need nothing beyond the config removal the caller already performs. `YtSource` and `SoundcloudSource` override it to additionally remove their isolated webview profile directory, keyed by the source's server id, mapping any io error to `SourceError::Backend`.

A small `signin_cleanup(db, id, service)` factory builds a cleanup-capable source for any saved server. It needs no live credentials, since the teardown only touches local on-disk state, which is what lets the call site go through the trait for a server that may not be the active one.

`handle_delete_saved` then calls `cleanup_signin().await` uniformly instead of matching on the service. The on-disk config removal stays exactly where it was; only the credential and profile teardown moves behind the trait. New integration tests cover the default no-op (which must leave the filesystem untouched) and the YT and SoundCloud overrides removing an existing profile directory while staying a no-op when one is absent.

## Testing

`cargo fmt --check`, `cargo clippy -p server`, `cargo check -p server`, and `cargo check -p pages` all pass clean. `cargo test -p server --test source` passes with 5 tests, including the 3 new `signin_cleanup_*` cases.

Fixes #428


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a saved server now properly clears its saved sign-in state instead of only removing browser-profile data.
  * Cleanup now works consistently for supported music services, including removing isolated login data where needed.
  * Non-isolated services are handled safely without unnecessary file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->