### PR TITLE
various: detailed scrobble logging and accuracy for MusicBrainz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3631,6 +3631,7 @@ dependencies = [
  "kopuz-utils",
  "rand 0.10.1",
  "reqwest 0.13.4",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/crates/hooks/Cargo.toml
+++ b/crates/hooks/Cargo.toml
@@ -25,6 +25,7 @@ player = { workspace = true }
 config = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
+serde_json = { workspace = true }
 server = { workspace = true }
 scrobble = { workspace = true }
 radio = { workspace = true }

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -5,6 +5,8 @@ use reader::Track;
 use std::collections::HashMap;
 use std::time::Duration;
 
+const NOW_PLAYING_INTERVAL_SECS: u64 = 30;
+
 #[derive(Clone, Copy)]
 pub struct ScrobbleOptions {
     pub include_librefm: bool,
@@ -34,14 +36,25 @@ pub fn schedule(
     config: Signal<AppConfig>,
     play_generation: Signal<usize>,
     generation: usize,
+    is_playing: Signal<bool>,
     active_source: Option<Signal<::server::source::ActiveSource>>,
     options: ScrobbleOptions,
 ) {
     let duration_secs = track.duration;
     let threshold_secs = std::cmp::min(240, duration_secs / 2);
+    let started_at = scrobble::musicbrainz::now_unix();
     let span = tracing::info_span!(
         "scrobble.submit",
         track = item_id.as_deref().unwrap_or(track.id.uid().as_str())
+    );
+
+    schedule_playing_now_heartbeat(
+        &track,
+        config,
+        play_generation,
+        generation,
+        is_playing,
+        options,
     );
 
     spawn(
@@ -55,7 +68,14 @@ pub fn schedule(
                 return;
             }
 
-            let mbids = musicbrainz_ids(&track, options.include_musicbrainz_ids);
+            if track.artist.trim().is_empty() || track.title.trim().is_empty() {
+                tracing::info!(
+                    "scrobble skipped: missing artist or title metadata: {:?} - {:?}",
+                    track.artist,
+                    track.title
+                );
+                return;
+            }
 
             if let (Some(source), Some(id)) = (active_source, item_id.as_deref()) {
                 let source = source.peek().clone();
@@ -108,28 +128,17 @@ pub fn schedule(
                 }
             }
 
-            let token_raw = config.read().musicbrainz_token.clone();
-            if !token_raw.is_empty() {
-                let auth = musicbrainz_auth(&token_raw);
-                let playing_now = scrobble::musicbrainz::make_playing_now(
-                    &track.artist,
-                    &track.title,
-                    Some(&track.album),
-                    mbids.clone(),
-                );
-                if let Err(error) =
-                    scrobble::musicbrainz::submit_listens(&auth, vec![playing_now], "playing_now")
-                        .await
-                {
-                    tracing::warn!("MusicBrainz playing_now failed: {}", error);
-                }
-            }
+            let reached = wait_for_playtime(
+                Duration::from_secs(threshold_secs),
+                play_generation,
+                generation,
+                is_playing,
+            )
+            .await;
 
-            sleep_threshold(Duration::from_secs(threshold_secs)).await;
-
-            if *play_generation.read() != generation {
+            if !reached {
                 tracing::info!(
-                    "scrobble skipped: track changed before {threshold_secs}s threshold: {} - {}",
+                    "scrobble skipped: track changed before {threshold_secs}s of playback: {} - {}",
                     track.artist,
                     track.title
                 );
@@ -189,11 +198,13 @@ pub fn schedule(
             let token_raw = config.read().musicbrainz_token.clone();
             if !token_raw.is_empty() {
                 let auth = musicbrainz_auth(&token_raw);
+                let info = listen_additional_info(&track, options.include_musicbrainz_ids);
                 let listen = scrobble::musicbrainz::make_listen(
                     &track.artist,
                     &track.title,
                     Some(&track.album),
-                    mbids,
+                    Some(info),
+                    started_at,
                 );
                 match scrobble::musicbrainz::submit_listens(&auth, vec![listen], "single").await {
                     Ok(_) => {
@@ -201,6 +212,58 @@ pub fn schedule(
                     }
                     Err(error) => tracing::warn!("MusicBrainz scrobble failed: {}", error),
                 }
+            }
+        }
+        .instrument(span),
+    );
+}
+
+fn schedule_playing_now_heartbeat(
+    track: &Track,
+    config: Signal<AppConfig>,
+    play_generation: Signal<usize>,
+    generation: usize,
+    is_playing: Signal<bool>,
+    options: ScrobbleOptions,
+) {
+    if track.duration < 30 {
+        return;
+    }
+
+    let token_raw = config.read().musicbrainz_token.clone();
+    if token_raw.is_empty() {
+        return;
+    }
+
+    let auth = musicbrainz_auth(&token_raw);
+    let track = track.clone();
+    let include_ids = options.include_musicbrainz_ids;
+    let span = tracing::info_span!("scrobble.playing_now", track = track.id.uid().as_str());
+
+    spawn(
+        async move {
+            loop {
+                if *play_generation.read() != generation {
+                    return;
+                }
+
+                if *is_playing.read() {
+                    let now_info = listen_additional_info(&track, include_ids);
+                    let playing_now = scrobble::musicbrainz::make_playing_now(
+                        &track.artist,
+                        &track.title,
+                        Some(&track.album),
+                        Some(now_info),
+                    );
+                    let _ = scrobble::musicbrainz::submit_listens(
+                        &auth,
+                        vec![playing_now],
+                        "playing_now",
+                    )
+                    .await;
+                }
+
+                tokio::time::sleep(Duration::from_secs(NOW_PLAYING_INTERVAL_SECS)).await;
             }
         }
         .instrument(span),
@@ -215,24 +278,59 @@ fn musicbrainz_auth(token: &str) -> String {
     }
 }
 
-fn musicbrainz_ids(track: &Track, enabled: bool) -> Option<HashMap<&str, &str>> {
-    if !enabled {
-        return None;
+fn listen_additional_info(
+    track: &Track,
+    include_ids: bool,
+) -> HashMap<&'static str, serde_json::Value> {
+    let mut map = HashMap::new();
+    map.insert("media_player", serde_json::Value::from("rusic"));
+    map.insert("submission_client", serde_json::Value::from("rusic"));
+    map.insert(
+        "submission_client_version",
+        serde_json::Value::from(env!("CARGO_PKG_VERSION")),
+    );
+    if track.duration > 0 {
+        map.insert(
+            "duration_ms",
+            serde_json::Value::from(track.duration * 1000),
+        );
     }
 
-    let mut map = HashMap::new();
-    if let Some(mbid) = &track.musicbrainz_release_id {
-        map.insert("release_mbid", mbid.as_str());
+    if include_ids {
+        if let Some(mbid) = &track.musicbrainz_release_id {
+            map.insert("release_mbid", serde_json::Value::from(mbid.as_str()));
+        }
+        if let Some(mbid) = &track.musicbrainz_recording_id {
+            map.insert("recording_mbid", serde_json::Value::from(mbid.as_str()));
+        }
+        if let Some(mbid) = &track.musicbrainz_track_id {
+            map.insert("track_mbid", serde_json::Value::from(mbid.as_str()));
+        }
     }
-    if let Some(mbid) = &track.musicbrainz_recording_id {
-        map.insert("recording_mbid", mbid.as_str());
-    }
-    if let Some(mbid) = &track.musicbrainz_track_id {
-        map.insert("track_mbid", mbid.as_str());
-    }
-    Some(map)
+
+    map
 }
 
-async fn sleep_threshold(duration: Duration) {
-    tokio::time::sleep(duration).await;
+async fn wait_for_playtime(
+    threshold: Duration,
+    play_generation: Signal<usize>,
+    generation: usize,
+    is_playing: Signal<bool>,
+) -> bool {
+    let tick = Duration::from_secs(1);
+    let mut played = Duration::ZERO;
+
+    while played < threshold {
+        tokio::time::sleep(tick).await;
+
+        if *play_generation.read() != generation {
+            return false;
+        }
+
+        if *is_playing.read() {
+            played += tick;
+        }
+    }
+
+    true
 }

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -47,6 +47,11 @@ pub fn schedule(
     spawn(
         async move {
             if duration_secs < 30 {
+                tracing::info!(
+                    "scrobble skipped: track too short ({duration_secs}s < 30s): {} - {}",
+                    track.artist,
+                    track.title
+                );
                 return;
             }
 
@@ -123,6 +128,11 @@ pub fn schedule(
             sleep_threshold(Duration::from_secs(threshold_secs)).await;
 
             if *play_generation.read() != generation {
+                tracing::info!(
+                    "scrobble skipped: track changed before {threshold_secs}s threshold: {} - {}",
+                    track.artist,
+                    track.title
+                );
                 return;
             }
 

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -283,8 +283,8 @@ fn listen_additional_info(
     include_ids: bool,
 ) -> HashMap<&'static str, serde_json::Value> {
     let mut map = HashMap::new();
-    map.insert("media_player", serde_json::Value::from("rusic"));
-    map.insert("submission_client", serde_json::Value::from("rusic"));
+    map.insert("media_player", serde_json::Value::from("kopuz"));
+    map.insert("submission_client", serde_json::Value::from("kopuz"));
     map.insert(
         "submission_client_version",
         serde_json::Value::from(env!("CARGO_PKG_VERSION")),

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -195,9 +195,8 @@ pub fn schedule(
                 }
             }
 
-            let token_raw = config.read().musicbrainz_token.clone();
-            if !token_raw.is_empty() {
-                let auth = musicbrainz_auth(&token_raw);
+            let token = config.read().musicbrainz_token.clone();
+            if !token.trim().is_empty() {
                 let info = listen_additional_info(&track, options.include_musicbrainz_ids);
                 let listen = scrobble::musicbrainz::make_listen(
                     &track.artist,
@@ -206,7 +205,7 @@ pub fn schedule(
                     Some(info),
                     started_at,
                 );
-                match scrobble::musicbrainz::submit_listens(&auth, vec![listen], "single").await {
+                match scrobble::musicbrainz::submit_listens(&token, vec![listen], "single").await {
                     Ok(_) => {
                         tracing::info!("MusicBrainz scrobbled: {} - {}", track.artist, track.title)
                     }
@@ -230,12 +229,11 @@ fn schedule_playing_now_heartbeat(
         return;
     }
 
-    let token_raw = config.read().musicbrainz_token.clone();
-    if token_raw.is_empty() {
+    let token = config.read().musicbrainz_token.clone();
+    if token.trim().is_empty() {
         return;
     }
 
-    let auth = musicbrainz_auth(&token_raw);
     let track = track.clone();
     let include_ids = options.include_musicbrainz_ids;
     let span = tracing::info_span!("scrobble.playing_now", track = track.id.uid().as_str());
@@ -256,7 +254,7 @@ fn schedule_playing_now_heartbeat(
                         Some(now_info),
                     );
                     let _ = scrobble::musicbrainz::submit_listens(
-                        &auth,
+                        &token,
                         vec![playing_now],
                         "playing_now",
                     )
@@ -268,14 +266,6 @@ fn schedule_playing_now_heartbeat(
         }
         .instrument(span),
     );
-}
-
-fn musicbrainz_auth(token: &str) -> String {
-    if token.contains(' ') {
-        token.to_string()
-    } else {
-        format!("Token {token}")
-    }
 }
 
 fn listen_additional_info(

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -240,6 +240,7 @@ fn schedule_playing_now_heartbeat(
 
     spawn(
         async move {
+            let mut announced = false;
             loop {
                 if *play_generation.read() != generation {
                     return;
@@ -253,12 +254,21 @@ fn schedule_playing_now_heartbeat(
                         Some(&track.album),
                         Some(now_info),
                     );
-                    let _ = scrobble::musicbrainz::submit_listens(
+                    let sent = scrobble::musicbrainz::submit_listens(
                         &token,
                         vec![playing_now],
                         "playing_now",
                     )
-                    .await;
+                    .await
+                    .is_ok();
+                    if sent && !announced {
+                        announced = true;
+                        tracing::info!(
+                            "ListenBrainz playing now: {} - {}",
+                            track.artist,
+                            track.title
+                        );
+                    }
                 }
 
                 tokio::time::sleep(Duration::from_secs(NOW_PLAYING_INTERVAL_SECS)).await;

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -866,6 +866,7 @@ impl PlayerController {
                                         cfg_signal,
                                         play_generation,
                                         current_gen,
+                                        is_playing,
                                         Some(active_source),
                                         ScrobbleOptions::REMOTE_NATIVE,
                                     );
@@ -973,6 +974,7 @@ impl PlayerController {
                                 self.config,
                                 self.play_generation,
                                 current_gen,
+                                self.is_playing,
                                 None,
                                 ScrobbleOptions::LOCAL,
                             );

--- a/crates/scrobble/src/musicbrainz.rs
+++ b/crates/scrobble/src/musicbrainz.rs
@@ -14,7 +14,7 @@ pub struct TrackMetadata<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     release_name: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    additional_info: Option<HashMap<&'a str, &'a str>>,
+    additional_info: Option<HashMap<&'a str, serde_json::Value>>,
 }
 
 #[derive(Serialize)]
@@ -40,9 +40,16 @@ pub async fn validate_token(token: &str) -> Result<Option<String>, reqwest::Erro
     let client = Client::new();
     let url = "https://api.listenbrainz.org/1/validate-token";
 
+    let token = token.trim();
+    let auth = if token.contains(' ') {
+        token.to_string()
+    } else {
+        format!("Token {token}")
+    };
+
     let resp = client
         .get(url)
-        .header("Authorization", token)
+        .header("Authorization", auth)
         .send()
         .await?;
 
@@ -107,10 +114,17 @@ pub async fn submit_listens(
 
         if status.is_success() {
             let body = read_body(resp).await;
-            tracing::info!(
-                "ListenBrainz {listen_type} ({count}) accepted: HTTP {} {body}",
-                status.as_u16()
-            );
+            if listen_type == "playing_now" {
+                tracing::debug!(
+                    "ListenBrainz {listen_type} ({count}) accepted: HTTP {} {body}",
+                    status.as_u16()
+                );
+            } else {
+                tracing::info!(
+                    "ListenBrainz {listen_type} ({count}) accepted: HTTP {} {body}",
+                    status.as_u16()
+                );
+            }
             return Ok(());
         }
 
@@ -181,19 +195,23 @@ fn backoff_delay(attempt: u32, retry_after: Option<Duration>) -> Duration {
     retry_after.unwrap_or(base).min(MAX_BACKOFF)
 }
 
+/// Unix timestamp for "now"; capture when playback starts and pass to `make_listen`.
+pub fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
 pub fn make_listen<'a>(
     artist: &'a str,
     track: &'a str,
     release: Option<&'a str>,
-    additional_info: Option<HashMap<&'a str, &'a str>>,
+    additional_info: Option<HashMap<&'a str, serde_json::Value>>,
+    listened_at: i64,
 ) -> Listen<'a> {
-    let now_unix = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64;
-
     Listen {
-        listened_at: Some(now_unix),
+        listened_at: Some(listened_at),
         track_metadata: TrackMetadata {
             artist_name: artist,
             track_name: track,
@@ -207,7 +225,7 @@ pub fn make_playing_now<'a>(
     artist: &'a str,
     track: &'a str,
     release: Option<&'a str>,
-    additional_info: Option<HashMap<&'a str, &'a str>>,
+    additional_info: Option<HashMap<&'a str, serde_json::Value>>,
 ) -> Listen<'a> {
     Listen {
         listened_at: None,

--- a/crates/scrobble/src/musicbrainz.rs
+++ b/crates/scrobble/src/musicbrainz.rs
@@ -47,11 +47,7 @@ pub async fn validate_token(token: &str) -> Result<Option<String>, reqwest::Erro
         format!("Token {token}")
     };
 
-    let resp = client
-        .get(url)
-        .header("Authorization", auth)
-        .send()
-        .await?;
+    let resp = client.get(url).header("Authorization", auth).send().await?;
 
     resp.error_for_status_ref()?;
 

--- a/crates/scrobble/src/musicbrainz.rs
+++ b/crates/scrobble/src/musicbrainz.rs
@@ -6,6 +6,9 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 const MAX_ATTEMPTS: u32 = 6;
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_BACKOFF: Duration = Duration::from_secs(60);
+// playing_now is ephemeral: the next heartbeat replaces it, so retrying a
+// stale submission only delays everything queued behind it.
+const PLAYING_NOW_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Serialize)]
 pub struct TrackMetadata<'a> {
@@ -71,8 +74,15 @@ pub async fn submit_listens(
     listens: Vec<Listen<'_>>,
     listen_type: &str,
 ) -> Result<(), reqwest::Error> {
+    let is_playing_now = listen_type == "playing_now";
+    let max_attempts = if is_playing_now { 1 } else { MAX_ATTEMPTS };
+    let timeout = if is_playing_now {
+        PLAYING_NOW_TIMEOUT
+    } else {
+        REQUEST_TIMEOUT
+    };
     let client = Client::builder()
-        .timeout(REQUEST_TIMEOUT)
+        .timeout(timeout)
         .build()
         .unwrap_or_else(|_| Client::new());
     let url = "https://api.listenbrainz.org/1/submit-listens";
@@ -98,15 +108,21 @@ pub async fn submit_listens(
             Ok(resp) => resp,
             Err(error) => {
                 let kind = error_kind(&error);
-                if attempt >= MAX_ATTEMPTS || !is_retryable_error(&error) {
-                    tracing::warn!(
-                        "ListenBrainz {listen_type} ({count}) failed after {attempt} attempt(s): {kind}: {error}"
-                    );
+                if attempt >= max_attempts || !is_retryable_error(&error) {
+                    if is_playing_now {
+                        tracing::debug!(
+                            "ListenBrainz {listen_type} ({count}) skipped, next heartbeat will resend: {kind}: {error}"
+                        );
+                    } else {
+                        tracing::warn!(
+                            "ListenBrainz {listen_type} ({count}) failed after {attempt} attempt(s): {kind}: {error}"
+                        );
+                    }
                     return Err(error);
                 }
                 let delay = backoff_delay(attempt, None);
                 tracing::warn!(
-                    "ListenBrainz {listen_type} ({count}) {kind} on attempt {attempt}/{MAX_ATTEMPTS}, retrying in {delay:?}: {error}"
+                    "ListenBrainz {listen_type} ({count}) {kind} on attempt {attempt}/{max_attempts}, retrying in {delay:?}: {error}"
                 );
                 tokio::time::sleep(delay).await;
                 continue;
@@ -135,7 +151,7 @@ pub async fn submit_listens(
             status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
         let retry_after = parse_retry_after(&resp);
 
-        if !retryable || attempt >= MAX_ATTEMPTS {
+        if !retryable || attempt >= max_attempts {
             let error = resp.error_for_status_ref().unwrap_err();
             let body = read_body(resp).await;
             tracing::warn!(
@@ -148,7 +164,7 @@ pub async fn submit_listens(
         let delay = backoff_delay(attempt, retry_after);
         let body = read_body(resp).await;
         tracing::warn!(
-            "ListenBrainz {listen_type} ({count}) HTTP {} on attempt {attempt}/{MAX_ATTEMPTS}, retrying in {delay:?} {body}",
+            "ListenBrainz {listen_type} ({count}) HTTP {} on attempt {attempt}/{max_attempts}, retrying in {delay:?} {body}",
             status.as_u16()
         );
         tokio::time::sleep(delay).await;

--- a/crates/scrobble/src/musicbrainz.rs
+++ b/crates/scrobble/src/musicbrainz.rs
@@ -36,18 +36,24 @@ struct ValidateResponse {
     user_name: Option<String>,
 }
 
+pub fn auth_header(token: &str) -> String {
+    let token = token.trim();
+    if token.contains(' ') {
+        token.to_string()
+    } else {
+        format!("Token {token}")
+    }
+}
+
 pub async fn validate_token(token: &str) -> Result<Option<String>, reqwest::Error> {
     let client = Client::new();
     let url = "https://api.listenbrainz.org/1/validate-token";
 
-    let token = token.trim();
-    let auth = if token.contains(' ') {
-        token.to_string()
-    } else {
-        format!("Token {token}")
-    };
-
-    let resp = client.get(url).header("Authorization", auth).send().await?;
+    let resp = client
+        .get(url)
+        .header("Authorization", auth_header(token))
+        .send()
+        .await?;
 
     resp.error_for_status_ref()?;
 
@@ -70,6 +76,7 @@ pub async fn submit_listens(
         .build()
         .unwrap_or_else(|_| Client::new());
     let url = "https://api.listenbrainz.org/1/submit-listens";
+    let auth = auth_header(token);
     let count = listens.len();
     let body = SubmitListens {
         listen_type,
@@ -82,7 +89,7 @@ pub async fn submit_listens(
 
         let result = client
             .post(url)
-            .header("Authorization", token)
+            .header("Authorization", auth.as_str())
             .json(&body)
             .send()
             .await;

--- a/crates/scrobble/src/musicbrainz.rs
+++ b/crates/scrobble/src/musicbrainz.rs
@@ -61,12 +61,13 @@ pub async fn submit_listens(
     token: &str,
     listens: Vec<Listen<'_>>,
     listen_type: &str,
-) -> Result<reqwest::Response, reqwest::Error> {
+) -> Result<(), reqwest::Error> {
     let client = Client::builder()
         .timeout(REQUEST_TIMEOUT)
         .build()
         .unwrap_or_else(|_| Client::new());
     let url = "https://api.listenbrainz.org/1/submit-listens";
+    let count = listens.len();
     let body = SubmitListens {
         listen_type,
         payload: listens,
@@ -86,13 +87,18 @@ pub async fn submit_listens(
         let resp = match result {
             Ok(resp) => resp,
             Err(error) => {
+                let kind = error_kind(&error);
                 if attempt >= MAX_ATTEMPTS || !is_retryable_error(&error) {
+                    tracing::warn!(
+                        "ListenBrainz {listen_type} ({count}) failed after {attempt} attempt(s): {kind}: {error}"
+                    );
                     return Err(error);
                 }
+                let delay = backoff_delay(attempt, None);
                 tracing::warn!(
-                    "ListenBrainz {listen_type} transport error (attempt {attempt}/{MAX_ATTEMPTS}), retrying: {error}"
+                    "ListenBrainz {listen_type} ({count}) {kind} on attempt {attempt}/{MAX_ATTEMPTS}, retrying in {delay:?}: {error}"
                 );
-                tokio::time::sleep(backoff_delay(attempt, None)).await;
+                tokio::time::sleep(delay).await;
                 continue;
             }
         };
@@ -100,23 +106,58 @@ pub async fn submit_listens(
         let status = resp.status();
 
         if status.is_success() {
-            return Ok(resp);
+            let body = read_body(resp).await;
+            tracing::info!(
+                "ListenBrainz {listen_type} ({count}) accepted: HTTP {} {body}",
+                status.as_u16()
+            );
+            return Ok(());
         }
 
         let retryable =
             status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
+        let retry_after = parse_retry_after(&resp);
 
         if !retryable || attempt >= MAX_ATTEMPTS {
-            resp.error_for_status_ref()?;
-            return Ok(resp);
+            let error = resp.error_for_status_ref().unwrap_err();
+            let body = read_body(resp).await;
+            tracing::warn!(
+                "ListenBrainz {listen_type} ({count}) rejected after {attempt} attempt(s): HTTP {} {body}",
+                status.as_u16()
+            );
+            return Err(error);
         }
 
-        let retry_after = parse_retry_after(&resp);
+        let delay = backoff_delay(attempt, retry_after);
+        let body = read_body(resp).await;
         tracing::warn!(
-            "ListenBrainz {listen_type} HTTP {status} (attempt {attempt}/{MAX_ATTEMPTS}), retrying"
+            "ListenBrainz {listen_type} ({count}) HTTP {} on attempt {attempt}/{MAX_ATTEMPTS}, retrying in {delay:?} {body}",
+            status.as_u16()
         );
-        tokio::time::sleep(backoff_delay(attempt, retry_after)).await;
+        tokio::time::sleep(delay).await;
     }
+}
+
+fn error_kind(error: &reqwest::Error) -> &'static str {
+    if error.is_timeout() {
+        "timeout"
+    } else if error.is_connect() {
+        "connection error"
+    } else if error.is_request() {
+        "request error"
+    } else {
+        "transport error"
+    }
+}
+
+async fn read_body(resp: reqwest::Response) -> String {
+    let text = resp.text().await.unwrap_or_default();
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    let snippet: String = trimmed.chars().take(300).collect();
+    format!("body={snippet}")
 }
 
 fn is_retryable_error(error: &reqwest::Error) -> bool {


### PR DESCRIPTION
Adds detailed logging for MusicBrainz scrobble outcomes: submits now log HTTP status, response body and retry attempts, and scrobble tasks run under tracing spans with skip reasons logged.

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
