### PR TITLE
Implement native Windows cookie decryption for YouTube Music and SoundCloud sign-in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4151,7 +4151,9 @@ dependencies = [
 name = "kopuz-server"
 version = "0.7.0"
 dependencies = [
+ "aes-gcm",
  "async-trait",
+ "base64 0.22.1",
  "directories",
  "hex",
  "httpdate",
@@ -4167,10 +4169,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "sqlx",
  "tokio",
  "tracing",
  "uuid 1.23.2",
  "web-time",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ tracing-appender = "0.2"
 ctrlc = "3.5"
 webbrowser = "1.2.1"
 base64 = "0.22"
+aes-gcm = "0.10"
 async-trait = "0.1"
 sqlx = { version = "0.8", default-features = false }
 arc-swap = "1.7"

--- a/crates/components/src/settings_popups.rs
+++ b/crates/components/src/settings_popups.rs
@@ -9,8 +9,7 @@ pub fn AddServerPopup(
     /// Selected Chromium-family browser when service is YouTube Music.
     yt_browser: Signal<Browser>,
     /// YouTube Music anonymous mode — true = no sign-in, browse + play
-    /// public surfaces only. Forced true on Windows (browser sign-in
-    /// is disabled there for now).
+    /// public surfaces only.
     yt_anonymous: Signal<bool>,
     error: Signal<Option<String>>,
     on_close: EventHandler<()>,
@@ -237,35 +236,23 @@ fn ServerServiceFields(
     server_service: Signal<MusicService>,
     server_url: Signal<String>,
     yt_browser: Signal<Browser>,
-    mut yt_anonymous: Signal<bool>,
+    yt_anonymous: Signal<bool>,
     server_url_placeholder: String,
 ) -> Element {
-    // Browser sign-in must decrypt the browser's cookie store, which Chrome 127+
-    // App-Bound Encryption blocks for non-admin apps on Windows (HKLM-only policy,
-    // no in-app workaround). Force anonymous there and hide the sign-in option.
-    let windows = cfg!(target_os = "windows");
-    use_effect(move || {
-        if cfg!(target_os = "windows") && !*yt_anonymous.peek() {
-            yt_anonymous.set(true);
-        }
-    });
-
     match server_service() {
         MusicService::YtMusic => {
             let anon = yt_anonymous();
             rsx! {
-                // Auth method selector (sign-in row hidden on Windows).
+                // Auth method selector.
                 div { class: "flex flex-col gap-2 mb-2",
-                    if !windows {
-                        label { class: "flex items-center gap-2 text-sm text-white cursor-pointer",
-                            input {
-                                r#type: "radio",
-                                name: "yt-auth-method",
-                                checked: !anon,
-                                onchange: move |_| yt_anonymous.set(false),
-                            }
-                            span { "Sign in with a browser" }
+                    label { class: "flex items-center gap-2 text-sm text-white cursor-pointer",
+                        input {
+                            r#type: "radio",
+                            name: "yt-auth-method",
+                            checked: !anon,
+                            onchange: move |_| yt_anonymous.set(false),
                         }
+                        span { "Sign in with a browser" }
                     }
                     label { class: "flex items-center gap-2 text-sm text-white cursor-pointer",
                         input {
@@ -280,15 +267,18 @@ fn ServerServiceFields(
 
                 if anon {
                     p { class: "text-xs text-white/60",
-                        if windows {
-                            "On Windows, kopuz uses YouTube Music anonymously (browser sign-in isn't supported here yet). You can browse, search, and play — but Liked Music, library playlists, and following/liking are disabled."
-                        } else {
-                            "kopuz will use YouTube Music without signing in. You can browse, search, and play — but Liked Music, your library playlists, and following/liking are disabled."
-                        }
+                        "kopuz will use YouTube Music without signing in. You can browse, search, and play — but Liked Music, your library playlists, and following/liking are disabled."
                     }
                 } else {
                     p { class: "text-xs text-white/60",
                         "Pick which browser kopuz should use for the YouTube Music sign-in window. It opens in an isolated profile (a fresh, separate session) — your normal browsing is untouched. Make sure the browser is installed."
+                    }
+                    // Windows Chrome keeps the auth cookies in memory until the
+                    // browser closes, so kopuz can only read them after close.
+                    if cfg!(target_os = "windows") {
+                        p { class: "text-xs text-amber-300/90 mt-1",
+                            "After you finish signing in, close the browser window — kopuz completes sign-in once it does."
+                        }
                     }
                     select {
                         onchange: move |e| {

--- a/crates/pages/src/settings.rs
+++ b/crates/pages/src/settings.rs
@@ -137,10 +137,9 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
             .and_then(|s| s.yt_browser)
             .unwrap_or(config::Browser::Chrome)
     });
-    // Anonymous YT mode for the add-server popup. Defaults to anonymous on
-    // Windows (browser sign-in unsupported there — App-Bound Encryption), so the
-    // popup opens on the only working method.
-    let yt_anonymous = use_signal(|| cfg!(target_os = "windows"));
+    // Anonymous YT mode for the add-server popup. Defaults to browser sign-in on
+    // every platform (Windows cookie decryption is now supported natively).
+    let yt_anonymous = use_signal(|| false);
 
     let mut username = use_signal(String::new);
     let mut password = use_signal(String::new);

--- a/crates/pages/src/settings_actions.rs
+++ b/crates/pages/src/settings_actions.rs
@@ -105,11 +105,46 @@ pub fn add_registry(
     );
 }
 
-pub fn ytmusic_auto_login(
+/// Persist freshly-obtained browser-sign-in credentials onto the active server
+/// and mirror the browser choice into its saved entry. Shared by the YT Music
+/// and SoundCloud auto-login flows (the only per-service differences are how the
+/// token is obtained and how the user id is derived).
+fn apply_browser_login(
     mut config: Signal<AppConfig>,
-    yt_browser: Signal<Browser>,
+    browser: Browser,
+    token: String,
+    user_id: String,
+) {
+    let mut cfg = config.write();
+    let saved_id = cfg.server.as_ref().and_then(|server| server.id.clone());
+    if let Some(server) = cfg.server.as_mut() {
+        server.access_token = Some(token);
+        server.user_id = Some(user_id);
+        server.yt_browser = Some(browser);
+    }
+    if let Some(id) = saved_id
+        && let Some(saved) = cfg.servers.iter_mut().find(|server| server.id == id)
+    {
+        saved.yt_browser = Some(browser);
+    }
+}
+
+/// Surface a browser sign-in failure to both the settings error line and the
+/// player error banner.
+fn report_signin_failure(
     mut error: Signal<Option<String>>,
     mut playback_error: Signal<Option<String>>,
+    msg: String,
+) {
+    error.set(Some(msg.clone()));
+    playback_error.set(Some(msg));
+}
+
+pub fn ytmusic_auto_login(
+    config: Signal<AppConfig>,
+    yt_browser: Signal<Browser>,
+    mut error: Signal<Option<String>>,
+    playback_error: Signal<Option<String>>,
 ) {
     let (browser, existing, server_id) = {
         let cfg = config.peek();
@@ -121,44 +156,30 @@ pub fn ytmusic_auto_login(
             srv.and_then(|s| s.id.clone()).unwrap_or_default(),
         )
     };
-    let mut report = move |msg: String| {
-        error.set(Some(msg.clone()));
-        playback_error.set(Some(msg));
-    };
     spawn(async move {
         let cookies = match ensure_ytmusic_signed_in(existing, browser, &server_id).await {
             Ok(cookies) => cookies,
             Err(err) => {
-                report(format!("YT Music sign-in failed ({browser}): {err}"));
+                report_signin_failure(
+                    error,
+                    playback_error,
+                    format!("YT Music sign-in failed ({browser}): {err}"),
+                );
                 return;
             }
         };
-
         let yt_user_id =
             ::server::ytmusic::derive_user_id(&cookies).unwrap_or_else(|| "me".to_string());
-        {
-            let mut cfg = config.write();
-            let saved_id = cfg.server.as_ref().and_then(|server| server.id.clone());
-            if let Some(server) = cfg.server.as_mut() {
-                server.access_token = Some(cookies);
-                server.user_id = Some(yt_user_id);
-                server.yt_browser = Some(browser);
-            }
-            if let Some(id) = saved_id
-                && let Some(saved) = cfg.servers.iter_mut().find(|server| server.id == id)
-            {
-                saved.yt_browser = Some(browser);
-            }
-        }
+        apply_browser_login(config, browser, cookies, yt_user_id);
         error.set(None);
     });
 }
 
 pub fn soundcloud_auto_login(
-    mut config: Signal<AppConfig>,
+    config: Signal<AppConfig>,
     yt_browser: Signal<Browser>,
     mut error: Signal<Option<String>>,
-    mut playback_error: Signal<Option<String>>,
+    playback_error: Signal<Option<String>>,
 ) {
     let (browser, server_id) = {
         let cfg = config.peek();
@@ -167,10 +188,6 @@ pub fn soundcloud_auto_login(
             srv.and_then(|s| s.yt_browser).unwrap_or(*yt_browser.peek()),
             srv.and_then(|s| s.id.clone()).unwrap_or_default(),
         )
-    };
-    let mut report = move |msg: String| {
-        error.set(Some(msg.clone()));
-        playback_error.set(Some(msg));
     };
     spawn(async move {
         let token = match ::server::soundcloud::signin::launch_signin_and_extract(
@@ -182,27 +199,18 @@ pub fn soundcloud_auto_login(
         {
             Ok(token) => token,
             Err(err) => {
-                report(format!("SoundCloud sign-in failed ({browser}): {err}"));
+                report_signin_failure(
+                    error,
+                    playback_error,
+                    format!("SoundCloud sign-in failed ({browser}): {err}"),
+                );
                 return;
             }
         };
         let user_id = ::server::soundcloud::derive_user_id(&token)
             .await
             .unwrap_or_else(|| "me".to_string());
-        {
-            let mut cfg = config.write();
-            let saved_id = cfg.server.as_ref().and_then(|server| server.id.clone());
-            if let Some(server) = cfg.server.as_mut() {
-                server.access_token = Some(token);
-                server.user_id = Some(user_id);
-                server.yt_browser = Some(browser);
-            }
-            if let Some(id) = saved_id
-                && let Some(saved) = cfg.servers.iter_mut().find(|server| server.id == id)
-            {
-                saved.yt_browser = Some(browser);
-            }
-        }
+        apply_browser_login(config, browser, token, user_id);
         error.set(None);
     });
 }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -29,7 +29,6 @@ md5 = { workspace = true }
 sha1 = { workspace = true }
 httpdate = { workspace = true }
 hex = { workspace = true }
-rookie = { workspace = true }
 web-time = { workspace = true }
 tokio = { workspace = true, features = ["fs", "process", "rt", "sync"] }
 reader = { workspace = true }
@@ -38,10 +37,24 @@ utils = { workspace = true }
 async-trait = { workspace = true }
 
 # Browser-cookie import. Not on Windows: rookie pulls `libesedb` (a bundled C
-# library) there, which can't cross-compile and is unusable anyway since
-# Chromium v20's App-Bound Encryption blocks non-admin cookie decryption.
+# library) there, which can't cross-compile.
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 rookie = "0.5"
+
+# Windows native cookie decryption (v10 DPAPI + planted v20 app-bound). Reuses
+# the project's sqlx/sqlite (NOT rusqlite — that would double-link libsqlite3).
+[target.'cfg(windows)'.dependencies]
+base64 = { workspace = true }
+aes-gcm = { workspace = true }
+sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"] }
+windows-core = "0.62"
+windows = { workspace = true, features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_System_Rpc",
+    "Win32_Security_Cryptography",
+    "Win32_System_Memory",
+] }
 
 [[example]]
 name = "duration_probe"

--- a/crates/server/src/cookies/mod.rs
+++ b/crates/server/src/cookies/mod.rs
@@ -2,6 +2,8 @@ pub(crate) mod browser;
 pub(crate) mod profile;
 pub(crate) mod signin;
 pub(crate) mod store;
+#[cfg(target_os = "windows")]
+pub(crate) mod windows_native;
 
 pub use profile::{delete_profile, profile_dir};
 pub use signin::launch_signin_and_extract;

--- a/crates/server/src/cookies/profile.rs
+++ b/crates/server/src/cookies/profile.rs
@@ -1,6 +1,6 @@
-use std::path::PathBuf;
 #[cfg(not(target_os = "windows"))]
 use std::path::Path;
+use std::path::PathBuf;
 
 /// Directory of an isolated browser profile kopuz owns, named
 /// `<prefix>-<server_id>`.

--- a/crates/server/src/cookies/signin.rs
+++ b/crates/server/src/cookies/signin.rs
@@ -1,8 +1,9 @@
 use std::future::Future;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use config::Browser;
+use tokio::process::Child;
 
 use super::browser::{
     browser_candidates, browser_command, find_browser_bin, find_host_browser_bin, in_flatpak,
@@ -10,10 +11,10 @@ use super::browser::{
 use super::profile::profile_dir;
 
 /// Wipe the `<prefix>-<server_id>` profile, launch `browser` at `signin_url`,
-/// then poll via `extract` until it yields the signed-in result. `extract`
+/// then wait via `extract` until it yields the signed-in result. `extract`
 /// returns `Ok(Some(value))` when done, `Ok(None)` while pending, `Err` for a
 /// transient read error (logged, retried). The browser is always killed before
-/// returning.
+/// returning. The wait strategy is platform-specific (see `wait_for_signin`).
 pub async fn launch_signin_and_extract<F, Fut>(
     browser: Browser,
     server_id: &str,
@@ -40,6 +41,8 @@ where
     for name in ["SingletonLock", "SingletonCookie", "SingletonSocket"] {
         let _ = tokio::fs::remove_file(profile.join(name)).await;
     }
+
+    prepare_profile(browser, &profile);
 
     let bin = if in_flatpak() {
         find_host_browser_bin(browser).await.ok_or_else(|| {
@@ -68,7 +71,7 @@ where
     // CREATE_BREAKAWAY_FROM_JOB detaches the child so its own sandbox works.
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
+        // tokio's Command has an inherent `creation_flags` on Windows.
         cmd.creation_flags(0x0100_0000);
     }
     let mut child = cmd
@@ -78,16 +81,53 @@ where
         .kill_on_drop(true)
         .spawn()
         .map_err(|e| format!("spawn {bin}: {e}"))?;
-    tracing::debug!(%bin, pid = ?child.id(), "browser spawned — polling for sign-in cookies");
+    tracing::debug!(%bin, pid = ?child.id(), "browser spawned — waiting for sign-in");
 
+    let deadline = Instant::now() + signin_timeout;
+    let outcome =
+        wait_for_signin(browser, &profile, &bin, &mut child, deadline, signin_timeout, &extract)
+            .await;
+
+    let _ = child.kill().await;
+    outcome
+}
+
+/// Windows: seed a NONE-protected app-bound key into the fresh profile before
+/// launch, so v20 cookies stay decryptable if Google's Finch-gated App-Bound
+/// rollout flips on. Best-effort — today's cookies are v10 (DPAPI). No-op
+/// elsewhere.
+#[cfg(target_os = "windows")]
+fn prepare_profile(browser: Browser, profile: &Path) {
+    if let Err(e) = super::windows_native::plant_app_bound_key(browser, profile) {
+        tracing::warn!(error = %e, "app-bound key plant failed — v20 cookies (if any) won't decrypt; v10 still works");
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn prepare_profile(_browser: Browser, _profile: &Path) {}
+
+/// Non-Windows: Chrome commits cookies to the store promptly, so poll `extract`
+/// every 500ms — the read succeeds while the sign-in window is still open.
+#[cfg(not(target_os = "windows"))]
+async fn wait_for_signin<F, Fut>(
+    browser: Browser,
+    profile: &Path,
+    bin: &str,
+    child: &mut Child,
+    deadline: Instant,
+    signin_timeout: Duration,
+    extract: &F,
+) -> Result<String, String>
+where
+    F: Fn(Browser, PathBuf) -> Fut,
+    Fut: Future<Output = Result<Option<String>, String>>,
+{
     let started = Instant::now();
-    let deadline = started + signin_timeout;
     let mut last_extract_err: Option<String> = None;
-    // Edge/Chrome on Windows often spawn the UI detached and the launched parent
-    // exits ~0 in <1s. The cookie store is still on disk in our profile, so keep
-    // polling regardless of child exit; just note it for the timeout message.
+    // Edge/Chrome sometimes spawn the UI detached and the launched parent exits
+    // early; the store is still on disk, so keep polling regardless of exit.
     let mut child_exited_at: Option<Instant> = None;
-    let outcome = loop {
+    loop {
         tokio::time::sleep(Duration::from_millis(500)).await;
         if Instant::now() > deadline {
             let detail = last_extract_err
@@ -98,7 +138,7 @@ where
                 .map(|_| " — note: the browser process exited early (likely detached UI); close all browser windows and try again")
                 .unwrap_or_default();
             tracing::warn!(%bin, timeout_s = signin_timeout.as_secs(), exited_early = child_exited_at.is_some(), "sign-in timed out");
-            break Err(format!(
+            return Err(format!(
                 "Sign-in not detected within {}s{exited_note}{detail}",
                 signin_timeout.as_secs()
             ));
@@ -109,23 +149,79 @@ where
             tracing::debug!(%bin, %status, "browser exited — still polling cookies (may be a detached UI)");
             child_exited_at = Some(Instant::now());
         }
-        match extract(browser, profile.clone()).await {
+        match extract(browser, profile.to_path_buf()).await {
             Ok(Some(value)) => {
                 tracing::info!(%bin, elapsed_ms = started.elapsed().as_millis(), "sign-in detected — closing browser");
-                break Ok(value);
+                return Ok(value);
             }
             Ok(None) => {}
             Err(e) => {
-                // Usually just "cookie store not ready yet" while the user is
-                // still signing in; log once per distinct message to avoid spam.
                 if last_extract_err.as_deref() != Some(e.as_str()) {
                     tracing::trace!(error = %e, "cookie extract not ready yet");
                     last_extract_err = Some(e);
                 }
             }
         }
-    };
+    }
+}
 
-    let _ = child.kill().await;
-    outcome
+/// Windows: Chrome buffers the signed-in auth cookies in memory and only writes
+/// them to the cookie store when the browser closes. Polling while it's open is
+/// futile, so wait for the cookie DB to go from browser-held to released (the
+/// user closing the window) — then read.
+#[cfg(target_os = "windows")]
+async fn wait_for_signin<F, Fut>(
+    browser: Browser,
+    profile: &Path,
+    bin: &str,
+    _child: &mut Child,
+    deadline: Instant,
+    signin_timeout: Duration,
+    extract: &F,
+) -> Result<String, String>
+where
+    F: Fn(Browser, PathBuf) -> Fut,
+    Fut: Future<Output = Result<Option<String>, String>>,
+{
+    let started = Instant::now();
+    // Latches once the browser has opened the cookie store, so a still-empty
+    // store before launch isn't mistaken for "browser closed".
+    let mut saw_browser = false;
+    let mut last_extract_err: Option<String> = None;
+    loop {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        if Instant::now() > deadline {
+            let detail = last_extract_err
+                .as_deref()
+                .map(|e| format!("; last extract error: {e}"))
+                .unwrap_or_default();
+            tracing::warn!(%bin, timeout_s = signin_timeout.as_secs(), saw_browser, "sign-in timed out");
+            return Err(format!(
+                "Sign-in not detected within {}s — finish signing in, then close the browser window to complete sign-in{detail}",
+                signin_timeout.as_secs()
+            ));
+        }
+        if super::windows_native::cookie_db_locked(profile) {
+            saw_browser = true;
+            continue;
+        }
+        if !saw_browser {
+            continue; // browser hasn't opened the cookie store yet
+        }
+        // Browser opened the store and has now released it (closed) → cookies are
+        // flushed; read them.
+        match extract(browser, profile.to_path_buf()).await {
+            Ok(Some(value)) => {
+                tracing::info!(%bin, elapsed_ms = started.elapsed().as_millis(), "sign-in detected after browser close");
+                return Ok(value);
+            }
+            Ok(None) => {}
+            Err(e) => {
+                if last_extract_err.as_deref() != Some(e.as_str()) {
+                    tracing::trace!(error = %e, "cookie extract after close not ready");
+                    last_extract_err = Some(e);
+                }
+            }
+        }
+    }
 }

--- a/crates/server/src/cookies/signin.rs
+++ b/crates/server/src/cookies/signin.rs
@@ -83,13 +83,24 @@ where
         .map_err(|e| format!("spawn {bin}: {e}"))?;
     tracing::debug!(%bin, pid = ?child.id(), "browser spawned — waiting for sign-in");
 
-    let deadline = Instant::now() + signin_timeout;
-    let outcome =
-        wait_for_signin(browser, &profile, &bin, &mut child, deadline, signin_timeout, &extract)
-            .await;
+    let wait = SigninWait {
+        browser,
+        profile: &profile,
+        bin: &bin,
+        timeout: signin_timeout,
+    };
+    let outcome = wait_for_signin(&wait, &mut child, &extract).await;
 
     let _ = child.kill().await;
     outcome
+}
+
+/// Fixed inputs for a sign-in wait, shared by both platform strategies.
+struct SigninWait<'a> {
+    browser: Browser,
+    profile: &'a Path,
+    bin: &'a str,
+    timeout: Duration,
 }
 
 /// Windows: seed a NONE-protected app-bound key into the fresh profile before
@@ -106,16 +117,12 @@ fn prepare_profile(browser: Browser, profile: &Path) {
 #[cfg(not(target_os = "windows"))]
 fn prepare_profile(_browser: Browser, _profile: &Path) {}
 
-/// Non-Windows: Chrome commits cookies to the store promptly, so poll `extract`
-/// every 500ms — the read succeeds while the sign-in window is still open.
+/// Non-Windows: Chrome commits cookies promptly, so poll `extract` every 500ms —
+/// the read succeeds while the sign-in window is still open.
 #[cfg(not(target_os = "windows"))]
 async fn wait_for_signin<F, Fut>(
-    browser: Browser,
-    profile: &Path,
-    bin: &str,
+    w: &SigninWait<'_>,
     child: &mut Child,
-    deadline: Instant,
-    signin_timeout: Duration,
     extract: &F,
 ) -> Result<String, String>
 where
@@ -123,9 +130,10 @@ where
     Fut: Future<Output = Result<Option<String>, String>>,
 {
     let started = Instant::now();
+    let deadline = started + w.timeout;
     let mut last_extract_err: Option<String> = None;
-    // Edge/Chrome sometimes spawn the UI detached and the launched parent exits
-    // early; the store is still on disk, so keep polling regardless of exit.
+    // Edge/Chrome sometimes spawn the UI detached and the launcher exits early;
+    // the store is still on disk, so keep polling regardless of exit.
     let mut child_exited_at: Option<Instant> = None;
     loop {
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -135,23 +143,32 @@ where
                 .map(|e| format!("; last extract error: {e}"))
                 .unwrap_or_default();
             let exited_note = child_exited_at
-                .map(|_| " — note: the browser process exited early (likely detached UI); close all browser windows and try again")
+                .map(|_| " — note: the browser exited early (likely detached UI); close all browser windows and try again")
                 .unwrap_or_default();
-            tracing::warn!(%bin, timeout_s = signin_timeout.as_secs(), exited_early = child_exited_at.is_some(), "sign-in timed out");
+            tracing::warn!(
+                bin = w.bin,
+                timeout_s = w.timeout.as_secs(),
+                exited_early = child_exited_at.is_some(),
+                "sign-in timed out"
+            );
             return Err(format!(
                 "Sign-in not detected within {}s{exited_note}{detail}",
-                signin_timeout.as_secs()
+                w.timeout.as_secs()
             ));
         }
         if child_exited_at.is_none()
             && let Ok(Some(status)) = child.try_wait()
         {
-            tracing::debug!(%bin, %status, "browser exited — still polling cookies (may be a detached UI)");
+            tracing::debug!(bin = w.bin, %status, "browser exited — still polling cookies");
             child_exited_at = Some(Instant::now());
         }
-        match extract(browser, profile.to_path_buf()).await {
+        match extract(w.browser, w.profile.to_path_buf()).await {
             Ok(Some(value)) => {
-                tracing::info!(%bin, elapsed_ms = started.elapsed().as_millis(), "sign-in detected — closing browser");
+                tracing::info!(
+                    bin = w.bin,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    "sign-in detected"
+                );
                 return Ok(value);
             }
             Ok(None) => {}
@@ -165,18 +182,13 @@ where
     }
 }
 
-/// Windows: Chrome buffers the signed-in auth cookies in memory and only writes
-/// them to the cookie store when the browser closes. Polling while it's open is
-/// futile, so wait for the cookie DB to go from browser-held to released (the
-/// user closing the window) — then read.
+/// Windows: Chrome buffers the auth cookies in memory and writes them to the
+/// store only when the browser closes, so wait for the cookie DB to go from
+/// browser-held to released (the user closing the window), then read.
 #[cfg(target_os = "windows")]
 async fn wait_for_signin<F, Fut>(
-    browser: Browser,
-    profile: &Path,
-    bin: &str,
+    w: &SigninWait<'_>,
     _child: &mut Child,
-    deadline: Instant,
-    signin_timeout: Duration,
     extract: &F,
 ) -> Result<String, String>
 where
@@ -184,8 +196,9 @@ where
     Fut: Future<Output = Result<Option<String>, String>>,
 {
     let started = Instant::now();
-    // Latches once the browser has opened the cookie store, so a still-empty
-    // store before launch isn't mistaken for "browser closed".
+    let deadline = started + w.timeout;
+    // Latches once the browser has opened the store, so a fresh empty profile
+    // isn't read as "browser closed".
     let mut saw_browser = false;
     let mut last_extract_err: Option<String> = None;
     loop {
@@ -195,24 +208,31 @@ where
                 .as_deref()
                 .map(|e| format!("; last extract error: {e}"))
                 .unwrap_or_default();
-            tracing::warn!(%bin, timeout_s = signin_timeout.as_secs(), saw_browser, "sign-in timed out");
+            tracing::warn!(
+                bin = w.bin,
+                timeout_s = w.timeout.as_secs(),
+                saw_browser,
+                "sign-in timed out"
+            );
             return Err(format!(
-                "Sign-in not detected within {}s — finish signing in, then close the browser window to complete sign-in{detail}",
-                signin_timeout.as_secs()
+                "Sign-in not detected within {}s — finish signing in, then close the browser window{detail}",
+                w.timeout.as_secs()
             ));
         }
-        if super::windows_native::cookie_db_locked(profile) {
+        if super::windows_native::cookie_db_locked(w.profile) {
             saw_browser = true;
             continue;
         }
         if !saw_browser {
-            continue; // browser hasn't opened the cookie store yet
+            continue;
         }
-        // Browser opened the store and has now released it (closed) → cookies are
-        // flushed; read them.
-        match extract(browser, profile.to_path_buf()).await {
+        match extract(w.browser, w.profile.to_path_buf()).await {
             Ok(Some(value)) => {
-                tracing::info!(%bin, elapsed_ms = started.elapsed().as_millis(), "sign-in detected after browser close");
+                tracing::info!(
+                    bin = w.bin,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    "sign-in detected after browser close"
+                );
                 return Ok(value);
             }
             Ok(None) => {}

--- a/crates/server/src/cookies/store.rs
+++ b/crates/server/src/cookies/store.rs
@@ -2,6 +2,16 @@ use std::path::Path;
 
 use config::Browser;
 
+/// A decrypted cookie — kopuz's consumers (YT Music + SoundCloud header
+/// builders) only ever read `name`/`value`, so this stays minimal and works on
+/// every platform (the non-Windows backend maps `rookie`'s richer struct down
+/// to it; Windows produces it natively).
+#[derive(Debug, Clone)]
+pub(crate) struct Cookie {
+    pub name: String,
+    pub value: String,
+}
+
 /// Decrypt the isolated profile's Chromium cookie store (via `rookie`) and
 /// return every cookie scoped to `domain`.
 #[cfg(not(target_os = "windows"))]
@@ -9,7 +19,7 @@ pub(crate) async fn read_cookies(
     browser: Browser,
     profile_root: &Path,
     domain: &str,
-) -> Result<Vec<rookie::enums::Cookie>, String> {
+) -> Result<Vec<Cookie>, String> {
     let db_path = super::profile::pick_cookies_path(profile_root).ok_or_else(|| {
         format!(
             "no Cookies database under {} — is `{}` installed?",
@@ -20,9 +30,16 @@ pub(crate) async fn read_cookies(
     let browser_name = browser.id();
     let domains = vec![domain.to_string()];
 
-    let cookies = tokio::task::spawn_blocking(move || -> Result<Vec<rookie::enums::Cookie>, String> {
+    let cookies = tokio::task::spawn_blocking(move || -> Result<Vec<Cookie>, String> {
         let config = rookie::config::get_browser_config(browser_name);
-        rookie::chromium_based(config, db_path, Some(domains)).map_err(|e| e.to_string())
+        let raw = rookie::chromium_based(config, db_path, Some(domains)).map_err(|e| e.to_string())?;
+        Ok(raw
+            .into_iter()
+            .map(|c| Cookie {
+                name: c.name,
+                value: c.value,
+            })
+            .collect())
     })
     .await
     .map_err(|e| format!("cookie extract task: {e}"))??;
@@ -30,14 +47,13 @@ pub(crate) async fn read_cookies(
     Ok(cookies)
 }
 
-/// Windows: unsupported — Chromium v20's App-Bound Encryption blocks non-admin
-/// decryption, and `rookie`'s ESE reader (`libesedb`) isn't built there.
+/// Windows: native v10/v11 (DPAPI) + v20 (planted app-bound) decryption — no
+/// `rookie`/`libesedb`, no admin. See [`super::windows_native`].
 #[cfg(target_os = "windows")]
 pub(crate) async fn read_cookies(
     browser: Browser,
     profile_root: &Path,
     domain: &str,
-) -> Result<Vec<rookie::enums::Cookie>, String> {
-    let _ = (browser, profile_root, domain);
-    Err("browser-cookie import isn't supported on Windows".to_string())
+) -> Result<Vec<Cookie>, String> {
+    super::windows_native::read_cookies(browser, profile_root, domain).await
 }

--- a/crates/server/src/cookies/store.rs
+++ b/crates/server/src/cookies/store.rs
@@ -32,7 +32,8 @@ pub(crate) async fn read_cookies(
 
     let cookies = tokio::task::spawn_blocking(move || -> Result<Vec<Cookie>, String> {
         let config = rookie::config::get_browser_config(browser_name);
-        let raw = rookie::chromium_based(config, db_path, Some(domains)).map_err(|e| e.to_string())?;
+        let raw =
+            rookie::chromium_based(config, db_path, Some(domains)).map_err(|e| e.to_string())?;
         Ok(raw
             .into_iter()
             .map(|c| Cookie {
@@ -43,7 +44,12 @@ pub(crate) async fn read_cookies(
     })
     .await
     .map_err(|e| format!("cookie extract task: {e}"))??;
-    tracing::trace!(browser = browser_name, domain, count = cookies.len(), "read cookies from isolated profile");
+    tracing::trace!(
+        browser = browser_name,
+        domain,
+        count = cookies.len(),
+        "read cookies from isolated profile"
+    );
     Ok(cookies)
 }
 

--- a/crates/server/src/cookies/windows_native.rs
+++ b/crates/server/src/cookies/windows_native.rs
@@ -14,17 +14,17 @@ use std::path::Path;
 
 use base64::Engine;
 use config::Browser;
-use windows::core::{interface, IUnknown, IUnknown_Vtbl, Interface, BSTR, GUID, HRESULT};
 use windows::Win32::Foundation::{SysAllocStringByteLen, SysStringByteLen};
 use windows::Win32::Security::Cryptography::{
-    CryptProtectData, CryptUnprotectData, CRYPT_INTEGER_BLOB,
+    CRYPT_INTEGER_BLOB, CryptProtectData, CryptUnprotectData,
 };
 use windows::Win32::System::Com::{
-    CoCreateInstance, CoInitializeEx, CoSetProxyBlanket, CLSCTX_LOCAL_SERVER,
-    COINIT_APARTMENTTHREADED, EOAC_DYNAMIC_CLOAKING, RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
+    CLSCTX_LOCAL_SERVER, COINIT_APARTMENTTHREADED, CoCreateInstance, CoInitializeEx,
+    CoSetProxyBlanket, EOAC_DYNAMIC_CLOAKING, RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
     RPC_C_IMP_LEVEL_IMPERSONATE,
 };
 use windows::Win32::System::Rpc::{RPC_C_AUTHN_DEFAULT, RPC_C_AUTHZ_DEFAULT};
+use windows::core::{BSTR, GUID, HRESULT, IUnknown, IUnknown_Vtbl, Interface, interface};
 
 use super::store::Cookie;
 
@@ -101,11 +101,12 @@ fn elevator_encrypt(browser: Browser, plaintext: &[u8]) -> Result<Vec<u8>, Strin
                 break;
             }
         }
-        let unk = unk.ok_or("no registered IElevator interface (Chrome version rotated the IID?)")?;
+        let unk =
+            unk.ok_or("no registered IElevator interface (Chrome version rotated the IID?)")?;
         CoSetProxyBlanket(
             &unk.cast::<IUnknown>().map_err(|e| e.to_string())?,
             RPC_C_AUTHN_DEFAULT as u32,
-            RPC_C_AUTHZ_DEFAULT as u32,
+            RPC_C_AUTHZ_DEFAULT,
             None,
             RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
             RPC_C_IMP_LEVEL_IMPERSONATE,
@@ -142,7 +143,12 @@ fn dpapi(data: &[u8], protect: bool) -> Result<Vec<u8>, String> {
         } else {
             CryptUnprotectData(&in_blob, None, None, None, None, 0, &mut out)
         };
-        res.map_err(|e| format!("DPAPI {}: {e}", if protect { "protect" } else { "unprotect" }))?;
+        res.map_err(|e| {
+            format!(
+                "DPAPI {}: {e}",
+                if protect { "protect" } else { "unprotect" }
+            )
+        })?;
         Ok(std::slice::from_raw_parts(out.pbData, out.cbData as usize).to_vec())
     }
 }
@@ -162,20 +168,20 @@ fn load_v10_key(profile_root: &Path) -> Option<Vec<u8>> {
     dpapi(stripped, false).ok()
 }
 
-/// True while the browser still holds the profile's cookie store open. Windows
-/// Chrome keeps the SQLite cookie DB open and buffers the signed-in auth cookies
-/// in memory until it closes — so the sign-in flow waits for this to flip false
-/// (browser closed → cookies flushed) before reading, instead of polling a store
-/// that's empty while the window is up.
+/// True while the browser holds the profile's cookie store open — an exclusive
+/// open then fails with `ERROR_SHARING_VIOLATION`.
 pub(crate) fn cookie_db_locked(profile_root: &Path) -> bool {
     use std::os::windows::fs::OpenOptionsExt;
     let p = profile_root.join("Default").join("Network").join("Cookies");
     if !p.exists() {
         return false;
     }
-    // share_mode(0) = deny-all: succeeds only if no other process has the file
-    // open. While the browser runs it fails with ERROR_SHARING_VIOLATION (32).
-    match std::fs::OpenOptions::new().read(true).share_mode(0).open(&p) {
+    // share_mode(0) = deny-all; 32 = ERROR_SHARING_VIOLATION.
+    match std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(0)
+        .open(&p)
+    {
         Ok(_) => false,
         Err(e) => e.raw_os_error() == Some(32),
     }
@@ -222,8 +228,11 @@ pub(crate) fn plant_app_bound_key(browser: Browser, profile_root: &Path) -> Resu
     if let Some(parent) = ls_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    std::fs::write(&ls_path, serde_json::to_vec(&ls).map_err(|e| e.to_string())?)
-        .map_err(|e| format!("write Local State: {e}"))?;
+    std::fs::write(
+        &ls_path,
+        serde_json::to_vec(&ls).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| format!("write Local State: {e}"))?;
 
     let wrapped = dpapi(&k, true)?;
     std::fs::write(profile_root.join(ABE_KEY_FILE), wrapped)
@@ -231,26 +240,44 @@ pub(crate) fn plant_app_bound_key(browser: Browser, profile_root: &Path) -> Resu
     Ok(())
 }
 
-/// AES-256-GCM cookie value: `<tag> | nonce[12] | ct+tag(16)`. Both v10 and v20
-/// in current Chrome prepend a 32-byte SHA(domain) block to the plaintext.
-fn decrypt_value(enc: &[u8], k_v10: &Option<Vec<u8>>, k_v20: &Option<Vec<u8>>) -> Option<String> {
+/// Chrome cookie-encryption tier, by the `encrypted_value` tag prefix.
+enum Scheme {
+    /// `v10`/`v11` — legacy DPAPI key.
+    Dpapi,
+    /// `v20` — planted app-bound key.
+    AppBound,
+}
+
+impl Scheme {
+    fn from_tag(tag: &[u8]) -> Option<Self> {
+        match tag {
+            b"v10" | b"v11" => Some(Self::Dpapi),
+            b"v20" => Some(Self::AppBound),
+            _ => None,
+        }
+    }
+}
+
+/// Decrypt one cookie value: `<tag> | nonce[12] | ct+tag`, AES-256-GCM, then drop
+/// the 32-byte SHA(domain) prefix current Chrome adds to both tiers.
+fn decrypt_value(enc: &[u8], dpapi: Option<&[u8]>, app_bound: Option<&[u8]>) -> Option<String> {
     use aes_gcm::aead::{Aead, KeyInit};
     use aes_gcm::{Aes256Gcm, Key, Nonce};
     if enc.len() < 3 + 12 + 16 {
         return None;
     }
-    let key = match &enc[..3] {
-        b"v10" | b"v11" => k_v10.as_ref()?,
-        b"v20" => k_v20.as_ref()?,
-        _ => return None,
+    let key = match Scheme::from_tag(&enc[..3])? {
+        Scheme::Dpapi => dpapi?,
+        Scheme::AppBound => app_bound?,
     };
     if key.len() != 32 {
         return None;
     }
     let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
-    let pt = cipher.decrypt(Nonce::from_slice(&enc[3..15]), &enc[15..]).ok()?;
-    let v = if pt.len() >= 32 { &pt[32..] } else { &pt[..] };
-    Some(String::from_utf8_lossy(v).into_owned())
+    let pt = cipher
+        .decrypt(Nonce::from_slice(&enc[3..15]), &enc[15..])
+        .ok()?;
+    Some(String::from_utf8_lossy(pt.get(32..).unwrap_or(&pt)).into_owned())
 }
 
 /// Copy the (possibly browser-locked) cookie store to a temp file and read every
@@ -277,11 +304,11 @@ pub(crate) async fn read_cookies(
         }
     }
 
-    let k_v10 = load_v10_key(profile_root);
-    let k_v20 = load_v20_key(profile_root);
+    let dpapi = load_v10_key(profile_root);
+    let app_bound = load_v20_key(profile_root);
 
-    // Open the temp copy read-write (not read_only): if the browser was killed
-    // mid-write the rollback journal needs recovery, which read_only can't do.
+    // Read-write (not read_only) so the rollback journal can recover if the
+    // browser was killed mid-write.
     let mut conn = sqlx::sqlite::SqliteConnectOptions::new()
         .filename(&db)
         .create_if_missing(false)
@@ -305,7 +332,7 @@ pub(crate) async fn read_cookies(
             plain
         } else {
             let enc: Vec<u8> = row.try_get("encrypted_value").unwrap_or_default();
-            match decrypt_value(&enc, &k_v10, &k_v20) {
+            match decrypt_value(&enc, dpapi.as_deref(), app_bound.as_deref()) {
                 Some(v) => v,
                 None => continue,
             }

--- a/crates/server/src/cookies/windows_native.rs
+++ b/crates/server/src/cookies/windows_native.rs
@@ -280,6 +280,12 @@ fn decrypt_value(enc: &[u8], dpapi: Option<&[u8]>, app_bound: Option<&[u8]>) -> 
     Some(String::from_utf8_lossy(pt.get(32..).unwrap_or(&pt)).into_owned())
 }
 
+/// A cookie `host_key` belongs to `domain` only as the domain itself or a
+/// dot-prefixed subdomain — never a bare substring (`notyoutube.com`).
+fn host_matches_domain(host: &str, domain: &str) -> bool {
+    host == domain || host.ends_with(&format!(".{domain}"))
+}
+
 /// Copy the (possibly browser-locked) cookie store to a temp file and read every
 /// cookie whose host is scoped to `domain`, decrypting v10/v20 values.
 pub(crate) async fn read_cookies(
@@ -294,7 +300,13 @@ pub(crate) async fn read_cookies(
         return Err(format!("no Cookies store under {}", profile_root.display()));
     }
     // Snapshot-copy so we read consistently even while the browser holds it open.
-    let tmp = std::env::temp_dir().join(format!("kopuz-ck-{}", std::process::id()));
+    // Unique per call (pid + counter) so concurrent reads don't clobber each other.
+    static SNAPSHOT_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let tmp = std::env::temp_dir().join(format!(
+        "kopuz-ck-{}-{}",
+        std::process::id(),
+        SNAPSHOT_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    ));
     std::fs::create_dir_all(&tmp).map_err(|e| e.to_string())?;
     let db = tmp.join("Cookies");
     for ext in ["", "-wal", "-shm", "-journal"] {
@@ -323,7 +335,7 @@ pub(crate) async fn read_cookies(
     let mut out = Vec::new();
     for row in rows {
         let host: String = row.try_get("host_key").unwrap_or_default();
-        if !host.contains(domain) {
+        if !host_matches_domain(&host, domain) {
             continue;
         }
         let name: String = row.try_get("name").unwrap_or_default();

--- a/crates/server/src/cookies/windows_native.rs
+++ b/crates/server/src/cookies/windows_native.rs
@@ -1,0 +1,317 @@
+//! Windows cookie decryption for kopuz's isolated browser profile.
+//!
+//! Chrome currently writes **v10/v11** cookies (legacy DPAPI) even for the
+//! signed-in Google/YouTube auth cookies — App-Bound Encryption (the v20 tier)
+//! is generated but Finch-gated off for our fresh isolated profile. We decrypt
+//! v10 with the profile's DPAPI key (non-admin `CryptUnprotectData`).
+//!
+//! As insurance against Google flipping the v20 rollout on, we also plant a
+//! `PROTECTION_NONE` app-bound key (which Chrome accepts) before launch and
+//! stash it DPAPI-wrapped in the profile; if a `v20` cookie ever appears we
+//! decrypt it with that key. No admin, no process injection, no read-time COM.
+
+use std::path::Path;
+
+use base64::Engine;
+use config::Browser;
+use windows::core::{interface, IUnknown, IUnknown_Vtbl, Interface, BSTR, GUID, HRESULT};
+use windows::Win32::Foundation::{SysAllocStringByteLen, SysStringByteLen};
+use windows::Win32::Security::Cryptography::{
+    CryptProtectData, CryptUnprotectData, CRYPT_INTEGER_BLOB,
+};
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CoSetProxyBlanket, CLSCTX_LOCAL_SERVER,
+    COINIT_APARTMENTTHREADED, EOAC_DYNAMIC_CLOAKING, RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
+    RPC_C_IMP_LEVEL_IMPERSONATE,
+};
+use windows::Win32::System::Rpc::{RPC_C_AUTHN_DEFAULT, RPC_C_AUTHZ_DEFAULT};
+
+use super::store::Cookie;
+
+// Chrome's elevation-service COM interface. Vtable after IUnknown is
+// RunRecoveryCRXElevated, EncryptData, DecryptData — we only call EncryptData
+// (slot 4). The trait IID is the base IElevator; we QI the brand IID at runtime.
+#[interface("A949CB4E-C4F9-44C4-B213-6BF8AA9AC69C")]
+unsafe trait IElevator: IUnknown {
+    unsafe fn run_recovery_crx_elevated(
+        &self,
+        crx_path: *const u16,
+        browser_appid: *const u16,
+        browser_version: *const u16,
+        session_id: *const u16,
+        caller_proc_id: u32,
+        proc_handle: *mut usize,
+    ) -> HRESULT;
+    unsafe fn encrypt_data(
+        &self,
+        protection_level: u32,
+        plaintext: BSTR,
+        ciphertext: *mut BSTR,
+        last_error: *mut u32,
+    ) -> HRESULT;
+    unsafe fn decrypt_data(
+        &self,
+        ciphertext: BSTR,
+        plaintext: *mut BSTR,
+        last_error: *mut u32,
+    ) -> HRESULT;
+}
+
+const PROTECTION_NONE: u32 = 0;
+const ABE_KEY_FILE: &str = ".kopuz-abe";
+
+/// (elevation CLSID, candidate IElevator IIDs newest-first). Chrome 149 rotated
+/// to IElevator2Chrome (== the elevation typelib GUID); the older IElevatorChrome
+/// IID is kept as a fallback for pre-149. Brands without an elevation service
+/// (Chromium/Vivaldi) return None — the plant is skipped, v10 still works.
+fn brand_elevation(browser: Browser) -> Option<(u128, &'static [u128])> {
+    match browser {
+        Browser::Chrome => Some((
+            0x708860E0_F641_4611_8895_7D867DD3675B,
+            &[
+                0x1BF5208B_295F_4992_B5F4_3A9BB6494838,
+                0x463ABECF_410D_407F_8AF5_0DF35A005CC8,
+            ],
+        )),
+        Browser::Edge => Some((
+            0x1FCBE96C_1697_43AF_9140_2897C7C69767,
+            &[0xC9C2B807_7731_4F34_81B7_44FF7779522B],
+        )),
+        Browser::Brave => Some((
+            0x576B31AF_6369_4B6B_8560_E4B203A97A8B,
+            &[0xF396861E_0C8E_4C71_8256_2FAE6D759CE9],
+        )),
+        Browser::Chromium | Browser::Vivaldi => None,
+    }
+}
+
+fn elevator_encrypt(browser: Browser, plaintext: &[u8]) -> Result<Vec<u8>, String> {
+    let (clsid, iids) = brand_elevation(browser).ok_or("no elevation service for browser")?;
+    unsafe {
+        let _ = CoInitializeEx(None, COINIT_APARTMENTTHREADED);
+        let clsid = GUID::from_u128(clsid);
+        let factory: IUnknown = CoCreateInstance(&clsid, None, CLSCTX_LOCAL_SERVER)
+            .map_err(|e| format!("CoCreateInstance: {e}"))?;
+        // QI the first registered brand interface (vtable layout-compatible).
+        let mut unk: Option<IElevator> = None;
+        for iid in iids {
+            let mut raw = core::ptr::null_mut();
+            if factory.query(&GUID::from_u128(*iid), &mut raw).is_ok() && !raw.is_null() {
+                unk = Some(IElevator::from_raw(raw));
+                break;
+            }
+        }
+        let unk = unk.ok_or("no registered IElevator interface (Chrome version rotated the IID?)")?;
+        CoSetProxyBlanket(
+            &unk.cast::<IUnknown>().map_err(|e| e.to_string())?,
+            RPC_C_AUTHN_DEFAULT as u32,
+            RPC_C_AUTHZ_DEFAULT as u32,
+            None,
+            RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
+            RPC_C_IMP_LEVEL_IMPERSONATE,
+            None,
+            EOAC_DYNAMIC_CLOAKING,
+        )
+        .map_err(|e| format!("CoSetProxyBlanket: {e}"))?;
+
+        let pt = SysAllocStringByteLen(Some(plaintext));
+        let mut ct = BSTR::default();
+        let mut last_err: u32 = 0;
+        let hr = unk.encrypt_data(PROTECTION_NONE, pt, &mut ct, &mut last_err);
+        if hr.is_err() {
+            return Err(format!("EncryptData hr={hr:?} last_error={last_err}"));
+        }
+        let len = SysStringByteLen(&ct) as usize;
+        let ptr = ct.as_ptr() as *const u8;
+        if ptr.is_null() || len == 0 {
+            return Err("EncryptData returned empty".into());
+        }
+        Ok(std::slice::from_raw_parts(ptr, len).to_vec())
+    }
+}
+
+fn dpapi(data: &[u8], protect: bool) -> Result<Vec<u8>, String> {
+    unsafe {
+        let in_blob = CRYPT_INTEGER_BLOB {
+            cbData: data.len() as u32,
+            pbData: data.as_ptr() as *mut u8,
+        };
+        let mut out = CRYPT_INTEGER_BLOB::default();
+        let res = if protect {
+            CryptProtectData(&in_blob, None, None, None, None, 0, &mut out)
+        } else {
+            CryptUnprotectData(&in_blob, None, None, None, None, 0, &mut out)
+        };
+        res.map_err(|e| format!("DPAPI {}: {e}", if protect { "protect" } else { "unprotect" }))?;
+        Ok(std::slice::from_raw_parts(out.pbData, out.cbData as usize).to_vec())
+    }
+}
+
+fn os_crypt_field(profile_root: &Path, field: &str) -> Option<String> {
+    let txt = std::fs::read_to_string(profile_root.join("Local State")).ok()?;
+    let v: serde_json::Value = serde_json::from_str(&txt).ok()?;
+    v.get("os_crypt")?.get(field)?.as_str().map(str::to_owned)
+}
+
+/// The legacy v10/v11 AES key: base64( "DPAPI" | CryptProtectData(key) ).
+fn load_v10_key(profile_root: &Path) -> Option<Vec<u8>> {
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(os_crypt_field(profile_root, "encrypted_key")?)
+        .ok()?;
+    let stripped = raw.strip_prefix(b"DPAPI")?;
+    dpapi(stripped, false).ok()
+}
+
+/// True while the browser still holds the profile's cookie store open. Windows
+/// Chrome keeps the SQLite cookie DB open and buffers the signed-in auth cookies
+/// in memory until it closes — so the sign-in flow waits for this to flip false
+/// (browser closed → cookies flushed) before reading, instead of polling a store
+/// that's empty while the window is up.
+pub(crate) fn cookie_db_locked(profile_root: &Path) -> bool {
+    use std::os::windows::fs::OpenOptionsExt;
+    let p = profile_root.join("Default").join("Network").join("Cookies");
+    if !p.exists() {
+        return false;
+    }
+    // share_mode(0) = deny-all: succeeds only if no other process has the file
+    // open. While the browser runs it fails with ERROR_SHARING_VIOLATION (32).
+    match std::fs::OpenOptions::new().read(true).share_mode(0).open(&p) {
+        Ok(_) => false,
+        Err(e) => e.raw_os_error() == Some(32),
+    }
+}
+
+/// Recover the planted app-bound (v20) key we DPAPI-wrapped at plant time.
+fn load_v20_key(profile_root: &Path) -> Option<Vec<u8>> {
+    let wrapped = std::fs::read(profile_root.join(ABE_KEY_FILE)).ok()?;
+    dpapi(&wrapped, false).ok()
+}
+
+/// Mint a random app-bound key, seal it via the elevation service with
+/// PROTECTION_NONE, plant it into the fresh profile's `Local State`, and stash
+/// the plaintext DPAPI-wrapped so a later read can decrypt v20 cookies. Must run
+/// AFTER the profile dir exists and BEFORE the browser launches. Best-effort:
+/// failure is non-fatal (v10 cookies still decrypt without it).
+pub(crate) fn plant_app_bound_key(browser: Browser, profile_root: &Path) -> Result<(), String> {
+    if brand_elevation(browser).is_none() {
+        return Ok(());
+    }
+    let k: [u8; 32] = rand::random();
+    let sealed = elevator_encrypt(browser, &k)?;
+
+    let mut planted = b"APPB".to_vec();
+    planted.extend_from_slice(&sealed);
+    let planted_b64 = base64::engine::general_purpose::STANDARD.encode(&planted);
+
+    let ls_path = profile_root.join("Local State");
+    let mut ls: serde_json::Value = std::fs::read_to_string(&ls_path)
+        .ok()
+        .and_then(|t| serde_json::from_str(&t).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    if !ls.is_object() {
+        ls = serde_json::json!({});
+    }
+    let oc = ls
+        .as_object_mut()
+        .unwrap()
+        .entry("os_crypt")
+        .or_insert_with(|| serde_json::json!({}));
+    oc.as_object_mut()
+        .ok_or("os_crypt not an object")?
+        .insert("app_bound_encrypted_key".into(), planted_b64.into());
+    if let Some(parent) = ls_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&ls_path, serde_json::to_vec(&ls).map_err(|e| e.to_string())?)
+        .map_err(|e| format!("write Local State: {e}"))?;
+
+    let wrapped = dpapi(&k, true)?;
+    std::fs::write(profile_root.join(ABE_KEY_FILE), wrapped)
+        .map_err(|e| format!("stash app-bound key: {e}"))?;
+    Ok(())
+}
+
+/// AES-256-GCM cookie value: `<tag> | nonce[12] | ct+tag(16)`. Both v10 and v20
+/// in current Chrome prepend a 32-byte SHA(domain) block to the plaintext.
+fn decrypt_value(enc: &[u8], k_v10: &Option<Vec<u8>>, k_v20: &Option<Vec<u8>>) -> Option<String> {
+    use aes_gcm::aead::{Aead, KeyInit};
+    use aes_gcm::{Aes256Gcm, Key, Nonce};
+    if enc.len() < 3 + 12 + 16 {
+        return None;
+    }
+    let key = match &enc[..3] {
+        b"v10" | b"v11" => k_v10.as_ref()?,
+        b"v20" => k_v20.as_ref()?,
+        _ => return None,
+    };
+    if key.len() != 32 {
+        return None;
+    }
+    let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(key));
+    let pt = cipher.decrypt(Nonce::from_slice(&enc[3..15]), &enc[15..]).ok()?;
+    let v = if pt.len() >= 32 { &pt[32..] } else { &pt[..] };
+    Some(String::from_utf8_lossy(v).into_owned())
+}
+
+/// Copy the (possibly browser-locked) cookie store to a temp file and read every
+/// cookie whose host is scoped to `domain`, decrypting v10/v20 values.
+pub(crate) async fn read_cookies(
+    _browser: Browser,
+    profile_root: &Path,
+    domain: &str,
+) -> Result<Vec<Cookie>, String> {
+    use sqlx::{ConnectOptions, Row};
+
+    let src = profile_root.join("Default").join("Network").join("Cookies");
+    if !src.exists() {
+        return Err(format!("no Cookies store under {}", profile_root.display()));
+    }
+    // Snapshot-copy so we read consistently even while the browser holds it open.
+    let tmp = std::env::temp_dir().join(format!("kopuz-ck-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp).map_err(|e| e.to_string())?;
+    let db = tmp.join("Cookies");
+    for ext in ["", "-wal", "-shm", "-journal"] {
+        let s = src.with_file_name(format!("Cookies{ext}"));
+        if s.exists() {
+            let _ = std::fs::copy(&s, tmp.join(format!("Cookies{ext}")));
+        }
+    }
+
+    let k_v10 = load_v10_key(profile_root);
+    let k_v20 = load_v20_key(profile_root);
+
+    // Open the temp copy read-write (not read_only): if the browser was killed
+    // mid-write the rollback journal needs recovery, which read_only can't do.
+    let mut conn = sqlx::sqlite::SqliteConnectOptions::new()
+        .filename(&db)
+        .create_if_missing(false)
+        .connect()
+        .await
+        .map_err(|e| format!("open Cookies: {e}"))?;
+    let rows = sqlx::query("SELECT host_key, name, value, encrypted_value FROM cookies")
+        .fetch_all(&mut conn)
+        .await
+        .map_err(|e| format!("query cookies: {e}"))?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let host: String = row.try_get("host_key").unwrap_or_default();
+        if !host.contains(domain) {
+            continue;
+        }
+        let name: String = row.try_get("name").unwrap_or_default();
+        let plain: String = row.try_get("value").unwrap_or_default();
+        let value = if !plain.is_empty() {
+            plain
+        } else {
+            let enc: Vec<u8> = row.try_get("encrypted_value").unwrap_or_default();
+            match decrypt_value(&enc, &k_v10, &k_v20) {
+                Some(v) => v,
+                None => continue,
+            }
+        };
+        out.push(Cookie { name, value });
+    }
+    let _ = std::fs::remove_dir_all(&tmp);
+    Ok(out)
+}

--- a/crates/server/src/ytmusic/cookies.rs
+++ b/crates/server/src/ytmusic/cookies.rs
@@ -6,7 +6,6 @@ use std::path::Path;
 
 use config::Browser;
 
-#[cfg(not(target_os = "windows"))]
 #[tracing::instrument(name = "yt.cookies_extract", skip(profile_root), fields(browser = %browser))]
 pub async fn extract_from(browser: Browser, profile_root: &Path) -> Result<String, String> {
     let cookies = crate::cookies::read_cookies(browser, profile_root, "youtube.com").await?;
@@ -33,15 +32,6 @@ pub async fn extract_from(browser: Browser, profile_root: &Path) -> Result<Strin
     Ok(header)
 }
 
-/// Windows: unsupported — App-Bound Encryption + no `libesedb`; callers fall
-/// back to anonymous access.
-#[cfg(target_os = "windows")]
-pub async fn extract_from(browser: Browser, profile_root: &Path) -> Result<String, String> {
-    let _ = (browser, profile_root);
-    Err("browser-cookie import isn't supported on Windows".to_string())
-}
-
-#[cfg(not(target_os = "windows"))]
 fn header_safe(s: &str) -> bool {
     !s.is_empty()
         && s.bytes()

--- a/crates/server/src/ytmusic/isolated_profile.rs
+++ b/crates/server/src/ytmusic/isolated_profile.rs
@@ -20,13 +20,9 @@ pub fn delete_profile(server_id: &str) -> std::io::Result<()> {
     cookies::delete_profile(PROFILE_PREFIX, server_id)
 }
 
-// TODO: (windows-signin) browser sign-in is disabled on Windows in the UI
-// (settings_popups.rs forces anonymous mode there) because the Google accounts
-// page renders a blank document inside the isolated `--user-data-dir` profile —
-// SAPISID/SID never land and this loops to timeout. Linux/macOS work. Likely
-// Edge/Chrome first-run + automation heuristics specific to Windows; needs a
-// Windows tester (tried --disable-blink-features=AutomationControlled + UA
-// spoof, reverted — commits 6bec69d/8a03c89). Until then, Windows = anonymous.
+// Windows browser sign-in is now supported: cookies are decrypted natively
+// (v10 DPAPI + planted v20 app-bound key — see `crate::cookies::windows_native`),
+// so the extract callback below resolves the same as Linux/macOS.
 #[tracing::instrument(name = "yt.signin", skip(server_id, signin_timeout), fields(browser = %browser))]
 pub async fn launch_signin_and_extract(
     browser: Browser,


### PR DESCRIPTION
This pull request introduces major improvements to browser-based sign-in for YouTube Music and SoundCloud, especially on Windows. The changes add native Windows support for decrypting Chrome/Edge cookies, unify and simplify sign-in logic, and update the UI and documentation to reflect the new cross-platform capabilities. The most important changes are grouped as follows:

**Platform Support & Dependencies:**
* Added native Windows support for Chrome/Edge cookie decryption by introducing the `windows_native` module and platform-specific dependencies (`aes-gcm`, `base64`, `windows-core`, and others) in `crates/server/Cargo.toml`. This enables browser sign-in on Windows without external C libraries. [[1]](diffhunk://#diff-e69b576d0ecfb734851abf4882a8a231930a77092948b45464c06ae19e45e3cbL41-R58) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R88) [[3]](diffhunk://#diff-8030910f8d128a9285eb395d67b132862c67577acb1b87bd7615d8149f511405R5-R6)
* Removed the unconditional `rookie` dependency from Windows builds, as native decryption is now handled internally. [[1]](diffhunk://#diff-e69b576d0ecfb734851abf4882a8a231930a77092948b45464c06ae19e45e3cbL32) [[2]](diffhunk://#diff-e69b576d0ecfb734851abf4882a8a231930a77092948b45464c06ae19e45e3cbL41-R58)

**Browser Sign-in Flow Improvements:**
* Refactored the sign-in process to use a new `wait_for_signin` strategy: on Windows, the app waits for the browser window to close before extracting cookies (since Chrome/Edge only flush cookies on close); on other platforms, it polls for cookies while the browser is open. [[1]](diffhunk://#diff-088031c1b63329f95022e3586a2a3efc143846a1915645067a3731973fab0d66L81-R130) [[2]](diffhunk://#diff-088031c1b63329f95022e3586a2a3efc143846a1915645067a3731973fab0d66L112-R226)
* Added a `prepare_profile` function to plant an app-bound encryption key in the browser profile on Windows, ensuring future-proof support for Chrome's v20+ cookie encryption. [[1]](diffhunk://#diff-088031c1b63329f95022e3586a2a3efc143846a1915645067a3731973fab0d66R45-R46) [[2]](diffhunk://#diff-088031c1b63329f95022e3586a2a3efc143846a1915645067a3731973fab0d66L81-R130)

**UI and User Experience Updates:**
* Updated the settings UI to allow browser sign-in on all platforms, removing previous Windows restrictions and clarifying instructions (e.g., prompting users to close the browser window after signing in on Windows). [[1]](diffhunk://#diff-6b66dbbf4f37c2fa610e9edc1a10f9ff7384853453b7c07c63a00c4216fbd384L240-L259) [[2]](diffhunk://#diff-6b66dbbf4f37c2fa610e9edc1a10f9ff7384853453b7c07c63a00c4216fbd384L283-R282) [[3]](diffhunk://#diff-197f2088f45245cf3c19a2cb22fde2ed469d1878837f86b3fad05ccdd9085b13L140-R142)

**Code Simplification & Error Handling:**
* Unified credential persistence and error handling for both YouTube Music and SoundCloud sign-in flows with new helper functions (`apply_browser_login` and `report_signin_failure`). [[1]](diffhunk://#diff-5901256db10c4fb5ab0880855798cd2af749c0a1c728fdf3a836f871d4106169L108-R147) [[2]](diffhunk://#diff-5901256db10c4fb5ab0880855798cd2af749c0a1c728fdf3a836f871d4106169L124-R182) [[3]](diffhunk://#diff-5901256db10c4fb5ab0880855798cd2af749c0a1c728fdf3a836f871d4106169L185-R213)

**Documentation and Comments:**
* Updated and clarified comments throughout the codebase to reflect the new cross-platform sign-in logic and platform-specific behaviors. [[1]](diffhunk://#diff-6b66dbbf4f37c2fa610e9edc1a10f9ff7384853453b7c07c63a00c4216fbd384L12-R12) [[2]](diffhunk://#diff-088031c1b63329f95022e3586a2a3efc143846a1915645067a3731973fab0d66L2-R17) [[3]](diffhunk://#diff-088031c1b63329f95022e3586a2a3efc143846a1915645067a3731973fab0d66L71-R74)

These changes together enable a seamless, cross-platform browser sign-in experience for users and significantly improve maintainability and clarity of the sign-in logic.