### PR TITLE
Native renderer: kopuz on Blitz (wgpu), no webview — rebuild

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4856,6 +4856,7 @@ name = "kopuz-components"
 version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
+ "blitz-traits",
  "dioxus",
  "directories",
  "kopuz-config",
@@ -4874,6 +4875,7 @@ dependencies = [
  "tracing",
  "uuid 1.23.2",
  "webbrowser",
+ "winit",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ dependencies = [
 [[package]]
 name = "accesskit_xplat"
 version = "0.1.1"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -854,7 +854,7 @@ checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
 [[package]]
 name = "blitz-dom"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "accesskit",
  "anyrender",
@@ -865,7 +865,7 @@ dependencies = [
  "color",
  "cssparser 0.37.0",
  "cursor-icon",
- "debug_timer 0.1.3 (git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8)",
+ "debug_timer 0.1.3 (git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e)",
  "euclid",
  "html-escape",
  "image",
@@ -877,15 +877,15 @@ dependencies = [
  "parley",
  "percent-encoding",
  "rayon",
- "selectors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.38.0",
  "skrifa",
  "slab",
  "smallvec",
  "stylo",
- "stylo_dom 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stylo_static_prefs 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stylo_dom",
+ "stylo_static_prefs",
  "stylo_taffy",
- "stylo_traits 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stylo_traits",
  "taffy",
  "thread_local",
  "url",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "blitz-html"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "blitz-dom",
  "blitz-traits",
@@ -908,7 +908,7 @@ dependencies = [
 [[package]]
 name = "blitz-net"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "blitz-traits",
  "data-url",
@@ -920,7 +920,7 @@ dependencies = [
 [[package]]
 name = "blitz-paint"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "anyrender",
  "anyrender_svg",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "blitz-shell"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "accesskit",
  "accesskit_xplat",
@@ -961,7 +961,7 @@ dependencies = [
 [[package]]
 name = "blitz-traits"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "bitflags 2.13.0",
  "bytes",
@@ -1936,7 +1936,7 @@ checksum = "da220af51a1a335e9a930beaaef53d261e41ea9eecfb3d973a3ddae1a7284b9c"
 [[package]]
 name = "debug_timer"
 version = "0.1.3"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 
 [[package]]
 name = "der"
@@ -2436,7 +2436,7 @@ dependencies = [
 [[package]]
 name = "dioxus-native"
 version = "0.7.0"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "android-activity",
  "anyrender",
@@ -2469,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "dioxus-native-dom"
 version = "0.7.0"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "blitz-dom",
  "blitz-traits",
@@ -8286,28 +8286,10 @@ dependencies = [
  "phf_codegen 0.13.1",
  "precomputed-hash",
  "rustc-hash 2.1.2",
- "servo_arc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo_arc 0.4.3",
  "smallvec",
-]
-
-[[package]]
-name = "selectors"
-version = "0.38.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
-dependencies = [
- "bitflags 2.13.0",
- "cssparser 0.37.0",
- "derive_more 2.1.1",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "precomputed-hash",
- "rustc-hash 2.1.2",
- "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "smallvec",
- "to_shmem 0.4.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "to_shmem_derive 0.1.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "to_shmem",
+ "to_shmem_derive",
 ]
 
 [[package]]
@@ -8464,14 +8446,6 @@ name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
-name = "servo_arc"
-version = "0.4.3"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9110,7 +9084,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.18.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=701ae9c8a28cd8da50970ff214ad986e689b2846#701ae9c8a28cd8da50970ff214ad986e689b2846"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -9138,9 +9112,9 @@ dependencies = [
  "rayon",
  "rayon-core",
  "rustc-hash 2.1.2",
- "selectors 0.38.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "selectors 0.38.0",
  "serde",
- "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "servo_arc 0.4.3",
  "smallbitvec",
  "smallvec",
  "static_assertions",
@@ -9149,13 +9123,13 @@ dependencies = [
  "strum_macros 0.28.0",
  "stylo_atoms",
  "stylo_derive",
- "stylo_dom 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "stylo_malloc_size_of 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "stylo_static_prefs 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "stylo_traits 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "stylo_dom",
+ "stylo_malloc_size_of",
+ "stylo_static_prefs",
+ "stylo_traits",
  "thin-vec",
- "to_shmem 0.4.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "to_shmem_derive 0.1.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "to_shmem",
+ "to_shmem_derive",
  "uluru",
  "url",
  "void",
@@ -9166,7 +9140,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.18.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=96224381a814e4267ac7cab3f33a9827597b8f68#96224381a814e4267ac7cab3f33a9827597b8f68"
 dependencies = [
  "string_cache 0.9.0",
  "string_cache_codegen 0.6.1",
@@ -9175,7 +9149,8 @@ dependencies = [
 [[package]]
 name = "stylo_derive"
 version = "0.18.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d312e035ba0b282b24f50c45378e9d45424cec68a9cde130df2b54ef59514a3"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -9191,16 +9166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8320050ce458da456b320dfa1252783e4113b3b1a05d0aefb41cbe2bb35ed849"
 dependencies = [
  "bitflags 2.13.0",
- "stylo_malloc_size_of 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "stylo_dom"
-version = "0.18.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
-dependencies = [
- "bitflags 2.13.0",
- "stylo_malloc_size_of 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "stylo_malloc_size_of",
 ]
 
 [[package]]
@@ -9212,25 +9178,8 @@ dependencies = [
  "app_units",
  "cssparser 0.37.0",
  "euclid",
- "selectors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "servo_arc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallbitvec",
- "smallvec",
- "string_cache 0.9.0",
- "thin-vec",
- "void",
-]
-
-[[package]]
-name = "stylo_malloc_size_of"
-version = "0.18.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
-dependencies = [
- "app_units",
- "cssparser 0.37.0",
- "euclid",
- "selectors 0.38.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "selectors 0.38.0",
+ "servo_arc 0.4.3",
  "smallbitvec",
  "smallvec",
  "string_cache 0.9.0",
@@ -9248,17 +9197,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "stylo_static_prefs"
-version = "0.18.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
-dependencies = [
- "toml 1.1.2+spec-1.1.0",
-]
-
-[[package]]
 name = "stylo_taffy"
 version = "0.3.0-alpha.4"
-source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3b8f6ae7303e585377d1a621c5a278a30ea2125e#3b8f6ae7303e585377d1a621c5a278a30ea2125e"
 dependencies = [
  "stylo",
  "stylo_atoms",
@@ -9276,35 +9217,14 @@ dependencies = [
  "cssparser 0.37.0",
  "euclid",
  "malloc_size_of_derive",
- "selectors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "selectors 0.38.0",
  "serde",
- "servo_arc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo_arc 0.4.3",
  "stylo_atoms",
- "stylo_malloc_size_of 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stylo_malloc_size_of",
  "thin-vec",
- "to_shmem 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "to_shmem_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url",
-]
-
-[[package]]
-name = "stylo_traits"
-version = "0.18.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
-dependencies = [
- "app_units",
- "bitflags 2.13.0",
- "cssparser 0.37.0",
- "euclid",
- "malloc_size_of_derive",
- "selectors 0.38.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "serde",
- "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "stylo_atoms",
- "stylo_malloc_size_of 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "thin-vec",
- "to_shmem 0.4.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
- "to_shmem_derive 0.1.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "to_shmem",
+ "to_shmem_derive",
  "url",
 ]
 
@@ -9658,8 +9578,7 @@ dependencies = [
 [[package]]
 name = "taffy"
 version = "0.11.0-experimental-cache-fix.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87b88128d417cd7c2c75b8a398177fb9efcb2ae5cddad22bcec106ba9c8e1c3"
+source = "git+https://github.com/Kopuz-org/kopuz-taffy?rev=edc3932b567dc5e3f0417fbe6041670418104294#edc3932b567dc5e3f0417fbe6041670418104294"
 dependencies = [
  "arrayvec",
  "grid",
@@ -9930,20 +9849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8eb8396666f8344ad4b8849ac0d493ae960290ba89ba1aaf0cb8045d2023288"
 dependencies = [
  "cssparser 0.37.0",
- "servo_arc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallbitvec",
- "smallvec",
- "string_cache 0.9.0",
- "thin-vec",
-]
-
-[[package]]
-name = "to_shmem"
-version = "0.4.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
-dependencies = [
- "cssparser 0.37.0",
- "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "servo_arc 0.4.3",
  "smallbitvec",
  "smallvec",
  "string_cache 0.9.0",
@@ -9955,18 +9861,6 @@ name = "to_shmem_derive"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba1f5563024b63bb6acb4558452d9ba737518c1d11fcc1861febe98d1e31cf4"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "synstructure",
-]
-
-[[package]]
-name = "to_shmem_derive"
-version = "0.1.0"
-source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
@@ -12934,8 +12828,3 @@ dependencies = [
  "syn 2.0.117",
  "winnow 1.0.3",
 ]
-
-[[patch.unused]]
-name = "taffy"
-version = "0.11.0"
-source = "git+https://github.com/Kopuz-org/kopuz-taffy?rev=8609e92f1a3b60da70ca0a0fd9fa090f62847f46#8609e92f1a3b60da70ca0a0fd9fa090f62847f46"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4833,6 +4833,7 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "objc2-media-player",
+ "parley",
  "percent-encoding",
  "rand 0.10.1",
  "reqwest 0.13.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,91 @@
 version = 4
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
+name = "accesskit"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+dependencies = [
+ "uuid 1.23.2",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53cf47daed85312e763fbf85ceca136e0d7abc68e0a7e12abe11f48172bc3b10"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_consumer"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950720ce064757a1b629caad3a408e8d2c63bb01f29b8a3ff8daa331053ffeb"
+dependencies = [
+ "accesskit",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "accesskit_macos"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cb8b66cef272d48161b02a6317cc2bdd5f98bb0a5e79c68f704a5862aa396b"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.37.0",
+ "hashbrown 0.16.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "accesskit_windows"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff7009f1a532e917d66970a1e80c965140c6cfbbabbdde3d64e5431e6c78e21"
+dependencies = [
+ "accesskit",
+ "accesskit_consumer 0.35.0",
+ "hashbrown 0.16.1",
+ "static_assertions",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "accesskit_xplat"
+version = "0.1.1"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+dependencies = [
+ "accesskit",
+ "accesskit_macos",
+ "accesskit_windows",
+ "android-activity",
+ "raw-window-handle 0.6.2",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -65,21 +151,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
 name = "aligned-vec"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
 dependencies = [
  "equator",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -111,6 +203,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-activity"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2a1bb052857d5dd49572219344a7332b31b76405648eabac5bc68978251bcd"
+dependencies = [
+ "android-properties",
+ "bitflags 2.13.0",
+ "cc",
+ "jni 0.22.4",
+ "libc",
+ "log",
+ "ndk",
+ "ndk-context",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "android-properties"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,10 +243,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "anyrender"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c79ab67fa5a03a47b088c5c9dfc8ad727e2a3a1921517cdf4b642433f925d50"
+dependencies = [
+ "kurbo",
+ "peniko",
+ "raw-window-handle 0.6.2",
+ "smallvec",
+]
+
+[[package]]
+name = "anyrender_svg"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2c1ecd7b35cea3ca88e8310eef73c5c06f7d8b0f878a2ac415ab6cf45de3ec6"
+dependencies = [
+ "anyrender",
+ "image",
+ "kurbo",
+ "peniko",
+ "usvg",
+]
+
+[[package]]
+name = "anyrender_vello"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482dc2351609dff9903c329b73910e42e78ba670aad9d5a1c8c1eecad30aeaac"
+dependencies = [
+ "anyrender",
+ "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-channel",
+ "kurbo",
+ "peniko",
+ "pollster",
+ "rustc-hash 2.1.2",
+ "vello",
+ "wasm-bindgen-futures",
+ "wgpu",
+ "wgpu_context",
+]
+
+[[package]]
+name = "anyrender_vello_cpu"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545d02c58581dc659b65bab63aef1aebcbcc442c96a49a599019c93ac03b1e42"
+dependencies = [
+ "anyrender",
+ "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glifo",
+ "kurbo",
+ "peniko",
+ "pixels_window_renderer",
+ "vello_common",
+ "vello_cpu",
+]
+
+[[package]]
+name = "app_units"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467b60e4ee6761cd6fd4e03ea58acefc8eec0d1b1def995c1b3b783fa7be8a60"
+dependencies = [
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
 
 [[package]]
 name = "arc-swap"
@@ -158,18 +362,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "as-slice"
-version = "0.2.1"
+name = "as-raw-xcb-connection"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "stable_deref_trait",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -448,30 +664,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic_refcell"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e4227379beff4205943696e6c3e0cd809bacdf3f0edd6e3dd153e2269571a4"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror 2.0.18",
- "v_frame",
- "y4m",
-]
 
 [[package]]
 name = "av1-grain"
@@ -608,6 +810,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,11 +847,130 @@ dependencies = [
 
 [[package]]
 name = "bitstream-io"
-version = "4.10.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
+name = "blitz-dom"
+version = "0.3.0-alpha.4"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
 dependencies = [
- "no_std_io2",
+ "accesskit",
+ "anyrender",
+ "app_units",
+ "atomic_refcell",
+ "bitflags 2.13.0",
+ "blitz-traits",
+ "color",
+ "cssparser 0.37.0",
+ "cursor-icon",
+ "debug_timer 0.1.3 (git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8)",
+ "euclid",
+ "html-escape",
+ "image",
+ "keyboard-types 0.7.0",
+ "kurbo",
+ "linebender_resource_handle",
+ "markup5ever 0.39.0",
+ "objc2 0.6.4",
+ "parley",
+ "percent-encoding",
+ "rayon",
+ "selectors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "skrifa",
+ "slab",
+ "smallvec",
+ "stylo",
+ "stylo_dom 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stylo_static_prefs 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stylo_taffy",
+ "stylo_traits 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "taffy",
+ "thread_local",
+ "url",
+ "usvg",
+ "web-time",
+ "wuff",
+]
+
+[[package]]
+name = "blitz-html"
+version = "0.3.0-alpha.4"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+dependencies = [
+ "blitz-dom",
+ "blitz-traits",
+ "html5ever 0.39.0",
+ "xml5ever",
+]
+
+[[package]]
+name = "blitz-net"
+version = "0.3.0-alpha.4"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+dependencies = [
+ "blitz-traits",
+ "data-url",
+ "reqwest 0.13.4",
+ "tokio",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "blitz-paint"
+version = "0.3.0-alpha.4"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+dependencies = [
+ "anyrender",
+ "anyrender_svg",
+ "blitz-dom",
+ "blitz-traits",
+ "color",
+ "euclid",
+ "kurbo",
+ "parley",
+ "peniko",
+ "stylo",
+ "taffy",
+ "usvg",
+]
+
+[[package]]
+name = "blitz-shell"
+version = "0.3.0-alpha.4"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+dependencies = [
+ "accesskit",
+ "accesskit_xplat",
+ "android-activity",
+ "anyrender",
+ "arboard",
+ "blitz-dom",
+ "blitz-paint",
+ "blitz-traits",
+ "futures-util",
+ "keyboard-types 0.7.0",
+ "rfd",
+ "wasm-bindgen",
+ "web-sys",
+ "web-time",
+ "winit",
+]
+
+[[package]]
+name = "blitz-traits"
+version = "0.3.0-alpha.4"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "cursor-icon",
+ "http 1.4.1",
+ "keyboard-types 0.7.0",
+ "serde",
+ "smol_str",
+ "url",
 ]
 
 [[package]]
@@ -663,11 +999,20 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -684,10 +1029,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "built"
-version = "0.8.1"
+name = "borsh"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+checksum = "2f3f6da4992df95bbcd9af42a6c7dcb994498fc9048230405f3b36ff7cd3f145"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "built"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
 
 [[package]]
 name = "bumpalo"
@@ -706,6 +1071,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -751,6 +1130,31 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "calloop"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dbf9978365bac10f54d1d4b04f7ce4427e51f71d61f2fe15e3fed5166474df7"
+dependencies = [
+ "bitflags 2.13.0",
+ "polling 3.11.0",
+ "rustix 1.1.4",
+ "slab",
+ "tracing",
+]
+
+[[package]]
+name = "calloop-wayland-source"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138efcf0940a02ebf0cc8d1eff41a1682a46b431630f4c52450d6265876021fa"
+dependencies = [
+ "calloop",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-client",
 ]
 
 [[package]]
@@ -885,6 +1289,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +1333,26 @@ dependencies = [
  "core-foundation 0.10.1",
  "core-graphics-types",
  "objc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1177,6 +1610,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "coreaudio-rs"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,13 +1649,13 @@ dependencies = [
  "ndk-context",
  "num-derive",
  "num-traits",
- "objc2",
+ "objc2 0.6.4",
  "objc2-audio-toolbox",
  "objc2-avf-audio",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1328,7 +1770,7 @@ version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93d03419cb5950ccfd3daf3ff1c7a36ace64609a1a8746d493df1ca0afde0fa"
 dependencies = [
- "cssparser-macros",
+ "cssparser-macros 0.6.1",
  "dtoa-short",
  "itoa",
  "matches",
@@ -1340,10 +1782,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros 0.7.0",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "serde",
+ "smallvec",
+]
+
+[[package]]
 name = "cssparser-macros"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1370,13 +1836,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1394,11 +1889,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -1414,6 +1920,23 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "debug_timer"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da220af51a1a335e9a930beaaef53d261e41ea9eecfb3d973a3ddae1a7284b9c"
+
+[[package]]
+name = "debug_timer"
+version = "0.1.3"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
 
 [[package]]
 name = "der"
@@ -1857,7 +2380,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "generational-box",
- "keyboard-types",
+ "keyboard-types 0.7.0",
  "lazy-js-bundle",
  "rustversion",
  "serde",
@@ -1908,6 +2431,53 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-wasm",
+]
+
+[[package]]
+name = "dioxus-native"
+version = "0.7.0"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+dependencies = [
+ "android-activity",
+ "anyrender",
+ "anyrender_vello",
+ "anyrender_vello_cpu",
+ "blitz-dom",
+ "blitz-html",
+ "blitz-net",
+ "blitz-paint",
+ "blitz-shell",
+ "blitz-traits",
+ "cfg-if",
+ "dioxus-asset-resolver",
+ "dioxus-cli-config",
+ "dioxus-core",
+ "dioxus-devtools",
+ "dioxus-document",
+ "dioxus-history",
+ "dioxus-html",
+ "dioxus-native-dom",
+ "futures-util",
+ "keyboard-types 0.7.0",
+ "rustc-hash 2.1.2",
+ "tokio",
+ "webbrowser",
+ "wgpu_context",
+ "winit",
+]
+
+[[package]]
+name = "dioxus-native-dom"
+version = "0.7.0"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+dependencies = [
+ "blitz-dom",
+ "blitz-traits",
+ "dioxus-core",
+ "dioxus-html",
+ "futures-util",
+ "keyboard-types 0.7.0",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -2048,9 +2618,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2224,7 +2794,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2265,6 +2835,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -2384,12 +2960,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "fax"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2397,6 +2967,12 @@ checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
 ]
+
+[[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 
 [[package]]
 name = "field-offset"
@@ -2423,6 +2999,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "fluent-bundle"
@@ -2481,6 +3063,66 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
+
+[[package]]
+name = "fontique"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "274fa4f0f0a926ae182c7c076c078cce8a38471d15e61a102a02cac984be9813"
+dependencies = [
+ "hashbrown 0.17.1",
+ "linebender_resource_handle",
+ "memmap2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-core-text",
+ "objc2-foundation 0.3.2",
+ "parlance",
+ "read-fonts",
+ "roxmltree 0.21.1",
+ "smallvec",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "yeslogic-fontconfig-sys",
+]
 
 [[package]]
 name = "foreign-types"
@@ -2866,9 +3508,9 @@ dependencies = [
 
 [[package]]
 name = "gif"
-version = "0.14.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2904,6 +3546,17 @@ dependencies = [
  "libc",
  "system-deps",
  "winapi",
+]
+
+[[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2954,6 +3607,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "glifo"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+dependencies = [
+ "bytemuck",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "skrifa",
+ "smallvec",
+ "vello_common",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2966,9 +3635,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9247516746aa8e53411a0db9b62b0e24efbcf6a76e0ba73e5a91b512ddabed7"
 dependencies = [
  "crossbeam-channel",
- "keyboard-types",
- "objc2",
- "objc2-app-kit",
+ "keyboard-types 0.7.0",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "once_cell",
  "thiserror 2.0.18",
  "windows-sys 0.59.0",
@@ -3035,6 +3704,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3044,6 +3734,46 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.18",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.13.0",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "grid"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
 
 [[package]]
 name = "gtk"
@@ -3098,6 +3828,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+ "svg_fmt",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3143,7 +3883,20 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
+]
+
+[[package]]
+name = "harfrust"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d12c7c642d4ce8c2e784b4751a6634bd89583912265add4a679a8882d123fbcd"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -3162,7 +3915,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -3170,6 +3934,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3235,6 +4002,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3262,6 +4035,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3269,8 +4051,18 @@ checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
 dependencies = [
  "log",
  "mac",
- "markup5ever",
+ "markup5ever 0.14.1",
  "match_token",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -3415,6 +4207,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,6 +4284,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3483,10 +4306,17 @@ checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
@@ -3536,12 +4366,36 @@ checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "icu_segmenter"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0794db0b1a86193ac9c48768d0e6c52c54448e0870ad87907d456ee0dac964"
+dependencies = [
+ "core_maths",
+ "icu_collections",
+ "icu_locale",
+ "icu_provider",
+ "icu_segmenter_data",
+ "potential_utf",
+ "utf8_iter",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_segmenter_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4a2c462a4d927d512f5f882a033ddd62f33a05bb9f230d98f736ac3dc85938f"
 
 [[package]]
 name = "id-arena"
@@ -3578,9 +4432,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.10"
+version = "0.25.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+checksum = "db35664ce6b9810857a38a906215e75a9c879f0696556a39f59c62829710251a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
@@ -3588,9 +4442,8 @@ dependencies = [
  "exr",
  "gif",
  "image-webp",
- "moxcms",
  "num-traits",
- "png 0.18.1",
+ "png 0.17.16",
  "qoi",
  "ravif",
  "rayon",
@@ -3609,6 +4462,12 @@ dependencies = [
  "byteorder-lite",
  "quick-error",
 ]
+
+[[package]]
+name = "imagesize"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "imgref"
@@ -3726,6 +4585,15 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -3863,6 +4731,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+
+[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3886,6 +4760,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fbe853b403ae61a04233030ae8a79d94975281ed9770a1f9e246732b534b28d"
+dependencies = [
+ "bitflags 2.13.0",
+ "serde",
+]
+
+[[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,9 +4806,10 @@ name = "kopuz"
 version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "ctrlc",
  "dioxus",
+ "dioxus-native",
  "directories",
  "discord-rich-presence",
  "getrandom 0.4.2",
@@ -3927,9 +4829,9 @@ dependencies = [
  "kopuz-server",
  "kopuz-utils",
  "libloading 0.8.9",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "objc2-media-player",
  "percent-encoding",
  "rand 0.10.1",
@@ -4077,17 +4979,17 @@ name = "kopuz-player"
 version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cpal",
  "jni 0.21.1",
  "kopuz-config",
  "mpris-server",
  "ndk-context",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-av-foundation",
  "objc2-avf-audio",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-media-player",
  "rb",
  "reqwest 0.13.4",
@@ -4201,10 +5103,22 @@ version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
- "cssparser",
- "html5ever",
+ "cssparser 0.29.6",
+ "html5ever 0.29.1",
  "indexmap",
- "selectors",
+ "selectors 0.24.0",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
 ]
 
 [[package]]
@@ -4364,6 +5278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4500,6 +5420,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_size_of_derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44db74bde26fdf427af23f1d146c211aed857c59e3be750cf2617f6b0b05c94"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "manganis"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4511,7 +5442,7 @@ dependencies = [
  "manganis-core",
  "manganis-macro",
  "ndk-context",
- "objc2",
+ "objc2 0.6.4",
  "thiserror 2.0.18",
 ]
 
@@ -4552,9 +5483,20 @@ dependencies = [
  "log",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
- "string_cache",
- "string_cache_codegen",
- "tendril",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+ "tendril 0.4.3",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril 0.5.0",
+ "web_atoms",
 ]
 
 [[package]]
@@ -4701,16 +5643,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
 name = "mpris-server"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4732,12 +5664,12 @@ dependencies = [
  "crossbeam-channel",
  "dpi",
  "gtk",
- "keyboard-types",
+ "keyboard-types 0.7.0",
  "libxdo",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "thiserror 2.0.18",
@@ -4759,6 +5691,32 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "naga"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
+ "hexf-parse",
+ "indexmap",
+ "libm",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.18",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4839,15 +5797,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no_std_io2"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,7 +5872,7 @@ dependencies = [
  "enumn",
  "memoffset 0.9.1",
  "nt-string",
- "strum_macros",
+ "strum_macros 0.24.3",
  "time",
 ]
 
@@ -5030,6 +5979,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5061,6 +6020,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,23 +6047,39 @@ dependencies = [
 
 [[package]]
 name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-cloud-kit",
- "objc2-core-data",
+ "objc2-core-data 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
+ "objc2-core-image 0.3.2",
  "objc2-core-text",
  "objc2-core-video",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -5098,13 +6089,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5114,19 +6105,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-avf-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-core-image",
+ "objc2-core-image 0.3.2",
  "objc2-core-video",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-image-io",
  "objc2-media-toolbox",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -5136,11 +6127,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-audio-toolbox",
  "objc2-core-audio-types",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5150,8 +6141,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5161,10 +6152,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
 dependencies = [
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-audio-types",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5174,7 +6165,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -5184,8 +6187,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5195,10 +6198,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -5209,9 +6212,22 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.0",
  "dispatch2",
- "objc2",
+ "libc",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -5220,8 +6236,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5232,7 +6248,7 @@ checksum = "05ec576860167a15dd9fce7fbee7512beb4e31f532159d3482d1f9c6caedf31d"
 dependencies = [
  "bitflags 2.13.0",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
@@ -5246,7 +6262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -5258,7 +6274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
  "objc2-io-surface",
@@ -5281,14 +6297,26 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -5298,7 +6326,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b0446e98cf4a784cc7a0177715ff317eeaa8463841c616cfc78aa4f953c4ea"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -5310,7 +6338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -5321,12 +6349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85f2a98483f6e76313cb85a5a185eaa3cda86a177b13a8852d56cbd0085bf635"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
- "objc2-app-kit",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-av-foundation",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5335,10 +6363,47 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd9fdde720df3da7046bb9097811000c1e7ab5cd579fa89d96b27d56781fb30"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-core-media",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -5348,8 +6413,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
 ]
 
 [[package]]
@@ -5359,9 +6426,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.13.0",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5371,11 +6438,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
- "objc2",
- "objc2-app-kit",
+ "block2 0.6.2",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -5440,6 +6507,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5447,6 +6523,7 @@ checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -5467,6 +6544,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "orbclient"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df339f526ea9a60e371768d50efc2f2508c7203290731565d1f7a6f71d21747"
+dependencies = [
+ "libc",
+ "libredox",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5484,6 +6580,15 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
 ]
 
 [[package]]
@@ -5541,16 +6646,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "parlance"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6937eda350acc1a5d05872c3cbf99fe78619c269096e2be3d4a350058639d5"
+
+[[package]]
+name = "parley"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1cfcf399c774719fb1fa51bc6b91e86bdf003b03202a0902f1827ba6750746"
+dependencies = [
+ "fontique",
+ "harfrust",
+ "hashbrown 0.17.1",
+ "icu_normalizer",
+ "icu_properties",
+ "icu_segmenter",
+ "linebender_resource_handle",
+ "parlance",
+ "parley_data",
+ "skrifa",
+]
+
+[[package]]
+name = "parley_data"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d3755e2cc12c0625b0cd2f2773c6a37dd11d1531940c945ade4aeb78f2b145"
+dependencies = [
+ "icu_properties",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "patch-apply"
@@ -5583,6 +6715,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5603,7 +6748,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.10.0",
  "phf_shared 0.10.0",
  "proc-macro-hack",
 ]
@@ -5615,6 +6760,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -5635,6 +6791,16 @@ checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5668,6 +6834,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand 2.4.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5679,6 +6855,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5707,6 +6896,21 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher 1.0.3",
 ]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher 1.0.3",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -5743,6 +6947,31 @@ dependencies = [
  "atomic-waker",
  "fastrand 2.4.1",
  "futures-io",
+]
+
+[[package]]
+name = "pixels"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ddc5048a90da4dab8f3f81fb280f44c9e1d76b68fb2f62dce78b22d55546b1"
+dependencies = [
+ "bytemuck",
+ "pollster",
+ "raw-window-handle 0.6.2",
+ "thiserror 2.0.18",
+ "ultraviolet",
+ "wgpu",
+]
+
+[[package]]
+name = "pixels_window_renderer"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ded35385f65726c281d08118df35f5c8dc24222bab14f3a8de91d61975cbc2"
+dependencies = [
+ "anyrender",
+ "debug_timer 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pixels",
 ]
 
 [[package]]
@@ -5841,6 +7070,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5853,11 +7091,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -5881,6 +7136,12 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "prettyplease"
@@ -6027,12 +7288,6 @@ dependencies = [
  "idna",
  "psl-types",
 ]
-
-[[package]]
-name = "pxfm"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -6263,22 +7518,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "rav1e"
-version = "0.8.1"
+name = "range-alloc"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
 dependencies = [
- "aligned-vec",
  "arbitrary",
  "arg_enum_proc_macro",
  "arrayvec",
- "av-scenechange",
  "av1-grain",
  "bitstream-io",
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.12.1",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -6287,21 +7546,23 @@ dependencies = [
  "noop_proc_macro",
  "num-derive",
  "num-traits",
+ "once_cell",
  "paste",
  "profiling",
- "rand 0.9.4",
- "rand_chacha 0.9.0",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "simd_helpers",
- "thiserror 2.0.18",
+ "system-deps",
+ "thiserror 1.0.69",
  "v_frame",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "ravif"
-version = "0.13.0"
+version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+checksum = "5825c26fddd16ab9f515930d49028a630efec172e903483c94796cfe31893e6b"
 dependencies = [
  "avif-serialize",
  "imgref",
@@ -6323,6 +7584,18 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
+]
 
 [[package]]
 name = "rawcopy-rs-next"
@@ -6361,6 +7634,16 @@ name = "rb"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56cf8381505b60ae18a4097f1d0be093287ca3bf4fbb23d36ac5ad3bba335daa"
+
+[[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -6427,6 +7710,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
 name = "reqwest"
 version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6441,7 +7730,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls",
+ "hyper-tls 0.5.0",
  "ipnet",
  "js-sys",
  "log",
@@ -6528,10 +7817,12 @@ dependencies = [
  "http-body-util",
  "hyper 1.10.1",
  "hyper-rustls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -6543,6 +7834,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -6559,15 +7851,15 @@ version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
 dependencies = [
- "block2",
+ "block2 0.6.2",
  "dispatch2",
  "js-sys",
  "libc",
  "log",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "percent-encoding",
  "pollster",
  "raw-window-handle 0.6.2",
@@ -6635,6 +7927,21 @@ dependencies = [
  "windows 0.51.1",
  "zbus 3.15.2",
  "zvariant 3.15.2",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+
+[[package]]
+name = "roxmltree"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6848,10 +8155,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -6884,6 +8218,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sctk-adwaita"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd3accc0f3f4bbaf2c9e1957a030dc582028130c67660d44c0a0345a22ca69b"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2",
+ "smithay-client-toolkit",
+ "tiny-skia",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6913,15 +8260,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
- "cssparser",
+ "cssparser 0.29.6",
  "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
  "phf_codegen 0.8.0",
  "precomputed-hash",
- "servo_arc",
+ "servo_arc 0.2.0",
  "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cssparser 0.37.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash 2.1.2",
+ "servo_arc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "bitflags 2.13.0",
+ "cssparser 0.37.0",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash 2.1.2",
+ "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "smallvec",
+ "to_shmem 0.4.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "to_shmem_derive 0.1.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
 ]
 
 [[package]]
@@ -7043,6 +8429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7061,6 +8456,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52aa42f8fdf0fed91e5ce7f23d8138441002fa31dca008acf47e6fd4721f741"
 dependencies = [
  "nodrop",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "serde",
  "stable_deref_trait",
 ]
 
@@ -7163,6 +8576,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7173,6 +8595,16 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
 
 [[package]]
 name = "slab"
@@ -7220,12 +8652,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallbitvec"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b0e903ee191d8f7a8fbf0d712c3a1699d19e04ceba5ad1eb673053c7d938a09"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smithay-client-toolkit"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0512da38f5e2b31201a93524adb8d3136276fa4fe4aafab4e1f727a82b534cc0"
+dependencies = [
+ "bitflags 2.13.0",
+ "calloop",
+ "calloop-wayland-source",
+ "cursor-icon",
+ "libc",
+ "log",
+ "memmap2",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-csd-frame",
+ "wayland-cursor",
+ "wayland-protocols",
+ "wayland-protocols-experimental",
+ "wayland-protocols-misc",
+ "wayland-protocols-wlr",
+ "wayland-scanner",
+ "xkeysym",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
 ]
 
 [[package]]
@@ -7291,6 +8766,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7523,6 +9007,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "string_cache"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7531,6 +9024,19 @@ dependencies = [
  "new_debug_unreachable",
  "parking_lot",
  "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
  "precomputed-hash",
  "serde",
 ]
@@ -7548,6 +9054,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7557,6 +9075,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "strum_macros"
@@ -7569,6 +9093,219 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "stylo"
+version = "0.18.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "app_units",
+ "arrayvec",
+ "atomic_refcell",
+ "bitflags 2.13.0",
+ "byteorder",
+ "cssparser 0.37.0",
+ "derive_more 2.1.1",
+ "encoding_rs",
+ "euclid",
+ "icu_segmenter",
+ "indexmap",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "malloc_size_of_derive",
+ "mime",
+ "new_debug_unreachable",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "num_cpus",
+ "parking_lot",
+ "precomputed-hash",
+ "rayon",
+ "rayon-core",
+ "rustc-hash 2.1.2",
+ "selectors 0.38.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "serde",
+ "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "smallbitvec",
+ "smallvec",
+ "static_assertions",
+ "string_cache 0.9.0",
+ "strum",
+ "strum_macros 0.28.0",
+ "stylo_atoms",
+ "stylo_derive",
+ "stylo_dom 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "stylo_malloc_size_of 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "stylo_static_prefs 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "stylo_traits 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "thin-vec",
+ "to_shmem 0.4.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "to_shmem_derive 0.1.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "uluru",
+ "url",
+ "void",
+ "walkdir",
+ "web_atoms",
+]
+
+[[package]]
+name = "stylo_atoms"
+version = "0.18.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
+]
+
+[[package]]
+name = "stylo_derive"
+version = "0.18.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "stylo_dom"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8320050ce458da456b320dfa1252783e4113b3b1a05d0aefb41cbe2bb35ed849"
+dependencies = [
+ "bitflags 2.13.0",
+ "stylo_malloc_size_of 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "stylo_dom"
+version = "0.18.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "bitflags 2.13.0",
+ "stylo_malloc_size_of 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+]
+
+[[package]]
+name = "stylo_malloc_size_of"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac39ecae5f591b1b200e7e400ce586d47b8e2e6122229ad3e93fcbc85f0b1b1"
+dependencies = [
+ "app_units",
+ "cssparser 0.37.0",
+ "euclid",
+ "selectors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "servo_arc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallbitvec",
+ "smallvec",
+ "string_cache 0.9.0",
+ "thin-vec",
+ "void",
+]
+
+[[package]]
+name = "stylo_malloc_size_of"
+version = "0.18.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "app_units",
+ "cssparser 0.37.0",
+ "euclid",
+ "selectors 0.38.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "smallbitvec",
+ "smallvec",
+ "string_cache 0.9.0",
+ "thin-vec",
+ "void",
+]
+
+[[package]]
+name = "stylo_static_prefs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b36e3ea5a1c20dfdc483ae3be554976dc2e7f99510f3322f8e38b594c2f6275"
+dependencies = [
+ "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "stylo_static_prefs"
+version = "0.18.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "stylo_taffy"
+version = "0.3.0-alpha.4"
+source = "git+https://github.com/Kopuz-org/kopuz-blitz?rev=3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8#3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8"
+dependencies = [
+ "stylo",
+ "stylo_atoms",
+ "taffy",
+]
+
+[[package]]
+name = "stylo_traits"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafd455fa178b566e6df9bb0ad3e6e6eae7d202fb636bd32f7af3d33b566a00c"
+dependencies = [
+ "app_units",
+ "bitflags 2.13.0",
+ "cssparser 0.37.0",
+ "euclid",
+ "malloc_size_of_derive",
+ "selectors 0.38.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde",
+ "servo_arc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stylo_atoms",
+ "stylo_malloc_size_of 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thin-vec",
+ "to_shmem 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "to_shmem_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url",
+]
+
+[[package]]
+name = "stylo_traits"
+version = "0.18.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "app_units",
+ "bitflags 2.13.0",
+ "cssparser 0.37.0",
+ "euclid",
+ "malloc_size_of_derive",
+ "selectors 0.38.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "serde",
+ "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "stylo_atoms",
+ "stylo_malloc_size_of 0.18.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "thin-vec",
+ "to_shmem 0.4.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "to_shmem_derive 0.1.0 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "url",
 ]
 
 [[package]]
@@ -7604,6 +9341,22 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "svg_fmt"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
+
+[[package]]
+name = "svgtypes"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695b5790b3131dafa99b3bbfd25a216edb3d216dad9ca208d4657bfb8f2abc3d"
+dependencies = [
+ "kurbo",
+ "siphasher 1.0.3",
+]
 
 [[package]]
 name = "symlink"
@@ -7903,13 +9656,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "taffy"
+version = "0.11.0-experimental-cache-fix.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e87b88128d417cd7c2c75b8a398177fb9efcb2ae5cddad22bcec106ba9c8e1c3"
+dependencies = [
+ "arrayvec",
+ "grid",
+ "serde",
+ "slotmap",
+]
+
+[[package]]
 name = "tao"
 version = "0.34.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.13.0",
- "block2",
+ "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics 0.25.0",
  "crossbeam-channel",
@@ -7925,9 +9690,9 @@ dependencies = [
  "ndk",
  "ndk-context",
  "ndk-sys",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "parking_lot",
  "raw-window-handle 0.5.2",
@@ -7983,6 +9748,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8033,16 +9823,13 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.11.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
 dependencies = [
- "fax",
  "flate2",
- "half",
- "quick-error",
+ "jpeg-decoder",
  "weezl",
- "zune-jpeg",
 ]
 
 [[package]]
@@ -8086,6 +9873,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8110,6 +9922,58 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "to_shmem"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8eb8396666f8344ad4b8849ac0d493ae960290ba89ba1aaf0cb8045d2023288"
+dependencies = [
+ "cssparser 0.37.0",
+ "servo_arc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallbitvec",
+ "smallvec",
+ "string_cache 0.9.0",
+ "thin-vec",
+]
+
+[[package]]
+name = "to_shmem"
+version = "0.4.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "cssparser 0.37.0",
+ "servo_arc 0.4.3 (git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e)",
+ "smallbitvec",
+ "smallvec",
+ "string_cache 0.9.0",
+ "thin-vec",
+]
+
+[[package]]
+name = "to_shmem_derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba1f5563024b63bb6acb4558452d9ba737518c1d11fcc1861febe98d1e31cf4"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "to_shmem_derive"
+version = "0.1.0"
+source = "git+https://github.com/Kopuz-org/kopuz-stylo?rev=ca38e455ef376e5b8715ef80e5e7a13cb5d2962e#ca38e455ef376e5b8715ef80e5e7a13cb5d2962e"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
 
 [[package]]
 name = "tokio"
@@ -8217,9 +10081,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -8259,7 +10138,7 @@ checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -8284,6 +10163,12 @@ checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.3",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -8460,11 +10345,11 @@ dependencies = [
  "dirs",
  "libappindicator",
  "muda",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.17.16",
  "thiserror 2.0.18",
@@ -8476,6 +10361,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "tungstenite"
@@ -8564,6 +10458,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ultraviolet"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea519dad475ee0446b8172793c3c327e4fc81dafdaf05aaac510e630000b6296"
+dependencies = [
+ "wide",
+]
+
+[[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "unic-langid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8594,6 +10506,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8615,10 +10539,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -8658,6 +10600,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -8667,10 +10610,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "usvg"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "rustybuzz",
+ "simplecss",
+ "siphasher 1.0.3",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8_iter"
@@ -8724,6 +10700,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
+name = "vello"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261359dbef879f8110ef7e1c442246c838d33d3d91cb05e0ea9288d432760c9f"
+dependencies = [
+ "bytemuck",
+ "futures-intrusive",
+ "log",
+ "peniko",
+ "png 0.18.1",
+ "skrifa",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "vello_encoding",
+ "vello_shaders",
+ "wgpu",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown 0.17.1",
+ "log",
+ "peniko",
+ "png 0.18.1",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown 0.17.1",
+ "vello_common",
+]
+
+[[package]]
+name = "vello_encoding"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2346f5f0d7dccb3582fcd397b4a57b43165209f1424e0d76e85dd814db164af7"
+dependencies = [
+ "bytemuck",
+ "guillotiere",
+ "peniko",
+ "skrifa",
+ "smallvec",
+]
+
+[[package]]
+name = "vello_shaders"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd38937516fa4b47423d9255bb5e4a65e839ec9d57c38c4af6189ce56bf46b7"
+dependencies = [
+ "bytemuck",
+ "log",
+ "naga",
+ "thiserror 2.0.18",
+ "vello_encoding",
+]
+
+[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8734,6 +10784,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "waker-fn"
@@ -8947,6 +11003,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-csd-frame"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
+dependencies = [
+ "bitflags 2.13.0",
+ "cursor-icon",
+ "wayland-backend",
+]
+
+[[package]]
+name = "wayland-cursor"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a52d18780be9b1314328a3de5f930b73d2200112e3849ca6cb11822793fb34d"
+dependencies = [
+ "rustix 1.1.4",
+ "wayland-client",
+ "xcursor",
+]
+
+[[package]]
 name = "wayland-protocols"
 version = "0.32.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8955,6 +11033,58 @@ dependencies = [
  "bitflags 2.13.0",
  "wayland-backend",
  "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-experimental"
+version = "20250721.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a1f863128dcaaec790d7b4b396cc9b9a7a079e878e18c47e6c2d2c5a8dcbb1"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-misc"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9567599ef23e09b8dad6e429e5738d4509dfc46b3b21f32841a304d16b29c8"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6d8cf1eb2c1c31ed1f5643c88a6e53538129d4af80030c8cabd1f9fa884d91"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 
@@ -8977,6 +11107,7 @@ checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
  "dlib",
  "log",
+ "once_cell",
  "pkg-config",
 ]
 
@@ -9001,6 +11132,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "web_atoms"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
+]
+
+[[package]]
 name = "webbrowser"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9010,8 +11153,8 @@ dependencies = [
  "jni 0.22.4",
  "log",
  "ndk-context",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
  "url",
  "web-sys",
 ]
@@ -9130,6 +11273,193 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "wgpu"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3feacc458f7bee8bc1737149b42b6c731aa461039a4264a67bb6681646b250"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02da3ad1b568337f25513b317870960ef87073ea0945502e44b864b67a8c77b7"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.13.0",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle 0.6.2",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-wasm",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e51b5447e144b3dbba4feb01f80f4fa21696fa0cd99afb2c3df1affd6fdb28"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3487cd6293a963bc5c0c0396f6a2192043c50003c07f4efdccbad3d90ec9d819"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-wasm"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2f2fb042f36920771deb0b966543c5751b18f3d327760ffc90f74e20b2dcd4"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb01076d0aa08b0ba9bd741e178b5cc440f5abe99d9581323a4c8b5d1a1916"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8e1a9e7a8512f276f7c62e018c7fa8d60954303fed2e5750114332049193f"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.16.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "naga",
+ "ndk-sys",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
+ "objc2-quartz-core 0.3.2",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle 0.6.2",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.18",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "windows-result 0.4.1",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59c654c483f058800972c3645e95388a7eca31bf9fe1933bc20e036588a0be02"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "29.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9bcc31518a0e9735aefebedb5f7a9ef3ed1c42549c9f4c882fa9060ceaac639"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "raw-window-handle 0.6.2",
+ "web-sys",
+]
+
+[[package]]
+name = "wgpu_context"
+version = "0.6.0"
+source = "git+https://github.com/Kopuz-org/kopuz-anyrender?rev=7af1a51e998ecb4a4b479fe29d707bbabe5ef9ac#7af1a51e998ecb4a4b479fe29d707bbabe5ef9ac"
+dependencies = [
+ "futures-intrusive",
+ "wgpu",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9149,6 +11479,16 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -9713,6 +12053,231 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winit"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2879d2854d1a43e48f67322d4bd097afcb6eb8f8f775c8de0260a71aea1df1aa"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg_aliases",
+ "cursor-icon",
+ "dpi",
+ "libc",
+ "raw-window-handle 0.6.2",
+ "rustix 1.1.4",
+ "smol_str",
+ "tracing",
+ "winit-android",
+ "winit-appkit",
+ "winit-common",
+ "winit-core",
+ "winit-orbital",
+ "winit-uikit",
+ "winit-wayland",
+ "winit-web",
+ "winit-win32",
+ "winit-x11",
+]
+
+[[package]]
+name = "winit-android"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d9c0d2cd93efec3a9f9ad819cfaf0834782403af7c0d248c784ec0c61761df"
+dependencies = [
+ "android-activity",
+ "bitflags 2.13.0",
+ "dpi",
+ "ndk",
+ "raw-window-handle 0.6.2",
+ "smol_str",
+ "tracing",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-appkit"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21310ca07851a49c348e0c2cc768e36b52ca65afda2c2354d78ed4b90074d8aa"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "dispatch2",
+ "dpi",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-video",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle 0.6.2",
+ "smol_str",
+ "tracing",
+ "winit-common",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-common"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45375fbac4cbb77260d83a30b1f9d8105880dbac99a9ae97f56656694680ff69"
+dependencies = [
+ "memmap2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "smol_str",
+ "tracing",
+ "winit-core",
+ "x11-dl",
+ "xkbcommon-dl",
+]
+
+[[package]]
+name = "winit-core"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f0ccd7abb43740e2c6124ac7cae7d865ecec74eec63783e8922577ac232583"
+dependencies = [
+ "bitflags 2.13.0",
+ "cursor-icon",
+ "dpi",
+ "keyboard-types 0.8.3",
+ "raw-window-handle 0.6.2",
+ "smol_str",
+ "web-time",
+]
+
+[[package]]
+name = "winit-orbital"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ea1fb262e7209f265f12bd0cc792c399b14355675e65531e9c8a87db287d46"
+dependencies = [
+ "bitflags 2.13.0",
+ "dpi",
+ "orbclient",
+ "raw-window-handle 0.6.2",
+ "redox_syscall 0.5.18",
+ "smol_str",
+ "tracing",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-uikit"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680a356e798837d8eb274d4556e83bceaf81698194e31aafc5cfb8a9f2fab643"
+dependencies = [
+ "bitflags 2.13.0",
+ "block2 0.6.2",
+ "dispatch2",
+ "dpi",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "objc2-ui-kit",
+ "raw-window-handle 0.6.2",
+ "smol_str",
+ "tracing",
+ "winit-common",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-wayland"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce5afb2ba07da603f84b722c95f9f9396d2cedae3944fb6c0cda4a6f88de545"
+dependencies = [
+ "ahash",
+ "bitflags 2.13.0",
+ "calloop",
+ "cursor-icon",
+ "dpi",
+ "libc",
+ "memmap2",
+ "raw-window-handle 0.6.2",
+ "rustix 1.1.4",
+ "sctk-adwaita",
+ "smithay-client-toolkit",
+ "smol_str",
+ "tracing",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-plasma",
+ "winit-common",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-web"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c2490a953fb776fbbd5e295d54f1c3847f4f15b6c3929ec53c09acda6487a92"
+dependencies = [
+ "atomic-waker",
+ "bitflags 2.13.0",
+ "concurrent-queue",
+ "cursor-icon",
+ "dpi",
+ "js-sys",
+ "pin-project",
+ "raw-window-handle 0.6.2",
+ "smol_str",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "web-time",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-win32"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644ea78af0e858aa3b092e5d1c67c41995a98220c81813f1353b28bc8bb91eaa"
+dependencies = [
+ "bitflags 2.13.0",
+ "cursor-icon",
+ "dpi",
+ "raw-window-handle 0.6.2",
+ "smol_str",
+ "tracing",
+ "unicode-segmentation",
+ "windows-sys 0.59.0",
+ "winit-core",
+]
+
+[[package]]
+name = "winit-x11"
+version = "0.31.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa5b600756534c7041aa93cd0d244d44b09fca1b89e202bd1cd80dd9f3636c46"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytemuck",
+ "calloop",
+ "cursor-icon",
+ "dpi",
+ "libc",
+ "percent-encoding",
+ "raw-window-handle 0.6.2",
+ "rustix 1.1.4",
+ "smol_str",
+ "tracing",
+ "winit-common",
+ "winit-core",
+ "x11-dl",
+ "x11rb",
+ "xkbcommon-dl",
+]
+
+[[package]]
 name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9865,24 +12430,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728b7d4c8ec8d81cab295e0b5b8a4c263c0d41a785fb8f8c4df284e5411140a2"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs",
  "dpi",
  "dunce",
  "gtk",
- "html5ever",
+ "html5ever 0.29.1",
  "http 1.4.1",
  "javascriptcore-rs",
  "jni 0.21.1",
  "kuchikiki",
  "libc",
  "ndk",
- "objc2",
- "objc2-app-kit",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",
@@ -9899,6 +12464,18 @@ dependencies = [
  "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
+]
+
+[[package]]
+name = "wuff"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77cd3107d02dc860d9377a7e28a60e2a77c6d1964f4119999b03dd95f007719"
+dependencies = [
+ "arrayvec",
+ "brotli-decompressor",
+ "bytes",
+ "flate2",
 ]
 
 [[package]]
@@ -9928,9 +12505,14 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
+ "as-raw-xcb-connection",
  "gethostname",
+ "libc",
+ "libloading 0.8.9",
+ "once_cell",
  "rustix 1.1.4",
  "x11rb-protocol",
+ "xcursor",
 ]
 
 [[package]]
@@ -9938,6 +12520,12 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xcursor"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
 
 [[package]]
 name = "xdg-home"
@@ -9950,10 +12538,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "xkbcommon-dl"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
+dependencies = [
+ "bitflags 2.13.0",
+ "dlib",
+ "log",
+ "once_cell",
+ "xkeysym",
+]
+
+[[package]]
 name = "xkeysym"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xml5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab627f34ff61b80d756180d556f9c68801d836d271b3b8c094504ceca69d221"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
+]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "xxhash-rust"
@@ -9962,10 +12585,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
-name = "y4m"
-version = "0.8.0"
+name = "yeslogic-fontconfig-sys"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
+dependencies = [
+ "dlib",
+ "once_cell",
+ "pkg-config",
+]
 
 [[package]]
 name = "yoke"
@@ -10173,6 +12801,7 @@ dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
@@ -10206,9 +12835,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
 name = "zune-inflate"
@@ -10221,9 +12850,9 @@ dependencies = [
 
 [[package]]
 name = "zune-jpeg"
-version = "0.5.15"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]
@@ -10305,3 +12934,8 @@ dependencies = [
  "syn 2.0.117",
  "winnow 1.0.3",
 ]
+
+[[patch.unused]]
+name = "taffy"
+version = "0.11.0"
+source = "git+https://github.com/Kopuz-org/kopuz-taffy?rev=8609e92f1a3b60da70ca0a0fd9fa090f62847f46#8609e92f1a3b60da70ca0a0fd9fa090f62847f46"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ dioxus = { version = "0.7.9", features = [] }
 dioxus-native = { git = "https://github.com/Kopuz-org/kopuz-blitz", rev = "3b8f6ae7303e585377d1a621c5a278a30ea2125e", package = "dioxus-native", default-features = false }
 blitz-traits = { git = "https://github.com/Kopuz-org/kopuz-blitz", rev = "3b8f6ae7303e585377d1a621c5a278a30ea2125e" }
 winit = "=0.31.0-beta.2"
+# complex-scripts: dictionary-based CJK line-breaking in blitz's parley.
+parley = { version = "0.10", default-features = false, features = ["complex-scripts"] }
 getrandom = { version = "0.4", features = ["wasm_js"] }
 web-sys = { version = "0.3", features = [
   "AudioContext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,11 +178,13 @@ panic = "abort"
 # forks so the build is reproducible and the team can iterate without waiting on
 # upstream. Each rev is the HEAD of the working branch on its fork; the upstream
 # PRs are linked from the blitz-phoenix PR.
-#   taffy:       kopuz-taffy @ fix/block-child-available-height
-#   stylo/atoms: kopuz-stylo @ spike/kopuz-deps (0.18.0; servo main has drifted)
+#   taffy:        kopuz-taffy  @ spike/cache-fix-3   (0.11.0-experimental-cache-fix.3;
+#                 the 0.11.0 release dropped APIs stylo_taffy needs)
+#   stylo:        kopuz-stylo  @ spike/style-0.18    (0.18.0)
+#   stylo_atoms:  kopuz-stylo  @ spike/atoms-0.18    (0.18.0)
 #   wgpu_context: kopuz-anyrender @ fix/drop-surface-output-before-reconfigure
 [patch.crates-io]
-taffy = { git = "https://github.com/Kopuz-org/kopuz-taffy", rev = "8609e92f1a3b60da70ca0a0fd9fa090f62847f46" }
-stylo = { git = "https://github.com/Kopuz-org/kopuz-stylo", rev = "ca38e455ef376e5b8715ef80e5e7a13cb5d2962e" }
-stylo_atoms = { git = "https://github.com/Kopuz-org/kopuz-stylo", rev = "ca38e455ef376e5b8715ef80e5e7a13cb5d2962e" }
+taffy = { git = "https://github.com/Kopuz-org/kopuz-taffy", rev = "edc3932b567dc5e3f0417fbe6041670418104294" }
+stylo = { git = "https://github.com/Kopuz-org/kopuz-stylo", rev = "701ae9c8a28cd8da50970ff214ad986e689b2846" }
+stylo_atoms = { git = "https://github.com/Kopuz-org/kopuz-stylo", rev = "96224381a814e4267ac7cab3f33a9827597b8f68" }
 wgpu_context = { git = "https://github.com/Kopuz-org/kopuz-anyrender", rev = "7af1a51e998ecb4a4b479fe29d707bbabe5ef9ac" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,9 @@ tokio = { version = "1.0", features = [
 async-recursion = "1.0"
 discord-rich-presence = "1.1.0"
 lofty = "0.24.0"
-image = { version = "0.25", default-features = false, features = [
+# Pinned exact: blitz-dom (dioxus-native) requires image =0.25.6, so the
+# resolver needs every consumer to agree on that one version.
+image = { version = "=0.25.6", default-features = false, features = [
   "jpeg",
   "png",
   "webp",
@@ -171,3 +173,16 @@ strip = "symbols"
 lto = "thin"
 codegen-units = 1
 panic = "abort"
+
+# Engine fixes for the native (Blitz) renderer, pinned by rev to the Kopuz-org
+# forks so the build is reproducible and the team can iterate without waiting on
+# upstream. Each rev is the HEAD of the working branch on its fork; the upstream
+# PRs are linked from the blitz-phoenix PR.
+#   taffy:       kopuz-taffy @ fix/block-child-available-height
+#   stylo/atoms: kopuz-stylo @ spike/kopuz-deps (0.18.0; servo main has drifted)
+#   wgpu_context: kopuz-anyrender @ fix/drop-surface-output-before-reconfigure
+[patch.crates-io]
+taffy = { git = "https://github.com/Kopuz-org/kopuz-taffy", rev = "8609e92f1a3b60da70ca0a0fd9fa090f62847f46" }
+stylo = { git = "https://github.com/Kopuz-org/kopuz-stylo", rev = "ca38e455ef376e5b8715ef80e5e7a13cb5d2962e" }
+stylo_atoms = { git = "https://github.com/Kopuz-org/kopuz-stylo", rev = "ca38e455ef376e5b8715ef80e5e7a13cb5d2962e" }
+wgpu_context = { git = "https://github.com/Kopuz-org/kopuz-anyrender", rev = "7af1a51e998ecb4a4b479fe29d707bbabe5ef9ac" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ keywords = ["music", "player", "audio", "dioxus"]
 
 [workspace.dependencies]
 dioxus = { version = "0.7.9", features = [] }
+# Native (Blitz/wgpu) renderer + its window-host API, pinned by rev to the
+# Kopuz-org fork. Crates add their own features.
+dioxus-native = { git = "https://github.com/Kopuz-org/kopuz-blitz", rev = "3b8f6ae7303e585377d1a621c5a278a30ea2125e", package = "dioxus-native", default-features = false }
+blitz-traits = { git = "https://github.com/Kopuz-org/kopuz-blitz", rev = "3b8f6ae7303e585377d1a621c5a278a30ea2125e" }
+winit = "=0.31.0-beta.2"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 web-sys = { version = "0.3", features = [
   "AudioContext",

--- a/crates/components/Cargo.toml
+++ b/crates/components/Cargo.toml
@@ -18,6 +18,8 @@ workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 dioxus = { workspace = true, features = ["desktop"] }
 directories = { workspace = true }
+blitz-traits = { workspace = true }
+winit = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 dioxus = { workspace = true, features = ["web"] }

--- a/crates/components/src/compact_player.rs
+++ b/crates/components/src/compact_player.rs
@@ -90,7 +90,7 @@ pub fn CompactPlayer() -> Element {
             ),
             onmousedown: move |_| {
                 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
-                dioxus::desktop::window().drag();
+                crate::window_host::drag();
             },
 
             if !cover.is_empty() {

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -1,6 +1,14 @@
 //! Reusable Dioxus UI components for the Kopuz music player: modern/normal list views,
 //! navigation controller, titlebar, sidebar, bottombar, and shared UI primitives.
 
+/// `KOPUZ_BLITZ=1` selects the native (Blitz/wgpu) renderer instead of the
+/// webview. Process-constant (read once), so renderer-conditional hooks keep a
+/// stable order across renders.
+pub fn blitz_active() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("KOPUZ_BLITZ").is_some_and(|v| v == "1"))
+}
+
 pub mod modern;
 pub mod navigation_controller;
 pub mod normal;

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -9,6 +9,8 @@ pub fn blitz_active() -> bool {
     *ON.get_or_init(|| std::env::var_os("KOPUZ_BLITZ").is_some_and(|v| v == "1"))
 }
 
+pub mod window_host;
+
 pub mod modern;
 pub mod navigation_controller;
 pub mod normal;

--- a/crates/components/src/modern/sidebar.rs
+++ b/crates/components/src/modern/sidebar.rs
@@ -1,5 +1,5 @@
 #[cfg(all(not(target_arch = "wasm32"), target_os = "macos"))]
-use dioxus::desktop::window;
+use crate::window_host;
 use dioxus::prelude::*;
 use kopuz_route::Route;
 
@@ -202,7 +202,7 @@ pub fn SidebarModern(props: SidebarProps) -> Element {
                     class: "h-10 flex-shrink-0",
                     onmousedown: move |_| {
                         #[cfg(all(not(target_arch = "wasm32"), target_os = "macos"))]
-                        window().drag();
+                        window_host::drag();
                     }
                 }
             }

--- a/crates/components/src/normal/sidebar.rs
+++ b/crates/components/src/normal/sidebar.rs
@@ -1,5 +1,5 @@
 #[cfg(all(not(target_arch = "wasm32"), target_os = "macos"))]
-use dioxus::desktop::window;
+use crate::window_host;
 use dioxus::prelude::*;
 use kopuz_route::Route;
 
@@ -313,7 +313,7 @@ pub fn SidebarNormal(props: SidebarProps) -> Element {
                     class: "absolute top-0 left-0 w-full h-10 z-50",
                     onmousedown: move |_| {
                         #[cfg(all(not(target_arch = "wasm32"), target_os = "macos"))]
-                        window().drag();
+                        window_host::drag();
                     }
                 }
             }

--- a/crates/components/src/queue_drag.rs
+++ b/crates/components/src/queue_drag.rs
@@ -169,15 +169,6 @@ pub fn install_native_artwork_drag_prevention() {
         if (!document.__kopuzNativeArtworkDragPreventionInstalled) {
             document.__kopuzNativeArtworkDragPreventionInstalled = true;
 
-            const style = document.createElement('style');
-            style.textContent = `
-                img, [style*="background-image"] {
-                    -webkit-user-drag: none;
-                    user-drag: none;
-                }
-            `;
-            document.head.appendChild(style);
-
             document.addEventListener('dragstart', (event) => {
                 const target = event.target;
                 const isTrackRowDrag = !!(target && target.closest && target.closest('.track-row-draggable'));

--- a/crates/components/src/titlebar.rs
+++ b/crates/components/src/titlebar.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_arch = "wasm32"))]
-use config::AppConfig;
+use crate::window_host;
 #[cfg(not(target_arch = "wasm32"))]
-use dioxus::desktop::window;
+use config::AppConfig;
 use dioxus::prelude::*;
 
 #[component]
@@ -14,7 +14,8 @@ pub fn Titlebar() -> Element {
     #[cfg(not(target_arch = "wasm32"))]
     {
         let config = use_context::<Signal<AppConfig>>();
-        if config.read().titlebar_mode != config::TitlebarMode::Custom {
+        if config.read().titlebar_mode != config::TitlebarMode::Custom || !window_host::available()
+        {
             return rsx! {};
         }
         let minimize_text = i18n::t("minimize").to_string();
@@ -25,7 +26,7 @@ pub fn Titlebar() -> Element {
             div {
                 class: "flex items-center h-9 bg-black/50 border-b border-white/5 flex-shrink-0 select-none relative",
                 onmousedown: move |_| {
-                    window().drag();
+                    window_host::drag();
                 },
 
                 div { class: "flex-1" }
@@ -45,19 +46,19 @@ pub fn Titlebar() -> Element {
                     button {
                         class: "w-11 h-full flex items-center justify-center text-white/25 hover:text-white/70 hover:bg-white/6 transition-all duration-150",
                         title: "{minimize_text}",
-                        onclick: move |_| window().window.set_minimized(true),
+                        onclick: move |_| window_host::minimize(),
                         i { class: "fa-solid fa-minus text-[10px] leading-none" }
                     }
                     button {
                         class: "w-11 h-full flex items-center justify-center text-white/25 hover:text-white/70 hover:bg-white/6 transition-all duration-150",
                         title: "{maximize_text}",
-                        onclick: move |_| window().toggle_maximized(),
+                        onclick: move |_| window_host::toggle_maximized(),
                         i { class: "fa-regular fa-square text-[10px] leading-none" }
                     }
                     button {
                         class: "w-11 h-full flex items-center justify-center text-white/25 hover:text-white hover:bg-red-500/70 transition-all duration-150",
                         title: "{close_text}",
-                        onclick: move |_| window().close(),
+                        onclick: move |_| window_host::close(),
                         i { class: "fa-solid fa-xmark text-[10px] leading-none" }
                     }
                 }

--- a/crates/components/src/window_host.rs
+++ b/crates/components/src/window_host.rs
@@ -1,0 +1,250 @@
+//! The single renderer seam for host-window operations.
+//!
+//! Window controls (decorations, drag, min/max/close, visibility, resize) are
+//! host-shell operations with no HTML/CSS surface, so each renderer exposes its
+//! own handle: the webview a wry/tao `DesktopContext`, the native renderer a
+//! blitz `ShellProvider` (close + chrome) plus the winit `Window` (everything
+//! else). Every renderer divergence for window control is resolved here.
+
+#[cfg(not(target_arch = "wasm32"))]
+use dioxus::prelude::*;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
+use winit::window::{Window, WindowLevel};
+
+#[cfg(not(target_arch = "wasm32"))]
+fn desktop() -> Option<dioxus::desktop::DesktopContext> {
+    try_consume_context::<dioxus::desktop::DesktopContext>()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn shell() -> Option<Arc<dyn blitz_traits::shell::ShellProvider>> {
+    try_consume_context::<Arc<dyn blitz_traits::shell::ShellProvider>>()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn winit_window() -> Option<Arc<dyn Window>> {
+    try_consume_context::<Arc<dyn Window>>()
+}
+
+/// Whether a host window is available (a desktop renderer is hosting us).
+pub fn available() -> bool {
+    #[cfg(target_arch = "wasm32")]
+    {
+        false
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        desktop().is_some() || winit_window().is_some()
+    }
+}
+
+/// True when a webview (wry/tao) host is active. The webview pumps the global
+/// muda / tray-icon event channels through its event loop; the native renderer
+/// (winit) does not, so callers must poll those channels themselves.
+pub fn is_webview() -> bool {
+    #[cfg(target_arch = "wasm32")]
+    {
+        false
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        desktop().is_some()
+    }
+}
+
+pub fn set_decorations(decorations: bool) {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        w.set_decorations(decorations);
+    } else if let Some(s) = shell() {
+        s.set_window_decorations(decorations);
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = decorations;
+}
+
+/// Begin an interactive window move (from a mousedown handler on a drag region).
+pub fn drag() {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        w.drag();
+    } else if let Some(s) = shell() {
+        s.drag_window();
+    }
+}
+
+pub fn minimize() {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        w.window.set_minimized(true);
+    } else if let Some(s) = shell() {
+        s.set_window_minimized(true);
+    }
+}
+
+pub fn toggle_maximized() {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        w.toggle_maximized();
+    } else if let Some(s) = shell() {
+        s.set_window_maximized(!s.is_window_maximized());
+    }
+}
+
+pub fn close() {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        w.close();
+    } else if let Some(s) = shell() {
+        s.request_window_close();
+    }
+}
+
+pub fn is_visible() -> bool {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        if let Some(w) = desktop() {
+            return w.is_visible();
+        }
+        if let Some(win) = winit_window() {
+            return win.is_visible().unwrap_or(true);
+        }
+    }
+    true
+}
+
+pub fn set_visible(visible: bool) {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        w.set_visible(visible);
+    } else if let Some(win) = winit_window() {
+        win.set_visible(visible);
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = visible;
+}
+
+pub fn set_focus() {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        w.set_focus();
+    } else if let Some(win) = winit_window() {
+        win.focus_window();
+    }
+}
+
+/// Whether closing the window hides it (kept alive in the tray) instead of
+/// quitting. Webview-only for now; under the native renderer this is a no-op
+/// (blitz exits on close — hide-on-close needs a blitz-shell lifecycle hook).
+pub fn set_hide_on_close(hide: bool) {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        use dioxus::desktop::WindowCloseBehaviour::{WindowCloses, WindowHides};
+        w.set_close_behavior(if hide { WindowHides } else { WindowCloses });
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = hide;
+}
+
+pub fn scale_factor() -> f64 {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        if let Some(w) = desktop() {
+            return w.window.scale_factor();
+        }
+        if let Some(win) = winit_window() {
+            return win.scale_factor();
+        }
+    }
+    1.0
+}
+
+/// Current window inner size in logical pixels.
+pub fn inner_size_logical() -> (f64, f64) {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        if let Some(w) = desktop() {
+            let scale = w.window.scale_factor();
+            let s = w.window.inner_size().to_logical::<f64>(scale);
+            return (s.width, s.height);
+        }
+        if let Some(win) = winit_window() {
+            let scale = win.scale_factor();
+            let s = win.surface_size().to_logical::<f64>(scale);
+            return (s.width, s.height);
+        }
+    }
+    (0.0, 0.0)
+}
+
+pub fn set_always_on_top(on: bool) {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        w.window.set_always_on_top(on);
+    } else if let Some(win) = winit_window() {
+        win.set_window_level(if on {
+            WindowLevel::AlwaysOnTop
+        } else {
+            WindowLevel::Normal
+        });
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = on;
+}
+
+pub fn set_resizable(resizable: bool) {
+    #[cfg(not(target_arch = "wasm32"))]
+    if let Some(w) = desktop() {
+        w.window.set_resizable(resizable);
+    } else if let Some(win) = winit_window() {
+        win.set_resizable(resizable);
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = resizable;
+}
+
+pub fn set_min_inner_size(size: Option<(f64, f64)>) {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let logical = size.map(|(w, h)| winit::dpi::LogicalSize::new(w, h));
+        if let Some(w) = desktop() {
+            w.window
+                .set_min_inner_size(logical.map(winit::dpi::Size::Logical));
+        } else if let Some(win) = winit_window() {
+            win.set_min_surface_size(logical.map(winit::dpi::Size::Logical));
+        }
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = size;
+}
+
+pub fn set_max_inner_size(size: Option<(f64, f64)>) {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let logical = size.map(|(w, h)| winit::dpi::LogicalSize::new(w, h));
+        if let Some(w) = desktop() {
+            w.window
+                .set_max_inner_size(logical.map(winit::dpi::Size::Logical));
+        } else if let Some(win) = winit_window() {
+            win.set_max_surface_size(logical.map(winit::dpi::Size::Logical));
+        }
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = size;
+}
+
+pub fn set_inner_size(width: f64, height: f64) {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let logical = winit::dpi::LogicalSize::new(width, height);
+        if let Some(w) = desktop() {
+            let _ = w.window.set_inner_size(logical);
+        } else if let Some(win) = winit_window() {
+            let _ = win.request_surface_size(winit::dpi::Size::Logical(logical));
+        }
+    }
+    #[cfg(target_arch = "wasm32")]
+    let _ = (width, height);
+}

--- a/crates/kopuz/Cargo.toml
+++ b/crates/kopuz/Cargo.toml
@@ -32,7 +32,7 @@ dioxus = { workspace = true, features = ["desktop"] }
 # fixes filed upstream. Both renderers compile in; KOPUZ_BLITZ=1 selects
 # native at runtime. Default features minus "vello-hybrid" (panics on
 # kopuz's 0-alpha paints) and minus "incremental".
-dioxus-native = { git = "https://github.com/Kopuz-org/kopuz-blitz", rev = "3b8f6ae7303e585377d1a621c5a278a30ea2125e", package = "dioxus-native", default-features = false, features = [
+dioxus-native = { workspace = true, features = [
     "accessibility",
     "hot-reload",
     "net",

--- a/crates/kopuz/Cargo.toml
+++ b/crates/kopuz/Cargo.toml
@@ -44,6 +44,8 @@ dioxus-native = { workspace = true, features = [
     "vello",
     "woff",
 ] }
+# Unused; pulls parley into the graph so its complex-scripts feature unifies.
+parley = { workspace = true }
 discord-rich-presence = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }

--- a/crates/kopuz/Cargo.toml
+++ b/crates/kopuz/Cargo.toml
@@ -28,6 +28,22 @@ discord-presence = { workspace = true }
 # Desktop only. Android uses the mobile renderer, logs to logcat, and has no Discord IPC.
 [target.'cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))'.dependencies]
 dioxus = { workspace = true, features = ["desktop"] }
+# Native renderer (Blitz/wgpu) from the Kopuz-org fork, carrying the engine
+# fixes filed upstream. Both renderers compile in; KOPUZ_BLITZ=1 selects
+# native at runtime. Default features minus "vello-hybrid" (panics on
+# kopuz's 0-alpha paints) and minus "incremental".
+dioxus-native = { git = "https://github.com/Kopuz-org/kopuz-blitz", rev = "3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8", package = "dioxus-native", default-features = false, features = [
+    "accessibility",
+    "hot-reload",
+    "net",
+    "html",
+    "svg",
+    "system-fonts",
+    "clipboard",
+    "file_dialog",
+    "vello",
+    "woff",
+] }
 discord-rich-presence = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }

--- a/crates/kopuz/Cargo.toml
+++ b/crates/kopuz/Cargo.toml
@@ -32,7 +32,7 @@ dioxus = { workspace = true, features = ["desktop"] }
 # fixes filed upstream. Both renderers compile in; KOPUZ_BLITZ=1 selects
 # native at runtime. Default features minus "vello-hybrid" (panics on
 # kopuz's 0-alpha paints) and minus "incremental".
-dioxus-native = { git = "https://github.com/Kopuz-org/kopuz-blitz", rev = "3d39b5fa4c3feef832d0af8f7dbb871094fbdaa8", package = "dioxus-native", default-features = false, features = [
+dioxus-native = { git = "https://github.com/Kopuz-org/kopuz-blitz", rev = "3b8f6ae7303e585377d1a621c5a278a30ea2125e", package = "dioxus-native", default-features = false, features = [
     "accessibility",
     "hot-reload",
     "net",

--- a/crates/kopuz/assets/main.css
+++ b/crates/kopuz/assets/main.css
@@ -1,26 +1,16 @@
 /* App-wide styling */
 
-/* Themed scrollbars — uses CSS vars so all themes apply automatically */
-::-webkit-scrollbar {
-    width: 6px;
-    height: 6px;
+/* Themed scrollbars — standard css-scrollbars-1; uses CSS vars so themes
+   apply automatically. Transparent track resolves to the app's black
+   background. Both WebKitGTK and blitz honor these. */
+html {
+    scrollbar-color: var(--color-slate-500, #64748b) transparent;
 }
 
-::-webkit-scrollbar-track {
-    background: var(--color-black, #000000);
-}
-
-::-webkit-scrollbar-thumb {
-    background: var(--color-slate-500, #64748b);
-    border-radius: 3px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-    background: var(--color-slate-400, #94a3b8);
-}
-
-::-webkit-scrollbar-corner {
-    background: var(--color-black, #000000);
+/* Referenced throughout the markup (horizontal shelves); previously
+   undefined, so the renderer showed its scrollbars on these by accident. */
+.scrollbar-hide {
+    scrollbar-width: none;
 }
 
 @keyframes scan-slide {
@@ -274,7 +264,6 @@ body {
 
 [data-platform="android"],
 [data-platform="android"] * {
-    -webkit-user-select: none !important;
     user-select: none !important;
     -webkit-touch-callout: none !important;
     -webkit-tap-highlight-color: transparent !important;
@@ -283,7 +272,6 @@ body {
 [data-platform="android"] input,
 [data-platform="android"] textarea,
 [data-platform="android"] [contenteditable="true"] {
-    -webkit-user-select: text !important;
     user-select: text !important;
 }
 

--- a/crates/kopuz/assets/themes.css
+++ b/crates/kopuz/assets/themes.css
@@ -451,8 +451,6 @@ select optgroup {
 
 select {
     appearance: none !important;
-    -webkit-appearance: none !important;
-    -moz-appearance: none !important;
     background-color: #000000 !important;
     background: #000000 !important;
     color: #ffffff !important;

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -225,8 +225,8 @@ fn main() {
             // carry over. Known-broken under blitz: YT playback (decipher needs
             // a JS engine), artwork:// covers, and the close-time persist flush.
             #[cfg(any(target_os = "linux", target_os = "windows"))]
-            let decorations = desktop_shell::read_titlebar_mode_from_disk()
-                == ::config::TitlebarMode::System;
+            let decorations =
+                desktop_shell::read_titlebar_mode_from_disk() == ::config::TitlebarMode::System;
             #[cfg(not(any(target_os = "linux", target_os = "windows")))]
             let decorations = true;
             let attrs = dioxus_native::WindowAttributes::default()
@@ -524,63 +524,67 @@ fn App() -> Element {
     // flush silently never ran. Signals are peeked here (not Send), the
     // joined thread does the blocking DB work. Idempotent across
     // CloseRequested/LoopDestroyed.
+    // Persist-on-close via a wry (webview) event subscription; wry *is* the
+    // webview, so it has no native-renderer form. Gated off under blitz.
     #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
-    dioxus::desktop::use_wry_event_handler(move |event, _| {
-        use dioxus::desktop::tao::event::{Event, WindowEvent};
-        if matches!(
-            event,
-            Event::LoopDestroyed
-                | Event::WindowEvent {
-                    event: WindowEvent::CloseRequested,
-                    ..
-                }
-        ) {
-            if let Some(db) = app_db::DB_HANDLE.get() {
-                let db = db.clone();
-                // None = the queue is empty (a cleared queue must persist as
-                // empty, not resurrect) — but only once the saved queue has
-                // actually been restored, else a quit during startup would
-                // wipe it.
-                let queue_snap = (*initial_load_done.peek()).then(|| {
-                    pending_queue_state_snapshot
-                        .peek()
-                        .clone()
-                        .map(queue_state::snapshot)
-                        .unwrap_or_default()
-                });
-                // Library/playlists/favorites need no flush — every mutation
-                // already committed as a targeted write when it happened.
-                let cfg = (*config_loaded_ok.peek()).then(|| {
-                    let mut cfg = config.peek().clone();
-                    cfg.volume = *volume.peek();
-                    cfg
-                });
-                let _ = std::thread::spawn(move || {
-                    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
-                        .enable_all()
-                        .build()
-                    else {
-                        return;
-                    };
-                    rt.block_on(async move {
-                        if let Some(snap) = queue_snap
-                            && let Err(e) = db.save_queue(&snap).await
-                        {
-                            tracing::warn!(error = %e, "queue flush on close failed");
-                        }
-                        if let Some(cfg) = cfg {
-                            let _ = db.save_config(&cfg).await;
-                        }
+    if !components::blitz_active() {
+        dioxus::desktop::use_wry_event_handler(move |event, _| {
+            use dioxus::desktop::tao::event::{Event, WindowEvent};
+            if matches!(
+                event,
+                Event::LoopDestroyed
+                    | Event::WindowEvent {
+                        event: WindowEvent::CloseRequested,
+                        ..
+                    }
+            ) {
+                if let Some(db) = app_db::DB_HANDLE.get() {
+                    let db = db.clone();
+                    // None = the queue is empty (a cleared queue must persist as
+                    // empty, not resurrect) — but only once the saved queue has
+                    // actually been restored, else a quit during startup would
+                    // wipe it.
+                    let queue_snap = (*initial_load_done.peek()).then(|| {
+                        pending_queue_state_snapshot
+                            .peek()
+                            .clone()
+                            .map(queue_state::snapshot)
+                            .unwrap_or_default()
                     });
-                })
-                .join();
+                    // Library/playlists/favorites need no flush — every mutation
+                    // already committed as a targeted write when it happened.
+                    let cfg = (*config_loaded_ok.peek()).then(|| {
+                        let mut cfg = config.peek().clone();
+                        cfg.volume = *volume.peek();
+                        cfg
+                    });
+                    let _ = std::thread::spawn(move || {
+                        let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                        else {
+                            return;
+                        };
+                        rt.block_on(async move {
+                            if let Some(snap) = queue_snap
+                                && let Err(e) = db.save_queue(&snap).await
+                            {
+                                tracing::warn!(error = %e, "queue flush on close failed");
+                            }
+                            if let Some(cfg) = cfg {
+                                let _ = db.save_config(&cfg).await;
+                            }
+                        });
+                    })
+                    .join();
+                }
+                // After the persists, so they (and any failure warnings) land in
+                // latest.log and the trace. Idempotent across CloseRequested/
+                // LoopDestroyed; Ctrl+C is covered by the SIGINT handler.
+                crate::logging::shutdown();
             }
-            // After the persists, so they (and any failure warnings) land in
-            // latest.log and the trace. Idempotent across CloseRequested/
-            // LoopDestroyed; Ctrl+C is covered by the SIGINT handler.
-            crate::logging::shutdown();
-        }
-    });
+        });
+    }
 
     #[cfg(all(not(target_arch = "wasm32"), target_os = "macos"))]
     use_effect(move || {

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -919,8 +919,7 @@ fn App() -> Element {
     ))]
     use_effect(move || {
         let mode = config.read().titlebar_mode;
-        let win = dioxus::desktop::window();
-        win.set_decorations(mode == config::TitlebarMode::System);
+        components::window_host::set_decorations(mode == config::TitlebarMode::System);
     });
 
     #[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
@@ -937,8 +936,9 @@ fn App() -> Element {
 
     #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
     {
+        use components::window_host as wh;
         use dioxus::desktop::trayicon::TrayIcon;
-        use dioxus::desktop::{WindowCloseBehaviour, window};
+        use dioxus::desktop::trayicon::menu::MenuId;
         use std::cell::RefCell;
         use std::rc::Rc;
 
@@ -948,32 +948,39 @@ fn App() -> Element {
         const TRAY_SHOW_ID: &str = "kopuz-tray-show";
         const TRAY_QUIT_ID: &str = "kopuz-tray-quit";
 
-        let win_ctx = window();
-        let handle_menu = {
-            let win_ctx = win_ctx.clone();
-            move |id: &dioxus::desktop::trayicon::menu::MenuId| {
-                tracing::debug!("tray menu event id={:?}", id);
-                if *id == TRAY_SHOW_ID {
-                    if win_ctx.is_visible() {
-                        win_ctx.set_visible(false);
-                    } else {
-                        win_ctx.set_visible(true);
-                        win_ctx.set_focus();
-                    }
-                } else if *id == TRAY_QUIT_ID {
-                    win_ctx.set_close_behavior(WindowCloseBehaviour::WindowCloses);
-                    win_ctx.close();
+        // Window ops route through the window_host seam (webview DesktopContext
+        // or blitz winit window), so this is renderer-agnostic.
+        let handle_menu = move |id: &MenuId| {
+            tracing::debug!("tray menu event id={:?}", id);
+            if *id == TRAY_SHOW_ID {
+                if wh::is_visible() {
+                    wh::set_visible(false);
+                } else {
+                    wh::set_visible(true);
+                    wh::set_focus();
                 }
+            } else if *id == TRAY_QUIT_ID {
+                wh::set_hide_on_close(false);
+                wh::close();
             }
         };
-        dioxus::desktop::use_tray_menu_event_handler({
-            let handle_menu = handle_menu.clone();
-            move |event| handle_menu(&event.id)
-        });
-        dioxus::desktop::use_muda_event_handler({
-            let handle_menu = handle_menu.clone();
-            move |event| handle_menu(&event.id)
-        });
+
+        // Menu events: the webview pumps muda's global channel through tao's
+        // event loop; winit doesn't, so under the native renderer we poll it.
+        if wh::is_webview() {
+            dioxus::desktop::use_tray_menu_event_handler(move |event| handle_menu(&event.id));
+            dioxus::desktop::use_muda_event_handler(move |event| handle_menu(&event.id));
+        } else {
+            use_future(move || async move {
+                let rx = dioxus::desktop::trayicon::menu::MenuEvent::receiver();
+                loop {
+                    while let Ok(event) = rx.try_recv() {
+                        handle_menu(&event.id);
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+            });
+        }
 
         use_effect({
             let tray_slot = tray_slot.clone();
@@ -999,11 +1006,7 @@ fn App() -> Element {
                     *warned = false;
                 }
                 drop(warned);
-                window().set_close_behavior(if enabled {
-                    WindowCloseBehaviour::WindowHides
-                } else {
-                    WindowCloseBehaviour::WindowCloses
-                });
+                wh::set_hide_on_close(enabled);
 
                 let mut slot = tray_slot.borrow_mut();
                 match (enabled, slot.is_some()) {
@@ -1494,33 +1497,29 @@ fn App() -> Element {
     use_context_provider(|| components::CompactMode(compact_mode));
     #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
     {
-        let mut saved_window_size = use_signal(|| None::<LogicalSize<f64>>);
+        let mut saved_window_size = use_signal(|| None::<(f64, f64)>);
         use_effect(move || {
+            use components::window_host as wh;
             let active = *compact_mode.read();
-            let win = dioxus::desktop::window();
             if active {
-                let scale = win.window.scale_factor();
-                let current = win.window.inner_size().to_logical::<f64>(scale);
-                saved_window_size.set(Some(current));
-                win.window.set_always_on_top(true);
+                saved_window_size.set(Some(wh::inner_size_logical()));
+                wh::set_always_on_top(true);
                 let compact_h = if cfg!(target_os = "macos") {
                     170.0
                 } else {
                     148.0
                 };
-                win.window.set_resizable(true);
-                win.window
-                    .set_min_inner_size(Some(LogicalSize::new(260.0, compact_h)));
-                win.window.set_max_inner_size(None::<LogicalSize<f64>>);
-                win.window
-                    .set_inner_size(LogicalSize::new(380.0, compact_h));
+                wh::set_resizable(true);
+                wh::set_min_inner_size(Some((260.0, compact_h)));
+                wh::set_max_inner_size(None);
+                wh::set_inner_size(380.0, compact_h);
             } else {
-                win.window.set_always_on_top(false);
-                win.window.set_resizable(true);
-                win.window.set_min_inner_size(None::<LogicalSize<f64>>);
-                win.window.set_max_inner_size(None::<LogicalSize<f64>>);
-                if let Some(size) = saved_window_size.take() {
-                    win.window.set_inner_size(size);
+                wh::set_always_on_top(false);
+                wh::set_resizable(true);
+                wh::set_min_inner_size(None);
+                wh::set_max_inner_size(None);
+                if let Some((w, h)) = saved_window_size.take() {
+                    wh::set_inner_size(w, h);
                 }
             }
         });

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -218,9 +218,33 @@ fn main() {
             config.with_menu(Some(menu))
         };
 
-        dioxus::LaunchBuilder::desktop()
-            .with_cfg(config)
-            .launch(App);
+        if components::blitz_active() {
+            tracing::info!("KOPUZ_BLITZ=1: launching the native (Blitz/wgpu) renderer");
+            // The webview `config` (artwork:// protocol, pot minter, macOS menu)
+            // doesn't apply to the native renderer; only the window attributes
+            // carry over. Known-broken under blitz: YT playback (decipher needs
+            // a JS engine), artwork:// covers, and the close-time persist flush.
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            let decorations = desktop_shell::read_titlebar_mode_from_disk()
+                == ::config::TitlebarMode::System;
+            #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+            let decorations = true;
+            let attrs = dioxus_native::WindowAttributes::default()
+                .with_title("Kopuz")
+                .with_decorations(decorations)
+                .with_surface_size(dioxus_native::LogicalSize::new(1350.0, 800.0));
+            dioxus_native::launch_cfg(
+                App,
+                vec![],
+                vec![Box::new(
+                    dioxus_native::Config::new().with_window_attributes(attrs),
+                )],
+            );
+        } else {
+            dioxus::LaunchBuilder::desktop()
+                .with_cfg(config)
+                .launch(App);
+        }
         // Window closed → flush the log file tail + finalize the
         // chrome trace's closing bracket.
         logging::shutdown();

--- a/crates/pages/src/album.rs
+++ b/crates/pages/src/album.rs
@@ -288,7 +288,6 @@ fn AlbumGrid(
                                         onclick: move |_| album_id.set(id_for_nav.clone()),
                                         div {
                                             class: "aspect-square rounded-lg bg-stone-800 mb-3 overflow-hidden relative",
-                                            style: "-webkit-user-drag: none;",
                                             ondragstart: move |evt| evt.prevent_default(),
                                             if let Some(url) = &cover_url {
                                                 img { src: "{url}", class: "w-full h-full object-cover group-hover:scale-105 transition-transform duration-300", decoding: "async", loading: "lazy", draggable: "false", ondragstart: move |evt| evt.prevent_default() }

--- a/crates/pages/src/artist.rs
+++ b/crates/pages/src/artist.rs
@@ -479,7 +479,6 @@ pub fn Artist(
                                             onclick: move |_| artist_name.set(art.clone()),
                                             div {
                                                 class: "aspect-square w-full rounded-full bg-stone-800 mb-4 overflow-hidden relative transition-all",
-                                                style: "-webkit-user-drag: none;",
                                                 ondragstart: move |evt| evt.prevent_default(),
                                                 if let Some(url) = cover_url {
                                                     img {
@@ -777,7 +776,6 @@ pub fn Artist(
                                                     div { class: "cursor-pointer",
                                                         div {
                                                             class: "aspect-square rounded-lg bg-stone-800 mb-3 overflow-hidden relative",
-                                                            style: "-webkit-user-drag: none;",
                                                             ondragstart: move |evt| evt.prevent_default(),
                                                             if let Some(url) = &cover_url {
                                                                 img {

--- a/crates/pages/src/server/discover.rs
+++ b/crates/pages/src/server/discover.rs
@@ -705,7 +705,7 @@ fn Card(
             div { class: "h-10 flex items-center overflow-hidden",
                 p {
                     class: "text-sm font-semibold text-white break-words",
-                    style: "display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; text-overflow: ellipsis;",
+                    style: "display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; line-clamp: 2; overflow: hidden; text-overflow: ellipsis;",
                     "{title}"
                 }
             }
@@ -826,7 +826,7 @@ fn SongCard(track: Track) -> Element {
             div { class: "h-10 flex items-center overflow-hidden",
                 p {
                     class: "text-sm font-semibold text-white break-words",
-                    style: "display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; text-overflow: ellipsis;",
+                    style: "display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; line-clamp: 2; overflow: hidden; text-overflow: ellipsis;",
                     "{title}"
                 }
             }


### PR DESCRIPTION
# Native renderer: kopuz on Blitz (wgpu), no webview — rebuild

A clean, from-scratch reimplementation of the [#394](https://github.com/Kopuz-org/kopuz/pull/394) spike on top of current `master`. Our goal is to use Dioxus's native renderer, and fix the issues upstream, while they are being merged, we will work on our own forks for fast-iteration.

## Why

On Linux kopuz renders through WebKitGTK, which CPU-rasterizes the viewport every scroll frame (~14–16ms/frame → ~70fps ceiling even on a 4090). Windows (WebView2) and macOS (WKWebView) don't pay this. Blitz renders RSX straight to the GPU. `KOPUZ_BLITZ=1` selects native at runtime; a plain run keeps the webview, so both compile into one binary and can be A/B'd live.

## Upstream engine fixes

**Blitz** — merged: DioxusLabs/blitz#452 (comment-node inline/block classification), DioxusLabs/blitz#454 + DioxusLabs/blitz#469 (UA button text centering), DioxusLabs/blitz#460 (positioned `z-index:auto` paint order), DioxusLabs/blitz#463 (`background-size: cover/contain`), DioxusLabs/blitz#465 (skip `pointer-events:none` in hit-testing), DioxusLabs/blitz#466 (window-chrome controls on `ShellProvider`). Open: DioxusLabs/blitz#453 (`display:contents` box-tree), DioxusLabs/blitz#461 (overlay scrollbar paint/drag/hover; supersedes the closed DioxusLabs/blitz#462), DioxusLabs/blitz#464 (draft — inline-root `aspect-ratio`, depends on DioxusLabs/taffy#965).

**Taffy** — DioxusLabs/taffy#965 (derive definite height from `aspect-ratio` at final layout) **merged**; it was stacked on DioxusLabs/taffy#964 (block in-flow available-space), which was closed in favor of the landed approach.

**Stylo** — servo/stylo#389 (`pointer`/`hover`/`any-*` interaction media features, so `@media (hover: hover)` matches) — closed.

**anyrender** — DioxusLabs/anyrender#66 (drop the surface output before reconfiguring; fixes the maximize/resize panic) — merged.

## Known out of scope

YouTube decipher (needs a host JS runtime once the webview's JavaScriptCore is gone), `artwork://` covers (move to localhost HTTP), and the remaining cosmetic tier as blitz matures. I will solve this via the host js interpreter.
