### PR TITLE
various: group settings sections into bordered section cards

### DIFF
--- a/crates/components/src/settings_items.rs
+++ b/crates/components/src/settings_items.rs
@@ -12,9 +12,23 @@ use tracing::Instrument;
 #[component]
 pub fn SettingItem(title: String, control: Element) -> Element {
     rsx! {
-        div { class: "flex items-center justify-between py-2",
-            p { class: "text-white font-medium", "{title}" }
+        div { class: "flex items-center justify-between gap-4 py-3",
+            p { class: "text-sm text-white font-medium", "{title}" }
             {control}
+        }
+    }
+}
+
+#[component]
+pub fn SettingsSection(title: String, children: Element) -> Element {
+    rsx! {
+        section { class: "rounded-xl border border-white/10 bg-white/[0.02] overflow-hidden",
+            div { class: "px-5 py-3 border-b border-white/10 bg-white/[0.03]",
+                h2 { class: "text-xs font-semibold uppercase tracking-wider text-white/60",
+                    "{title}"
+                }
+            }
+            div { class: "px-5 py-1 divide-y divide-white/[0.06]", {children} }
         }
     }
 }

--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -419,9 +419,6 @@
   .my-4 {
     margin-block: calc(var(--spacing) * 4);
   }
-  .-mt-2 {
-    margin-top: calc(var(--spacing) * -2);
-  }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
   }
@@ -990,13 +987,6 @@
       margin-block-end: calc(calc(var(--spacing) * 3) * calc(1 - var(--tw-space-y-reverse)));
     }
   }
-  .space-y-4 {
-    :where(& > :not(:last-child)) {
-      --tw-space-y-reverse: 0;
-      margin-block-start: calc(calc(var(--spacing) * 4) * var(--tw-space-y-reverse));
-      margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-y-reverse)));
-    }
-  }
   .space-y-5 {
     :where(& > :not(:last-child)) {
       --tw-space-y-reverse: 0;
@@ -1049,6 +1039,23 @@
   }
   .gap-y-3 {
     row-gap: calc(var(--spacing) * 3);
+  }
+  .divide-y {
+    :where(& > :not(:last-child)) {
+      --tw-divide-y-reverse: 0;
+      border-bottom-style: var(--tw-border-style);
+      border-top-style: var(--tw-border-style);
+      border-top-width: calc(1px * var(--tw-divide-y-reverse));
+      border-bottom-width: calc(1px * calc(1 - var(--tw-divide-y-reverse)));
+    }
+  }
+  .divide-white\/\[0\.06\] {
+    :where(& > :not(:last-child)) {
+      border-color: color-mix(in srgb, #fff 6%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        border-color: color-mix(in oklab, var(--color-white) 6%, transparent);
+      }
+    }
   }
   .self-center {
     align-self: center;
@@ -1433,6 +1440,18 @@
     background-color: color-mix(in srgb, #fff 80%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
       background-color: color-mix(in oklab, var(--color-white) 80%, transparent);
+    }
+  }
+  .bg-white\/\[0\.02\] {
+    background-color: color-mix(in srgb, #fff 2%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 2%, transparent);
+    }
+  }
+  .bg-white\/\[0\.03\] {
+    background-color: color-mix(in srgb, #fff 3%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-white) 3%, transparent);
     }
   }
   .bg-yellow-400\/60 {
@@ -1919,6 +1938,12 @@
   }
   .text-emerald-400 {
     color: var(--color-emerald-400);
+  }
+  .text-emerald-400\/80 {
+    color: color-mix(in srgb, oklch(76.5% 0.177 163.223) 80%, transparent);
+    @supports (color: color-mix(in lab, red, red)) {
+      color: color-mix(in oklab, var(--color-emerald-400) 80%, transparent);
+    }
   }
   .text-green-400 {
     color: var(--color-green-400);
@@ -3129,6 +3154,11 @@
   inherits: false;
   initial-value: 0;
 }
+@property --tw-divide-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
 @property --tw-border-style {
   syntax: "*";
   inherits: false;
@@ -3391,6 +3421,7 @@
       --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
       --tw-space-x-reverse: 0;
+      --tw-divide-y-reverse: 0;
       --tw-border-style: solid;
       --tw-gradient-position: initial;
       --tw-gradient-from: #0000;

--- a/crates/pages/src/settings.rs
+++ b/crates/pages/src/settings.rs
@@ -3,12 +3,10 @@ use crate::theme_editor::ThemeEditorPage;
 #[cfg(not(target_os = "android"))]
 fn theme_editor_section(config: Signal<AppConfig>) -> Element {
     rsx! {
-        section {
-            h2 {
-                class: "text-lg font-semibold text-white/80 mb-4 border-b border-white/5 pb-2",
-                "{i18n::t(\"theme_editor\")}"
+        SettingsSection { title: i18n::t("theme_editor").to_string(),
+            div { class: "py-2",
+                ThemeEditorPage { config, embedded: true }
             }
-            ThemeEditorPage { config, embedded: true }
         }
     }
 }
@@ -33,12 +31,8 @@ fn trigger_test_crash() {
 #[cfg(not(target_os = "android"))]
 fn logs_section(mut config: Signal<AppConfig>) -> Element {
     rsx! {
-        section {
-            h2 {
-                class: "text-lg font-semibold text-white/80 mb-4 border-b border-white/5 pb-2",
-                "{i18n::t(\"logs\")}"
-            }
-            div { class: "space-y-4",
+        SettingsSection { title: i18n::t("logs").to_string(),
+            div {
                 SettingItem {
                     title: i18n::t("enable_tracing").to_string(),
                     control: rsx! {
@@ -51,11 +45,11 @@ fn logs_section(mut config: Signal<AppConfig>) -> Element {
                     },
                 }
                 p {
-                    class: "text-xs text-amber-400/80 -mt-2",
+                    class: "text-xs text-amber-400/80 pb-3",
                     "{i18n::t(\"tracing_warning\")}"
                 }
             }
-            div { class: "flex flex-wrap gap-3 mt-4",
+            div { class: "flex flex-wrap gap-3 py-3",
                 button {
                     class: "px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-white text-sm transition-colors flex items-center gap-2",
                     onclick: move |_| {
@@ -171,7 +165,7 @@ use components::settings_items::{
     BackBehaviorSelector, ChannelModeSelector, DiscordPresencePausedSettings,
     DiscordPresenceSettings, EqualizerPanel, LanguageSelector, LastFmSettings, LibreFmSettings,
     MultiDirectoryPicker, MusicBrainzSettings, RadioRegistryDropdown, ServerSettings, SettingItem,
-    ThemeSelector, ToggleSetting,
+    SettingsSection, ThemeSelector, ToggleSetting,
 };
 use components::settings_popups::{AddRegistryPopup, AddServerPopup, LoginPopup};
 use config::{AppConfig, ArtistPhotoSource, FetchStrategy, MusicService, OfflineQuality};
@@ -280,14 +274,9 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                 h1 { class: "text-3xl font-bold text-white mb-6", "{i18n::t(\"settings\")}" }
             }
 
-            div { class: "space-y-8",
-                section {
-                    h2 {
-                        class: "text-lg font-semibold text-white/80 mb-4 border-b border-white/5 pb-2",
-                        "{i18n::t(\"general\")}"
-                    }
-
-                    div { class: "space-y-4",
+            div { class: "space-y-12",
+                SettingsSection {
+                    title: i18n::t("general").to_string(),
                         SettingItem {
                             title: i18n::t("language").to_string(),
                             control: rsx! {
@@ -561,13 +550,9 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                                 }
                             }
                         }
-                        section {
-                            h2 {
-                                class: "text-lg font-semibold text-white/80 mb-4 border-b border-white/5 pb-2",
-                                "{i18n::t(\"connectivity\")}"
-                            }
-                            div {
-                                class: "space-y-4",
+                }
+                SettingsSection {
+                    title: i18n::t("connectivity").to_string(),
                                 if !cfg!(target_os = "android") {
                                     SettingItem {
                                         title: i18n::t("discord_presence").to_string(),
@@ -642,18 +627,11 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                                         }
                                     }
                                 }
-                            }
-                        }
-                    }
                 }
 
                 if config.read().server.is_some() {
-                    section {
-                        h2 {
-                            class: "text-lg font-semibold text-white/80 mb-4 border-b border-white/5 pb-2",
-                            "{i18n::t(\"offline_downloads\")}"
-                        }
-                        div { class: "space-y-4",
+                    SettingsSection {
+                        title: i18n::t("offline_downloads").to_string(),
                             SettingItem {
                                 title: i18n::t("download_quality").to_string(),
                                 control: rsx! {
@@ -672,16 +650,11 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                                     }
                                 }
                             }
-                        }
                     }
                 }
 
-                section {
-                    h2 {
-                        class: "text-lg font-semibold text-white/80 mb-4 border-b border-white/5 pb-2",
-                        "{i18n::t(\"metadata\")}"
-                    }
-                    div { class: "space-y-4",
+                SettingsSection {
+                    title: i18n::t("metadata").to_string(),
                         SettingItem {
                             title: i18n::t("auto_fetch_covers").to_string(),
                             control: rsx! {
@@ -779,17 +752,11 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                                 }
                             }
                         }
-                    }
                     ClearCacheButton {}
                 }
 
-                section {
-                    h2 {
-                        class: "text-lg font-semibold text-white/80 mb-4 border-b border-white/5 pb-2",
-                        "{i18n::t(\"player_settings\")}"
-                    }
-
-                    div { class: "space-y-4",
+                SettingsSection {
+                    title: i18n::t("player_settings").to_string(),
                         SettingItem {
                             title: i18n::t("crossfade").to_string(),
                             control: rsx! {
@@ -866,7 +833,6 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                                 }
                             }
                         }
-                    }
                 }
 
                 {logs_section(config)}


### PR DESCRIPTION
New SettingsSection component wraps each settings group in a bordered card with a labeled header and hairline dividers between rows. Section boundaries and individual options now read clearly. Connectivity moved out of General, where it was nested and looked like a sub item. Row spacing tightened, gap between sections widened.

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
