### PR TITLE
various: show media source in Discord presence with optional toggle

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -498,6 +498,8 @@ pub struct AppConfig {
     pub discord_presence: Option<bool>,
     #[serde(default = "default_discord_presence_paused")]
     pub discord_presence_paused: Option<bool>,
+    #[serde(default = "default_discord_presence_source")]
+    pub discord_presence_source: Option<bool>,
     #[serde(default = "default_sort_order")]
     pub sort_order: SortOrder,
     #[serde(default = "default_artist_view_order")]
@@ -603,6 +605,10 @@ fn default_discord_presence_paused() -> Option<bool> {
     Some(true)
 }
 
+fn default_discord_presence_source() -> Option<bool> {
+    Some(true)
+}
+
 fn default_sort_order() -> SortOrder {
     SortOrder::Title
 }
@@ -681,6 +687,7 @@ impl Default for AppConfig {
             device_id: default_device_id(),
             discord_presence: Some(true),
             discord_presence_paused: Some(true),
+            discord_presence_source: Some(true),
             sort_order: default_sort_order(),
             artist_view_order: default_artist_view_order(),
             listen_counts: HashMap::new(),

--- a/crates/config/src/views.rs
+++ b/crates/config/src/views.rs
@@ -59,6 +59,7 @@ pub struct LibraryConfig {
 pub struct IntegrationConfig {
     pub discord_presence: Option<bool>,
     pub discord_presence_paused: Option<bool>,
+    pub discord_presence_source: Option<bool>,
     pub musicbrainz_token: String,
     pub lastfm_api_key: String,
     pub lastfm_api_secret: String,
@@ -132,6 +133,7 @@ impl AppConfig {
         IntegrationConfig {
             discord_presence: self.discord_presence,
             discord_presence_paused: self.discord_presence_paused,
+            discord_presence_source: self.discord_presence_source,
             musicbrainz_token: self.musicbrainz_token.clone(),
             lastfm_api_key: self.lastfm_api_key.clone(),
             lastfm_api_secret: self.lastfm_api_secret.clone(),

--- a/crates/discord-presence/src/lib.rs
+++ b/crates/discord-presence/src/lib.rs
@@ -45,6 +45,7 @@ impl Presence {
         elapsed_secs: u64,
         duration_secs: u64,
         cover_url: Option<&str>,
+        source: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as i64;
 
@@ -58,6 +59,7 @@ impl Presence {
         };
 
         let state = artist.to_string();
+        let name = source.map(|s| format!("Kopuz - on {s}"));
 
         let mut activity = activity::Activity::new()
             .details(title)
@@ -65,6 +67,10 @@ impl Presence {
             .status_display_type(activity::StatusDisplayType::State)
             .timestamps(timestamps)
             .activity_type(activity::ActivityType::Listening);
+
+        if let Some(ref name) = name {
+            activity = activity.name(name);
+        }
 
         if let Some(url) = cover_url {
             let assets = Assets::new().large_image(url).large_text(album);
@@ -84,13 +90,19 @@ impl Presence {
         artist: &str,
         album: &str,
         cover_url: Option<&str>,
+        source: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let state = format!("{artist} • Paused");
+        let name = source.map(|s| format!("Kopuz - on {s}"));
         let mut activity = activity::Activity::new()
             .details(title)
             .state(&state)
             .status_display_type(activity::StatusDisplayType::State)
             .activity_type(activity::ActivityType::Listening);
+
+        if let Some(ref name) = name {
+            activity = activity.name(name);
+        }
 
         if let Some(url) = cover_url {
             let assets = Assets::new().large_image(url).large_text(album);
@@ -149,6 +161,7 @@ impl Presence {
         _elapsed_secs: u64,
         _duration_secs: u64,
         _cover_url: Option<&str>,
+        _source: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
@@ -159,6 +172,7 @@ impl Presence {
         _artist: &str,
         _album: &str,
         _cover_url: Option<&str>,
+        _source: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }

--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -360,6 +360,17 @@ pub fn use_player_task(ctrl: PlayerController) {
                 let discord_enabled = config.read().discord_presence.unwrap_or(true);
                 #[cfg(not(target_arch = "wasm32"))]
                 let discord_paused_enabled = config.read().discord_presence_paused.unwrap_or(true);
+                #[cfg(not(target_arch = "wasm32"))]
+                let discord_source_name = config
+                    .read()
+                    .discord_presence_source
+                    .unwrap_or(true)
+                    .then(|| {
+                        config
+                            .read()
+                            .active_service()
+                            .map_or("Local", |s| s.display_name())
+                    });
                 let pos = ctrl.player.read().get_position();
                 let mut defer_player_progress = false;
 
@@ -554,7 +565,13 @@ pub fn use_player_task(ctrl: PlayerController) {
                                 let cover_ref = resolved.as_deref();
 
                                 let _ = p.set_now_playing(
-                                    &title, &artist, &album, progress, duration, cover_ref,
+                                    &title,
+                                    &artist,
+                                    &album,
+                                    progress,
+                                    duration,
+                                    cover_ref,
+                                    discord_source_name,
                                 );
 
                                 if resolved.is_some() {
@@ -644,7 +661,13 @@ pub fn use_player_task(ctrl: PlayerController) {
                             let album = ctrl.current_song_album.read().clone();
                             if discord_enabled && discord_paused_enabled {
                                 let resolved = discord_cover_url.read().clone();
-                                let _ = p.set_paused(&title, &artist, &album, resolved.as_deref());
+                                let _ = p.set_paused(
+                                    &title,
+                                    &artist,
+                                    &album,
+                                    resolved.as_deref(),
+                                    discord_source_name,
+                                );
                             } else if last_discord_enabled || !discord_paused_enabled {
                                 let _ = p.clear_activity();
                             }
@@ -658,7 +681,13 @@ pub fn use_player_task(ctrl: PlayerController) {
                                 let artist = ctrl.current_song_artist.read().clone();
                                 let album = ctrl.current_song_album.read().clone();
                                 let resolved = discord_cover_url.read().clone();
-                                let _ = p.set_paused(&title, &artist, &album, resolved.as_deref());
+                                let _ = p.set_paused(
+                                    &title,
+                                    &artist,
+                                    &album,
+                                    resolved.as_deref(),
+                                    discord_source_name,
+                                );
                             }
                         }
                     }

--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -95,6 +95,8 @@ pub fn use_player_task(ctrl: PlayerController) {
     #[cfg(not(target_arch = "wasm32"))]
     let mut last_title = use_signal(String::new);
     #[cfg(not(target_arch = "wasm32"))]
+    let mut last_source: Signal<Option<String>> = use_signal(|| None);
+    #[cfg(not(target_arch = "wasm32"))]
     let mut was_playing = use_signal(|| false);
     #[cfg(not(target_arch = "wasm32"))]
     let mut discord_cover_url: Signal<Option<String>> = use_signal(|| None);
@@ -371,6 +373,8 @@ pub fn use_player_task(ctrl: PlayerController) {
                             .active_service()
                             .map_or("Local", |s| s.display_name())
                     });
+                #[cfg(not(target_arch = "wasm32"))]
+                let source_changed = last_source.peek().as_deref() != discord_source_name;
                 let pos = ctrl.player.read().get_position();
                 let mut defer_player_progress = false;
 
@@ -558,8 +562,14 @@ pub fn use_player_task(ctrl: PlayerController) {
                             let cover_just_resolved =
                                 discord_cover_url.peek().is_some() && !*discord_cover_sent.peek();
 
-                            if song_changed || resumed || toggled_on || cover_just_resolved {
+                            if song_changed
+                                || resumed
+                                || toggled_on
+                                || cover_just_resolved
+                                || source_changed
+                            {
                                 last_title.set(title.clone());
+                                last_source.set(discord_source_name.map(str::to_owned));
 
                                 let resolved = discord_cover_url.read().clone();
                                 let cover_ref = resolved.as_deref();
@@ -661,6 +671,7 @@ pub fn use_player_task(ctrl: PlayerController) {
                             let album = ctrl.current_song_album.read().clone();
                             if discord_enabled && discord_paused_enabled {
                                 let resolved = discord_cover_url.read().clone();
+                                last_source.set(discord_source_name.map(str::to_owned));
                                 let _ = p.set_paused(
                                     &title,
                                     &artist,
@@ -675,12 +686,15 @@ pub fn use_player_task(ctrl: PlayerController) {
                     } else if let Some(ref p) = presence {
                         if !discord_enabled && last_discord_enabled {
                             let _ = p.clear_activity();
-                        } else if discord_enabled && !last_discord_enabled {
+                        } else if discord_enabled
+                            && (!last_discord_enabled || (source_changed && discord_paused_enabled))
+                        {
                             let title = ctrl.current_song_title.read().clone();
                             if !title.is_empty() {
                                 let artist = ctrl.current_song_artist.read().clone();
                                 let album = ctrl.current_song_album.read().clone();
                                 let resolved = discord_cover_url.read().clone();
+                                last_source.set(discord_source_name.map(str::to_owned));
                                 let _ = p.set_paused(
                                     &title,
                                     &artist,

--- a/crates/i18n/locales/ar.ftl
+++ b/crates/i18n/locales/ar.ftl
@@ -45,6 +45,7 @@ player_settings = إعدادات المشغل
 discord_presence = شارة Discord
 connectivity = الاتصال
 discord_presence_paused = إظهار حالة Discord عند الإيقاف المؤقت
+discord_presence_source = إظهار مصدر الوسائط في حالة Discord
 reduce_animations = تقليل الرسوم المتحركة
 show_source_toggle = إظهار إختيار تبديل المصدر
 titlebar_mode = شريط العنوان

--- a/crates/i18n/locales/de.ftl
+++ b/crates/i18n/locales/de.ftl
@@ -45,6 +45,7 @@ player_settings = Player-Einstellungen
 discord_presence = Discord-Status
 connectivity = Konnektivität
 discord_presence_paused = Pausierten Discord-Status anzeigen
+discord_presence_source = Medienquelle im Discord-Status anzeigen
 reduce_animations = Animationen reduzieren
 show_source_toggle = Quellenumschalter anzeigen
 titlebar_mode = Titelleiste

--- a/crates/i18n/locales/en.ftl
+++ b/crates/i18n/locales/en.ftl
@@ -54,6 +54,7 @@ channel_mode_swap_left_right = Swap L/R
 discord_presence = Discord Presence
 connectivity = Connectivity
 discord_presence_paused = Show paused Discord status
+discord_presence_source = Show media source in Discord status
 reduce_animations = Reduce Animations
 auto_check_updates = Auto Check Updates
 minimize_to_tray = Minimize to system tray

--- a/crates/i18n/locales/es.ftl
+++ b/crates/i18n/locales/es.ftl
@@ -45,6 +45,7 @@ player_settings = Configuración del reproductor
 discord_presence = Presencia de Discord
 connectivity = Conectividad
 discord_presence_paused = Mostrar estado de Discord en pausa
+discord_presence_source = Mostrar la fuente multimedia en el estado de Discord
 reduce_animations = Reducir animaciones
 show_source_toggle = Mostrar interruptor de fuente
 titlebar_mode = Barra de título

--- a/crates/i18n/locales/fil.ftl
+++ b/crates/i18n/locales/fil.ftl
@@ -54,6 +54,7 @@ channel_mode_swap_left_right = Ipagpalit ang L/R
 discord_presence = Discord Presence
 connectivity = Koneksyon
 discord_presence_paused = Ipakita ang Naka-pause na Discord status
+discord_presence_source = Ipakita ang media source sa Discord status
 reduce_animations = Bawasan ang mga Animation
 auto_check_updates = Awtomatikong Pag-check ng mga Update
 minimize_to_tray = I-minimize sa system tray

--- a/crates/i18n/locales/fr.ftl
+++ b/crates/i18n/locales/fr.ftl
@@ -45,6 +45,7 @@ player_settings = Parametre du Player
 discord_presence = Discord Presence
 connectivity = Connectivité
 discord_presence_paused = Afficher le statut Discord en pause
+discord_presence_source = Afficher la source multimédia dans le statut Discord
 reduce_animations = Reduire Les Animation
 show_source_toggle = Afficheur De Source Toggle
 titlebar_mode = Barre de titre

--- a/crates/i18n/locales/gr.ftl
+++ b/crates/i18n/locales/gr.ftl
@@ -45,6 +45,7 @@ player_settings = Ρυθμίσεις Αναπαραγωγής
 discord_presence = Κατάσταση Discord
 connectivity = Συνδεσιμότητα
 discord_presence_paused = Εμφάνιση κατάστασης Discord σε παύση
+discord_presence_source = Εμφάνιση πηγής πολυμέσων στην κατάσταση Discord
 reduce_animations = Μείωση κινήσεων
 show_source_toggle = Εμφάνιση διακόπτη πηγής
 titlebar_mode = Γραμμή τίτλου

--- a/crates/i18n/locales/he.ftl
+++ b/crates/i18n/locales/he.ftl
@@ -45,6 +45,7 @@ player_settings = הגדרות נגן
 discord_presence = נוכחות דיסקורד
 connectivity = קישוריות
 discord_presence_paused = הצגת סטטוס Discord במצב מושהה
+discord_presence_source = הצגת מקור המדיה בסטטוס Discord
 reduce_animations = הפחתת אנימציות
 show_source_toggle = הצגת מקור
 titlebar_mode = סרגל כותרת

--- a/crates/i18n/locales/hu.ftl
+++ b/crates/i18n/locales/hu.ftl
@@ -45,6 +45,7 @@ player_settings = Lejátszó beállításai
 discord_presence = Discord jelenlét
 connectivity = Kapcsolódás
 discord_presence_paused = Szüneteltetett Discord állapot megjelenítése
+discord_presence_source = Médiaforrás megjelenítése a Discord állapotban
 reduce_animations = Animációk csökkentése
 show_source_toggle = Forrás kapcsoló megjelenítése
 titlebar_mode = Címsor

--- a/crates/i18n/locales/id.ftl
+++ b/crates/i18n/locales/id.ftl
@@ -54,6 +54,7 @@ channel_mode_swap_left_right = Tukar L/R
 discord_presence = Discord Presence
 connectivity = Konektivitas
 discord_presence_paused = Tampilkan status Discord saat dijeda
+discord_presence_source = Tampilkan sumber media di status Discord
 reduce_animations = Kurangi Animasi
 auto_check_updates = Otomatis Memeriksa Pembaruan
 minimize_to_tray = Minimalkan ke baki sistem

--- a/crates/i18n/locales/it.ftl
+++ b/crates/i18n/locales/it.ftl
@@ -54,6 +54,7 @@ channel_mode_swap_left_right = Scambia L/R
 discord_presence = Presenza su Discord
 connectivity = Connettività
 discord_presence_paused = Mostra lo status in pausa su Discord
+discord_presence_source = Mostra la sorgente multimediale nello status di Discord
 reduce_animations = Animazioni ridotte
 auto_check_updates = Cerca aggiornamenti in automatico
 minimize_to_tray = Riduci a icona nella barra di sistema

--- a/crates/i18n/locales/ja.ftl
+++ b/crates/i18n/locales/ja.ftl
@@ -45,6 +45,7 @@ player_settings = プレイヤー設定
 discord_presence = Discordプレゼンス
 connectivity = 接続
 discord_presence_paused = 一時停止中のDiscordステータスを表示
+discord_presence_source = Discordステータスにメディアソースを表示
 reduce_animations = アニメーションを減らす
 show_source_toggle = ソース切替を表示
 titlebar_mode = タイトルバー

--- a/crates/i18n/locales/ko.ftl
+++ b/crates/i18n/locales/ko.ftl
@@ -45,6 +45,7 @@ player_settings = 플레이어 설정
 discord_presence = Discord 상태 표시
 connectivity = 연결
 discord_presence_paused = 일시정지한 Discord 상태 표시
+discord_presence_source = Discord 상태에 미디어 소스 표시
 reduce_animations = 애니메이션 줄이기
 show_source_toggle = 소스 전환 표시
 titlebar_mode = 제목 표시줄

--- a/crates/i18n/locales/ml.ftl
+++ b/crates/i18n/locales/ml.ftl
@@ -54,6 +54,7 @@ channel_mode_swap_left_right = ഇടത്/വലത് മാറ്റുക
 discord_presence = Discord സാന്നിധ്യം
 connectivity = കണക്റ്റിവിറ്റി
 discord_presence_paused = നിർത്തിയ Discord നില കാണിക്കുക
+discord_presence_source = Discord നിലയിൽ മീഡിയ ഉറവിടം കാണിക്കുക
 reduce_animations = ആനിമേഷനുകൾ കുറയ്ക്കുക
 auto_check_updates = അപ്‌ഡേറ്റുകൾ സ്വയം പരിശോധിക്കുക
 minimize_to_tray = സിസ്റ്റം ട്രേയിലേക്ക് ചെറുതാക്കുക

--- a/crates/i18n/locales/nl.ftl
+++ b/crates/i18n/locales/nl.ftl
@@ -54,6 +54,7 @@ channel_mode_swap_left_right = L/R omwisselen
 discord_presence = Discord-status
 connectivity = Connectiviteit
 discord_presence_paused = Gepauzeerde Discord-status tonen
+discord_presence_source = Mediabron tonen in Discord-status
 reduce_animations = Animaties verminderen
 auto_check_updates = Automatisch op updates controleren
 minimize_to_tray = Naar systeemvak minimaliseren

--- a/crates/i18n/locales/pl.ftl
+++ b/crates/i18n/locales/pl.ftl
@@ -45,6 +45,7 @@ player_settings = Ustawienia odtwarzacza
 discord_presence = Aktywność na Discord
 connectivity = Łączność
 discord_presence_paused = Pokaż wstrzymany status Discord
+discord_presence_source = Pokaż źródło multimediów w statusie Discord
 reduce_animations = Ogranicz Animacje
 show_source_toggle = Pokaż Przełącznik Źródła
 titlebar_mode = Pasek tytułu

--- a/crates/i18n/locales/pt-BR.ftl
+++ b/crates/i18n/locales/pt-BR.ftl
@@ -45,6 +45,7 @@ player_settings = Configurações do player
 discord_presence = Presença no Discord
 connectivity = Conectividade
 discord_presence_paused = Mostrar status do Discord em pausa
+discord_presence_source = Mostrar a fonte de mídia no status do Discord
 reduce_animations = Reduzir animações
 show_source_toggle = Mostrar alternância de fonte
 titlebar_mode = Barra de título

--- a/crates/i18n/locales/pt-PT.ftl
+++ b/crates/i18n/locales/pt-PT.ftl
@@ -45,6 +45,7 @@ player_settings = Configurações do reprodutor
 discord_presence = Presença no Discord
 connectivity = Conectividade
 discord_presence_paused = Mostrar estado do Discord em pausa
+discord_presence_source = Mostrar a fonte de média no estado do Discord
 reduce_animations = Reduzir animações
 show_source_toggle = Mostrar alternador de fonte
 titlebar_mode = Barra de título

--- a/crates/i18n/locales/ro.ftl
+++ b/crates/i18n/locales/ro.ftl
@@ -45,6 +45,7 @@ player_settings = Setări Player
 discord_presence = Prezență Discord
 connectivity = Conectivitate
 discord_presence_paused = Afișează statusul Discord în pauză
+discord_presence_source = Afișează sursa media în statusul Discord
 reduce_animations = Reducere Animații
 show_source_toggle = Comutator Sursă
 titlebar_mode = Bară de titlu

--- a/crates/i18n/locales/ru.ftl
+++ b/crates/i18n/locales/ru.ftl
@@ -45,6 +45,7 @@ player_settings = Настройки плеера
 discord_presence = Discord Presence
 connectivity = Подключения
 discord_presence_paused = Показать статус Discord на паузе
+discord_presence_source = Показывать источник медиа в статусе Discord
 reduce_animations = Уменьшение анимаций
 show_source_toggle = Показать переключатель источника
 titlebar_mode = Строка заголовка

--- a/crates/i18n/locales/ta.ftl
+++ b/crates/i18n/locales/ta.ftl
@@ -54,6 +54,7 @@ channel_mode_swap_left_right = இடது/வலது மாற்று
 discord_presence = Discord இருப்பு
 connectivity = இணைப்புத்தன்மை
 discord_presence_paused = இடைநிறுத்தப்பட்ட Discord நிலையைக் காட்டு
+discord_presence_source = Discord நிலையில் மீடியா மூலத்தைக் காட்டு
 reduce_animations = அனிமேஷன்களைக் குறை
 auto_check_updates = புதுப்பிப்புகளைத் தானாகச் சரிபார்
 minimize_to_tray = கணினி தட்டுக்குச் சிறிதாக்கு

--- a/crates/i18n/locales/tok-SP.ftl
+++ b/crates/i18n/locales/tok-SP.ftl
@@ -45,6 +45,7 @@ player_settings = 󱤿󱥍󱤎󱤤󱤕
 discord_presence = 󱤬󱥍󱤎󱦐󱥛󱦜󱤜󱦝󱦑
 connectivity = 󱥩󱤬󱥭
 discord_presence_paused = 󱥄󱤮󱤉 󱤬󱥍󱤎󱦐󱥛 󱥫
+discord_presence_source = 󱥄󱤮󱤉 󱤎 󱤬 󱤬󱥍󱤎󱦐󱥛󱦜󱤜󱦝󱦑
 reduce_animations = 󱥄󱤨󱤉󱥩
 show_source_toggle = 󱥄󱤮󱤉󱤎󱤆
 titlebar_mode = 󱤤󱤎

--- a/crates/i18n/locales/tok.ftl
+++ b/crates/i18n/locales/tok.ftl
@@ -45,6 +45,7 @@ player_settings = nasin pi ilo lawa kalama
 discord_presence = lon pi ilo Siko
 connectivity = tawa lon ma
 discord_presence_paused = o lukin e lon pi ilo Siko lon tenpo awen
+discord_presence_source = o lukin e ilo pi kalama lon lon pi ilo Siko
 reduce_animations = o lili e tawa
 show_source_toggle = o lukin e ilo ante
 titlebar_mode = lawa ilo

--- a/crates/i18n/locales/tr.ftl
+++ b/crates/i18n/locales/tr.ftl
@@ -45,6 +45,7 @@ player_settings = Oynatıcı Ayarları
 discord_presence = Discord Durumu
 connectivity = Bağlantı
 discord_presence_paused = Discord durumu duraklatıldığında göster
+discord_presence_source = Medya kaynağını Discord durumunda göster
 reduce_animations = Animasyonları Azalt
 show_source_toggle = Sidebar'da Kaynağı Göster
 titlebar_mode = Başlık çubuğu

--- a/crates/i18n/locales/uk.ftl
+++ b/crates/i18n/locales/uk.ftl
@@ -45,6 +45,7 @@ player_settings = Налаштування програвача
 discord_presence = присутність Discord
 connectivity = Підключення
 discord_presence_paused = Показати статус Discord на паузі
+discord_presence_source = Показувати джерело медіа у статусі Discord
 reduce_animations = Зменшити кількість анімацій
 show_source_toggle = Показати перемикач джерела
 titlebar_mode = Рядок заголовка

--- a/crates/i18n/locales/vi-VN.ftl
+++ b/crates/i18n/locales/vi-VN.ftl
@@ -54,6 +54,7 @@ channel_mode_swap_left_right = Đổi trái/phải
 discord_presence = Trạng thái Discord
 connectivity = Kết nối
 discord_presence_paused = Hiển thị trạng thái Discord khi tạm dừng
+discord_presence_source = Hiển thị nguồn phát trong trạng thái Discord
 reduce_animations = Giảm hiệu ứng động
 auto_check_updates = Tự động kiểm tra cập nhật
 minimize_to_tray = Thu nhỏ vào khay hệ thống

--- a/crates/i18n/locales/zh-CN.ftl
+++ b/crates/i18n/locales/zh-CN.ftl
@@ -45,6 +45,7 @@ player_settings = 播放器设置
 discord_presence = Discord 状态
 connectivity = 连接
 discord_presence_paused = 显示暂停时的 Discord 状态
+discord_presence_source = 在 Discord 状态中显示媒体来源
 reduce_animations = 减少动画
 show_source_toggle = 显示来源切换
 titlebar_mode = 标题栏

--- a/crates/pages/src/settings.rs
+++ b/crates/pages/src/settings.rs
@@ -531,6 +531,15 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                                                 }
                                             }
                                         }
+                                        SettingItem {
+                                            title: i18n::t("discord_presence_source").to_string(),
+                                            control: rsx! {
+                                                ToggleSetting {
+                                                    enabled: config.read().discord_presence_source.unwrap_or(true),
+                                                    on_change: move |val| config.write().discord_presence_source = Some(val),
+                                                }
+                                            }
+                                        }
                                     }
                                     SettingItem {
                                         title: i18n::t("listenbrainz").to_string(),


### PR DESCRIPTION
Just like these:

<img width="282" height="125" alt="image" src="https://github.com/user-attachments/assets/bc7785e7-fd24-40d0-9490-7b3d9df4b35a" />


<img width="282" height="125" alt="image" src="https://github.com/user-attachments/assets/61c50bfa-6285-40fc-9814-ced09e1bd9fa" />

<img width="1123" height="71" alt="image" src="https://github.com/user-attachments/assets/0c0c2c83-19f1-434d-81a4-e481dbb4d52d" />
