### PR TITLE
kopuz: add opt-in UI render profiler via `KOPUZ_UI_PROFILE`

### DIFF
--- a/crates/kopuz/src/logging.rs
+++ b/crates/kopuz/src/logging.rs
@@ -38,6 +38,9 @@ use tracing_subscriber::{
 struct LogGuards {
     _file: tracing_appender::non_blocking::WorkerGuard,
     _chrome: Option<crate::chrome_trace::FlushGuard>,
+    // Dropped on shutdown, finalizing the UI-profile trace JSON and writing
+    // the ranked render report. `None` unless `KOPUZ_UI_PROFILE` is set.
+    _ui_profile: Option<crate::ui_profile::UiProfileGuard>,
 }
 
 #[cfg(not(target_os = "android"))]
@@ -81,6 +84,15 @@ fn debug_mode() -> bool {
         .unwrap_or(false)
 }
 
+/// Whether the opt-in UI render profiler is active this session, from
+/// `KOPUZ_UI_PROFILE` (any non-empty, non-`0`/`false` value).
+#[cfg(not(target_os = "android"))]
+fn ui_profile_enabled() -> bool {
+    std::env::var("KOPUZ_UI_PROFILE")
+        .map(|v| !v.is_empty() && v != "0" && v != "false")
+        .unwrap_or(false)
+}
+
 #[cfg(not(target_os = "android"))]
 fn user_directives() -> Option<String> {
     std::env::var("KOPUZ_LOG")
@@ -118,41 +130,72 @@ pub fn init(log_dir: &Path, config_tracing_enabled: bool) {
     // and filters still come from `KOPUZ_LOG` / `RUST_LOG` / `KOPUZ_DEBUG`.
     let trace_path = log_dir.join("kopuz-trace.json");
 
-    let chrome_guard = if config_tracing_enabled {
+    // Both optional sinks are `Option<Layer>` (no-op when `None`) so the
+    // subscriber is assembled in one chain. Open failures are logged after
+    // `init`, since tracing isn't live yet here.
+    let mut chrome_err: Option<String> = None;
+    let (chrome_layer, chrome_guard) = if config_tracing_enabled {
         match crate::chrome_trace::ChromeTraceLayer::new(&trace_path) {
-            Ok((chrome_layer, guard)) => {
-                tracing_subscriber::registry()
-                    .with(file_layer)
-                    .with(console_layer)
-                    // Filter the chrome layer the same as the file so the
-                    // trace isn't 30MB of h2/wgpu/dioxus-internal spans
-                    // burying the kopuz spans you actually want to analyze.
-                    .with(chrome_layer.with_filter(file_filter()))
-                    .init();
-                tracing::info!(trace = %trace_path.display(), "chrome span trace enabled");
-                Some(guard)
-            }
+            // Filter the chrome layer the same as the file so the trace
+            // isn't 30MB of h2/wgpu/dioxus-internal spans burying the
+            // kopuz spans you actually want to analyze.
+            Ok((layer, guard)) => (Some(layer.with_filter(file_filter())), Some(guard)),
             Err(err) => {
-                tracing_subscriber::registry()
-                    .with(file_layer)
-                    .with(console_layer)
-                    .init();
-                tracing::warn!(trace = %trace_path.display(), %err, "failed to open chrome trace file — tracing disabled this session");
-                None
+                chrome_err = Some(err.to_string());
+                (None, None)
             }
         }
     } else {
-        tracing_subscriber::registry()
-            .with(file_layer)
-            .with(console_layer)
-            .init();
-        None
+        (None, None)
     };
+
+    // Opt-in developer profiler. Its per-layer filter re-enables Dioxus's
+    // trace-level render/memo spans (suppressed everywhere else via
+    // QUIET_DEPS) for this layer only, so the other sinks stay unaffected.
+    let ui_trace_path = log_dir.join("kopuz-ui-profile.json");
+    let mut ui_err: Option<String> = None;
+    let (ui_layer, ui_guard) = if ui_profile_enabled() {
+        match crate::ui_profile::UiProfileLayer::new(&ui_trace_path) {
+            Ok((layer, guard)) => (
+                Some(
+                    layer.with_filter(EnvFilter::new("off,dioxus_core=trace,dioxus_signals=trace")),
+                ),
+                Some(guard),
+            ),
+            Err(err) => {
+                ui_err = Some(err.to_string());
+                (None, None)
+            }
+        }
+    } else {
+        (None, None)
+    };
+
+    tracing_subscriber::registry()
+        .with(file_layer)
+        .with(console_layer)
+        .with(chrome_layer)
+        .with(ui_layer)
+        .init();
+
+    if chrome_guard.is_some() {
+        tracing::info!(trace = %trace_path.display(), "chrome span trace enabled");
+    }
+    if let Some(err) = chrome_err {
+        tracing::warn!(trace = %trace_path.display(), %err, "failed to open chrome trace file, tracing disabled this session");
+    }
+    if ui_guard.is_some() {
+        tracing::info!(trace = %ui_trace_path.display(), "UI render profiler enabled (KOPUZ_UI_PROFILE)");
+    }
+    if let Some(err) = ui_err {
+        tracing::warn!(trace = %ui_trace_path.display(), %err, "failed to open UI profile trace file, profiler disabled this session");
+    }
 
     let trace_enabled = chrome_guard.is_some();
     *GUARDS.lock().unwrap_or_else(|e| e.into_inner()) = Some(LogGuards {
         _file: file_guard,
         _chrome: chrome_guard,
+        _ui_profile: ui_guard,
     });
 
     // SIGINT (Ctrl+C from a terminal `cargo run`) skips stack/global

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -32,6 +32,8 @@ mod logging;
 #[cfg(not(target_os = "android"))]
 mod pot_minter;
 mod queue_state;
+#[cfg(not(target_os = "android"))]
+mod ui_profile;
 mod updates;
 #[cfg(target_os = "windows")]
 mod windows_titlebar;

--- a/crates/kopuz/src/ui_profile.rs
+++ b/crates/kopuz/src/ui_profile.rs
@@ -1,0 +1,319 @@
+//! Opt-in UI render profiler (`KOPUZ_UI_PROFILE`), wired in [`crate::logging`].
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    fs::{self, File},
+    io::{BufWriter, Write as _},
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex,
+        mpsc::{self, Sender},
+    },
+    thread::{self, JoinHandle},
+    time::Instant,
+};
+
+use serde_json::{Map, Value};
+use tracing::{Subscriber, field::Field, span};
+use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
+
+/// Per-span data resolved at creation and read back while timing.
+struct Tracked {
+    /// The component (`scope`) for renders, else the span name.
+    name: String,
+    /// Tracing target, used as the Chrome-trace category.
+    cat: &'static str,
+}
+
+struct Frame {
+    id: span::Id,
+    start: Instant,
+    /// Trace timestamp (µs since profiler start) at enter.
+    ts_us: f64,
+    /// Total time of spans nested inside this one.
+    child_ns: u128,
+}
+
+thread_local! {
+    static STACK: RefCell<Vec<Frame>> = const { RefCell::new(Vec::new()) };
+}
+
+#[derive(Default, Clone)]
+struct Agg {
+    count: u64,
+    total_ns: u128,
+    self_ns: u128,
+    max_self_ns: u128,
+}
+
+enum Msg {
+    Entry(Value),
+    Done,
+}
+
+pub struct UiProfileLayer {
+    tx: Mutex<Sender<Msg>>,
+    start: Instant,
+    aggs: Arc<Mutex<HashMap<String, Agg>>>,
+}
+
+/// Finalizes the trace JSON and writes the summary on drop, and shares the
+/// live aggregate map with the layer via `Arc`.
+pub struct UiProfileGuard {
+    tx: Sender<Msg>,
+    handle: Option<JoinHandle<()>>,
+    aggs: Arc<Mutex<HashMap<String, Agg>>>,
+    summary_path: PathBuf,
+    start: Instant,
+}
+
+impl UiProfileLayer {
+    /// `trace_path` gets the Chrome/Perfetto JSON; the summary is written
+    /// beside it as `<stem>-summary.txt` when the guard drops.
+    pub fn new(trace_path: &Path) -> std::io::Result<(Self, UiProfileGuard)> {
+        let file = File::create(trace_path)?;
+        let (tx, rx) = mpsc::channel::<Msg>();
+        let handle = thread::spawn(move || {
+            let mut out = BufWriter::new(file);
+            let _ = out.write_all(b"[");
+            let mut first = true;
+            while let Ok(Msg::Entry(entry)) = rx.recv() {
+                if !first {
+                    let _ = out.write_all(b",\n");
+                }
+                first = false;
+                let _ = serde_json::to_writer(&mut out, &entry);
+            }
+            let _ = out.write_all(b"\n]");
+            let _ = out.flush();
+        });
+
+        let stem = trace_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("kopuz-ui-profile");
+        let summary_path = trace_path.with_file_name(format!("{stem}-summary.txt"));
+
+        let start = Instant::now();
+        let aggs: Arc<Mutex<HashMap<String, Agg>>> = Arc::default();
+        let layer = Self {
+            tx: Mutex::new(tx.clone()),
+            start,
+            aggs: Arc::clone(&aggs),
+        };
+        let guard = UiProfileGuard {
+            tx,
+            handle: Some(handle),
+            aggs,
+            summary_path,
+            start,
+        };
+        Ok((layer, guard))
+    }
+
+    fn ts_us(&self) -> f64 {
+        self.start.elapsed().as_nanos() as f64 / 1000.0
+    }
+}
+
+impl<S> Layer<S> for UiProfileLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else { return };
+        let meta = span.metadata();
+        let mut visitor = ScopeVisitor(None);
+        attrs.record(&mut visitor);
+        let name = visitor.0.unwrap_or_else(|| meta.name().to_string());
+        span.extensions_mut().insert(Tracked {
+            name,
+            cat: meta.target(),
+        });
+    }
+
+    fn on_enter(&self, id: &span::Id, _ctx: Context<'_, S>) {
+        STACK.with(|s| {
+            s.borrow_mut().push(Frame {
+                id: id.clone(),
+                start: Instant::now(),
+                ts_us: self.ts_us(),
+                child_ns: 0,
+            });
+        });
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        // Renders nest strictly (LIFO) on the UI thread; bail on any other
+        // ordering rather than mis-charge an unrelated frame.
+        let Some(frame) = STACK.with(|s| {
+            let mut stack = s.borrow_mut();
+            match stack.last() {
+                Some(top) if top.id == *id => stack.pop(),
+                _ => None,
+            }
+        }) else {
+            return;
+        };
+
+        let total_ns = frame.start.elapsed().as_nanos();
+        let self_ns = total_ns.saturating_sub(frame.child_ns);
+        STACK.with(|s| {
+            if let Some(parent) = s.borrow_mut().last_mut() {
+                parent.child_ns += total_ns;
+            }
+        });
+
+        let Some(span) = ctx.span(id) else { return };
+        let exts = span.extensions();
+        let Some(tracked) = exts.get::<Tracked>() else {
+            return;
+        };
+
+        if let Ok(mut aggs) = self.aggs.lock() {
+            let agg = aggs.entry(tracked.name.clone()).or_default();
+            agg.count += 1;
+            agg.total_ns += total_ns;
+            agg.self_ns += self_ns;
+            agg.max_self_ns = agg.max_self_ns.max(self_ns);
+        }
+
+        let entry = Map::from_iter([
+            ("ph".into(), "X".into()),
+            ("pid".into(), 1.into()),
+            ("tid".into(), 0.into()),
+            ("ts".into(), frame.ts_us.into()),
+            ("dur".into(), (total_ns as f64 / 1000.0).into()),
+            ("name".into(), tracked.name.as_str().into()),
+            ("cat".into(), tracked.cat.into()),
+        ]);
+        if let Ok(tx) = self.tx.lock() {
+            let _ = tx.send(Msg::Entry(Value::Object(entry)));
+        }
+    }
+}
+
+impl Drop for UiProfileGuard {
+    fn drop(&mut self) {
+        let _ = self.tx.send(Msg::Done);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+
+        let aggs = self.aggs.lock().map(|a| a.clone()).unwrap_or_default();
+        if aggs.is_empty() {
+            return;
+        }
+        let report = render_report(&aggs, self.start.elapsed().as_secs_f64());
+        let _ = fs::write(&self.summary_path, &report);
+        tracing::info!(summary = %self.summary_path.display(), "\n{}", report);
+    }
+}
+
+/// Components ranked by total self time, with per-render stats.
+fn render_report(aggs: &HashMap<String, Agg>, session_secs: f64) -> String {
+    let mut rows: Vec<(&String, &Agg)> = aggs.iter().collect();
+    rows.sort_by_key(|(_, agg)| std::cmp::Reverse(agg.self_ns));
+
+    let mut out = format!("UI render profile - {session_secs:.1}s session\n");
+    out.push_str(&format!(
+        "{:>5}  {:>10}  {:>10}  {:>8}  {:>10}  {:>10}  {}\n",
+        "rank", "self ms", "total ms", "renders", "avg self µs", "max self µs", "component"
+    ));
+    out.push_str(&"-".repeat(90));
+    out.push('\n');
+    for (i, (name, agg)) in rows.iter().enumerate() {
+        let avg_self_us = agg.self_ns as f64 / agg.count.max(1) as f64 / 1000.0;
+        out.push_str(&format!(
+            "{:>5}  {:>10.2}  {:>10.2}  {:>8}  {:>10.1}  {:>10.1}  {}\n",
+            i + 1,
+            agg.self_ns as f64 / 1_000_000.0,
+            agg.total_ns as f64 / 1_000_000.0,
+            agg.count,
+            avg_self_us,
+            agg.max_self_ns as f64 / 1000.0,
+            name
+        ));
+    }
+    out
+}
+
+/// Reads the `scope` field off a render span. `%`/`?` values land in
+/// `record_debug`; a literal `&str` lands in `record_str`.
+struct ScopeVisitor(Option<String>);
+
+impl tracing::field::Visit for ScopeVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "scope" {
+            self.0 = Some(value.to_owned());
+        }
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "scope" {
+            self.0 = Some(format!("{value:?}"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::env::temp_dir;
+    use std::process;
+    use std::time::Duration;
+
+    use super::*;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    /// A span nested inside another must have its time subtracted from the
+    /// outer span's self time and attributed to itself.
+    #[test]
+    fn self_time_excludes_nested_spans() {
+        let path = temp_dir().join(format!("kopuz-ui-prof-agg-{}.json", process::id()));
+        let (layer, guard) = UiProfileLayer::new(&path).unwrap();
+        let aggs = Arc::clone(&guard.aggs);
+
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let outer = tracing::info_span!(target: "dioxus_core", "render", scope = "Outer");
+            outer.in_scope(|| {
+                let inner = tracing::info_span!(target: "dioxus_signals", "recompute");
+                inner.in_scope(|| thread::sleep(Duration::from_millis(3)));
+            });
+        });
+
+        let aggs = aggs.lock().unwrap();
+        let outer = &aggs["Outer"];
+        let inner = &aggs["recompute"];
+        // The outer's only child is `inner`, so this is exact, not timing-dependent.
+        assert_eq!(outer.self_ns, outer.total_ns - inner.total_ns);
+        assert_eq!(inner.self_ns, inner.total_ns);
+        assert!(outer.total_ns >= inner.total_ns);
+        drop(aggs);
+
+        drop(guard);
+        let _ = fs::remove_file(&path);
+    }
+
+    /// Render slices are named by the `scope` field, not the span name.
+    #[test]
+    fn trace_slices_named_by_scope() {
+        let path = temp_dir().join(format!("kopuz-ui-prof-name-{}.json", process::id()));
+        let (layer, guard) = UiProfileLayer::new(&path).unwrap();
+        let subscriber = tracing_subscriber::registry().with(layer);
+        tracing::subscriber::with_default(subscriber, || {
+            let s = tracing::info_span!(target: "dioxus_core", "render", scope = "ShowcaseNormal");
+            s.in_scope(|| {});
+        });
+        drop(guard);
+
+        let json: Vec<Value> = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let _ = fs::remove_file(&path);
+
+        let slice = json
+            .iter()
+            .find(|e| e["ph"] == "X")
+            .expect("a complete event");
+        assert_eq!(slice["name"], "ShowcaseNormal");
+        assert!(slice["dur"].is_number());
+    }
+}


### PR DESCRIPTION
AI disclosure: DeepSeek V4 was used to trace through Dioxus API documentation to investigate available options for the implementation.

Wake up jesse we gotta profile the UI. Adds an opt-in UI render profiler to the application, activated via the `KOPUZ_UI_PROFILE` environment variable. It's Chrome trace/Perfetto compatible JSON and collects detailed per-component render and memo timing data so that we're not flying blind when it comes to optimizing the (very poor) WebKit UI performance. It also generates a human-readable summary report ranking components by their self time. I was careful to isolate the profiling to only the UI layer, and this should not affect other tracing sinks. One *idea* could be to make this a compile-time flag to that the tracing framework, even though it should not include personal data, can be nuked.

I've got a followup PR that fixes the issue diagnosed by the new profiler.

Change-Id: I1c027ab03ecff861d9e131bd310e8b3c6a6a6964

<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
