### PR TITLE
server/cookies: don't split the Windows browser path on spaces

### DIFF
--- a/crates/server/src/cookies/browser.rs
+++ b/crates/server/src/cookies/browser.rs
@@ -174,15 +174,25 @@ pub(crate) async fn find_browser_bin(browser: Browser) -> Option<String> {
 /// Plain `Command` natively; `flatpak-spawn --host --watch-bus` when packaged,
 /// so `child.kill()`/`kill_on_drop` still tears the host browser down.
 pub(crate) fn browser_command(bin: &str) -> Command {
-    let cmd: Vec<&str> = bin.split(' ').collect();
-    if in_flatpak() {
-        let mut c = Command::new("flatpak-spawn");
-        c.args(["--host", "--watch-bus"]);
-        c.args(cmd);
-        c
-    } else {
-        let mut c = Command::new(cmd[0]);
-        c.args(&cmd[1..]);
-        c
+    // On Windows `bin` is a single executable path that can contain spaces
+    // (e.g. `C:\Program Files\...`), so it must not be split. Elsewhere `bin`
+    // may be a multi-token command like `flatpak run <id>`, so split on spaces.
+    #[cfg(windows)]
+    {
+        Command::new(bin)
+    }
+    #[cfg(not(windows))]
+    {
+        let cmd: Vec<&str> = bin.split(' ').collect();
+        if in_flatpak() {
+            let mut c = Command::new("flatpak-spawn");
+            c.args(["--host", "--watch-bus"]);
+            c.args(cmd);
+            c
+        } else {
+            let mut c = Command::new(cmd[0]);
+            c.args(&cmd[1..]);
+            c
+        }
     }
 }


### PR DESCRIPTION
browser_command split `bin` on spaces to support the Linux `flatpak run <id>` form, but that shattered Windows paths like
`C:\Program Files\Google\Chrome\Application\chrome.exe` at the "Program Files" space, so sign-in tried to spawn `C:\Program` and failed with os error 2. Chrome sign-in was broken on any default Windows install.

Gate the split to non-Windows (where `bin` can be a multi-token command); on Windows `bin` is always a single executable path, use it verbatim.

Used Claude Fable to generate code, reviewed and wrote pr desc manually.

<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [x] Windows
- [ ] Android
- [ ] iOS
