### PR TITLE
meta: improve contributor onboarding and contribution QA

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+Please include a clear and concise description of the aim of your pull request
+above this line.
+
+If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
+For playback, scanning, source, packaging, or crash fixes, include the relevant
+logs or reproduction steps.
+-->
+
+## Sanity Checking
+
+<!--
+Please check all that apply. These boxes help maintainers quickly understand
+what you already verified and what still needs review.
+-->
+
+[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md
+
+- [ ] I have read and followed the [contribution guidelines].
+- [ ] My commits follow Kopuz's scoped commit convention and history hygiene
+      rules.
+- [ ] I have disclosed any AI assistance as required by the AI policy in the
+      [contribution guidelines], or this pull request did not use AI assistance.
+- [ ] I have tested and self-reviewed my changes.
+
+### Style and Consistency
+
+- [ ] My changes are consistent with the existing crate boundaries and Dioxus
+      style.
+- [ ] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
+- [ ] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
+      explained why it could not be run.
+- [ ] I kept generated assets, translations, and packaging files in sync when
+      this change depends on them.
+
+### Testing
+
+- [ ] I ran the smallest relevant verifier for this change.
+- [ ] I documented any platform or verifier that I could not run.
+
+Tested on platform(s):
+
+- [ ] `x86_64-linux`
+- [ ] `aarch64-linux`
+- [ ] `x86_64-darwin`
+- [ ] `aarch64-darwin`
+- [ ] Windows
+- [ ] Android
+- [ ] iOS

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,61 @@
+name: commit message
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check commit subjects
+        env:
+          BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          zero=0000000000000000000000000000000000000000
+          if [[ "$BASE_SHA" == "$zero" ]]; then
+            range="$HEAD_SHA"
+          else
+            range="$BASE_SHA..$HEAD_SHA"
+          fi
+
+          conventional_re='^(feat|fix|refactor|perf|test|style|ci|revert)(\([^)]+\)!?|!): '
+          scoped_re='^[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)?: .+'
+          checked=0
+          failed=0
+          while IFS=$'\t' read -r sha subject; do
+            checked=$((checked + 1))
+            if ((${#subject} > 80)); then
+              echo "::error title=Commit subject too long::$sha has ${#subject} characters: $subject"
+              failed=1
+              continue
+            fi
+
+            if [[ "$subject" =~ $conventional_re ]]; then
+              echo "::error title=Conventional Commit subject::$sha looks like Conventional Commits; Kopuz uses scoped commits: $subject"
+              failed=1
+              continue
+            fi
+
+            if ! [[ "$subject" =~ $scoped_re ]]; then
+              echo "::error title=Invalid commit subject::$sha must use 'scope: description': $subject"
+              failed=1
+              continue
+            fi
+          done < <(git log --format='%h%x09%s' "$range")
+
+          if ((checked == 0)); then
+            echo "No commits to check."
+          elif ((failed)); then
+            exit 1
+          else
+            echo "Checked $checked commit subject(s)."
+          fi

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check commit subjects
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@
   - [Testing Expectations](#testing-expectations)
   - [Code Style](#code-style)
   - [Pull Requests and Submitting Changes](#pull-requests-and-submitting-changes)
+    - [History Hygiene](#history-hygiene)
     - [Commit Messages](#commit-messages)
   - [Maintainer Communication](#maintainer-communication)
   - [AI Policy](#ai-policy)
@@ -137,6 +138,18 @@ Maintainers may ask for narrower diffs, clearer tests, or a different boundary.
 Please handle review comments in follow-up commits instead of force-pushing away
 review context unless a maintainer asks you to clean up the branch.
 
+### History Hygiene
+
+Keep the final history reviewable; each commit should be an atomic, squashed
+logical change with a useful subject. Before asking for final review, squash
+fixup commits, typo-only follow-ups, formatter-only repair commits, and
+review-addressing noise into the commit that introduced the behavior.
+
+Avoid merge commits in pull request branches. Rebase on the target branch when
+needed, then force-push with lease. A pull request may contain more than one
+commit when the changes are genuinely separate, but each commit should build on
+its own idea and pass the commit message rules below.
+
 ### Commit Messages
 
 [scoped commits]
@@ -177,6 +190,11 @@ We also use `nix` specifically for Nix-related packaging.
 In most cases, the format will be `<crate-name>/<module-name>: <description>`.
 You should also strive to make your commits atomic, and focus each commit on one
 logical change. Ensure that your messages are _descriptive_ .
+
+CI enforces these commit subject rules on pull requests and pushes:
+
+- the subject must be no longer than 80 characters;
+- the subject must use `scope: description` or `scope/module: description`.
 
 > [!TIP]
 > You do not need to reference issues in commit bodies, but you _may_ add


### PR DESCRIPTION
I'm nuking @temidaradev into orbit via CI.

tl;dr: initial onboarding work for enforcing our commit conventions (to an extent, via CI) and documenting the git history hygiene expected from a professional project. The goal is not to increase friction, but introduce a tiny bit of gatekeeping to make sure incoming contributions do not waste maintainer time. Also introduces a PR template.