### PR TITLE
various: reconnect Discord presence when Discord starts late or restarts

### DIFF
--- a/crates/discord-presence/src/lib.rs
+++ b/crates/discord-presence/src/lib.rs
@@ -9,31 +9,178 @@ use discord_rich_presence::{
     activity::{self, Assets, Timestamps},
 };
 #[cfg(not(target_os = "android"))]
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 #[cfg(not(target_os = "android"))]
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+#[cfg(not(target_os = "android"))]
+const RECONNECT_INTERVAL: Duration = Duration::from_secs(10);
+
+#[cfg(not(target_os = "android"))]
+#[derive(Debug, Clone)]
+struct StoredActivity {
+    details: String,
+    state: String,
+    name: Option<String>,
+    timestamps: Option<(i64, Option<i64>)>,
+    assets: Option<(String, String)>,
+}
+
+#[cfg(not(target_os = "android"))]
+impl StoredActivity {
+    fn as_activity(&self) -> activity::Activity<'_> {
+        let mut act = activity::Activity::new()
+            .details(&self.details)
+            .state(&self.state)
+            .status_display_type(activity::StatusDisplayType::State)
+            .activity_type(activity::ActivityType::Listening);
+
+        if let Some((start, end)) = self.timestamps {
+            let mut timestamps = Timestamps::new().start(start);
+            if let Some(end) = end {
+                timestamps = timestamps.end(end);
+            }
+            act = act.timestamps(timestamps);
+        }
+
+        if let Some(ref name) = self.name {
+            act = act.name(name);
+        }
+
+        if let Some((ref image, ref text)) = self.assets {
+            act = act.assets(Assets::new().large_image(image).large_text(text));
+        }
+
+        act
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+#[derive(Debug)]
+struct Inner {
+    client: Option<DiscordIpcClient>,
+    last_activity: Option<StoredActivity>,
+    next_retry: Option<Instant>,
+}
 
 #[cfg(not(target_os = "android"))]
 #[derive(Debug)]
 pub struct Presence {
-    client: Mutex<DiscordIpcClient>,
+    client_id: String,
+    inner: Mutex<Inner>,
 }
 
 #[cfg(not(target_os = "android"))]
 impl Presence {
     pub fn new(client_id: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        let mut client = DiscordIpcClient::new(client_id);
-        client.connect()?;
-        Ok(Self {
-            client: Mutex::new(client),
-        })
+        let presence = Self {
+            client_id: client_id.to_owned(),
+            inner: Mutex::new(Inner {
+                client: None,
+                last_activity: None,
+                next_retry: None,
+            }),
+        };
+
+        {
+            let mut inner = presence.lock();
+            if presence.try_connect(&mut inner) {
+                tracing::info!("Discord presence connected");
+            } else {
+                tracing::info!("Discord IPC unavailable at startup; will retry in the background");
+            }
+        }
+
+        Ok(presence)
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn try_connect(&self, inner: &mut Inner) -> bool {
+        let mut client = DiscordIpcClient::new(&self.client_id);
+        match client.connect() {
+            Ok(()) => {
+                inner.client = Some(client);
+                inner.next_retry = None;
+                true
+            }
+            Err(e) => {
+                tracing::debug!("Discord IPC connect failed: {e}");
+                inner.client = None;
+                inner.next_retry = Some(Instant::now() + RECONNECT_INTERVAL);
+                false
+            }
+        }
+    }
+
+    fn send_current(&self, inner: &mut Inner) -> Result<(), Box<dyn std::error::Error>> {
+        let Some(client) = inner.client.as_mut() else {
+            return Err("Discord IPC is not connected".into());
+        };
+        let result = match inner.last_activity {
+            Some(ref act) => client.set_activity(act.as_activity()),
+            None => client.clear_activity(),
+        };
+        if result.is_err() {
+            inner.client = None;
+            inner.next_retry = Some(Instant::now() + RECONNECT_INTERVAL);
+        }
+        result.map_err(Into::into)
+    }
+
+    fn set_and_deliver(&self, stored: StoredActivity) -> Result<(), Box<dyn std::error::Error>> {
+        let mut inner = self.lock();
+        inner.last_activity = Some(stored);
+
+        if inner.client.is_none() {
+            if !self.try_connect(&mut inner) {
+                return Err("Discord IPC unavailable".into());
+            }
+            tracing::info!("Discord presence connected");
+            return self.send_current(&mut inner);
+        }
+
+        match self.send_current(&mut inner) {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                tracing::debug!("Discord activity update failed ({e}); reconnecting");
+                if self.try_connect(&mut inner) {
+                    tracing::info!("Discord presence reconnected");
+                    self.send_current(&mut inner)
+                } else {
+                    Err(e)
+                }
+            }
+        }
+    }
+
+    pub fn tick(&self) {
+        let mut inner = self.lock();
+        if inner.client.is_some() || inner.last_activity.is_none() {
+            return;
+        }
+        if let Some(at) = inner.next_retry
+            && Instant::now() < at
+        {
+            return;
+        }
+        if self.try_connect(&mut inner) {
+            tracing::info!("Discord presence connected; restoring activity");
+            if let Err(e) = self.send_current(&mut inner) {
+                tracing::debug!("Failed to restore Discord activity: {e}");
+            }
+        }
     }
 
     pub fn disconnect(&self) -> Result<(), Box<dyn std::error::Error>> {
-        self.client
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .close()?;
+        let mut inner = self.lock();
+        inner.last_activity = None;
+        inner.next_retry = None;
+        if let Some(mut client) = inner.client.take() {
+            client.close()?;
+        }
         Ok(())
     }
 
@@ -53,35 +200,18 @@ impl Presence {
         let end_time = start_time + duration_secs as i64;
 
         let timestamps = if duration_secs == u64::MAX {
-            Timestamps::new().start(start_time)
+            (start_time, None)
         } else {
-            Timestamps::new().start(start_time).end(end_time)
+            (start_time, Some(end_time))
         };
 
-        let state = artist.to_string();
-        let name = source.map(|s| format!("Kopuz - on {s}"));
-
-        let mut activity = activity::Activity::new()
-            .details(title)
-            .state(&state)
-            .status_display_type(activity::StatusDisplayType::State)
-            .timestamps(timestamps)
-            .activity_type(activity::ActivityType::Listening);
-
-        if let Some(ref name) = name {
-            activity = activity.name(name);
-        }
-
-        if let Some(url) = cover_url {
-            let assets = Assets::new().large_image(url).large_text(album);
-            activity = activity.assets(assets);
-        }
-
-        self.client
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .set_activity(activity)?;
-        Ok(())
+        self.set_and_deliver(StoredActivity {
+            details: title.to_owned(),
+            state: artist.to_owned(),
+            name: source.map(|s| format!("Kopuz - on {s}")),
+            timestamps: Some(timestamps),
+            assets: cover_url.map(|url| (url.to_owned(), album.to_owned())),
+        })
     }
 
     pub fn set_paused(
@@ -92,35 +222,21 @@ impl Presence {
         cover_url: Option<&str>,
         source: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let state = format!("{artist} • Paused");
-        let name = source.map(|s| format!("Kopuz - on {s}"));
-        let mut activity = activity::Activity::new()
-            .details(title)
-            .state(&state)
-            .status_display_type(activity::StatusDisplayType::State)
-            .activity_type(activity::ActivityType::Listening);
-
-        if let Some(ref name) = name {
-            activity = activity.name(name);
-        }
-
-        if let Some(url) = cover_url {
-            let assets = Assets::new().large_image(url).large_text(album);
-            activity = activity.assets(assets);
-        }
-
-        self.client
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .set_activity(activity)?;
-        Ok(())
+        self.set_and_deliver(StoredActivity {
+            details: title.to_owned(),
+            state: format!("{artist} • Paused"),
+            name: source.map(|s| format!("Kopuz - on {s}")),
+            timestamps: None,
+            assets: cover_url.map(|url| (url.to_owned(), album.to_owned())),
+        })
     }
 
     pub fn clear_activity(&self) -> Result<(), Box<dyn std::error::Error>> {
-        self.client
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .clear_activity()?;
+        let mut inner = self.lock();
+        inner.last_activity = None;
+        if inner.client.is_some() {
+            self.send_current(&mut inner)?;
+        }
         Ok(())
     }
 }
@@ -128,11 +244,10 @@ impl Presence {
 #[cfg(not(target_os = "android"))]
 impl Drop for Presence {
     fn drop(&mut self) {
-        let mut client = match self.client.lock() {
-            Ok(c) => c,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        let _ = client.close();
+        let mut inner = self.lock();
+        if let Some(mut client) = inner.client.take() {
+            let _ = client.close();
+        }
     }
 }
 
@@ -152,6 +267,8 @@ impl Presence {
     pub fn disconnect(&self) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
     }
+
+    pub fn tick(&self) {}
 
     pub fn set_now_playing(
         &self,
@@ -179,5 +296,86 @@ impl Presence {
 
     pub fn clear_activity(&self) -> Result<(), Box<dyn std::error::Error>> {
         Ok(())
+    }
+}
+
+#[cfg(all(test, not(target_os = "android"), target_family = "unix"))]
+mod reconnect_tests {
+    use super::*;
+    use std::io::{Read as _, Write as _};
+    use std::os::unix::net::{UnixListener, UnixStream};
+    use std::sync::mpsc;
+
+    fn read_frame(sock: &mut UnixStream) -> std::io::Result<String> {
+        let mut header = [0u8; 8];
+        sock.read_exact(&mut header)?;
+        let len = u32::from_le_bytes(header[4..].try_into().expect("4-byte slice"));
+        let mut payload = vec![0u8; len as usize];
+        sock.read_exact(&mut payload)?;
+        Ok(String::from_utf8(payload).expect("IPC payload is JSON"))
+    }
+
+    fn write_frame(sock: &mut UnixStream, opcode: u32, payload: &str) -> std::io::Result<()> {
+        sock.write_all(&opcode.to_le_bytes())?;
+        sock.write_all(&(payload.len() as u32).to_le_bytes())?;
+        sock.write_all(payload.as_bytes())
+    }
+
+    fn serve_one(listener: UnixListener, tx: mpsc::Sender<String>) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || {
+            let (mut sock, _) = listener.accept().expect("accept IPC client");
+            read_frame(&mut sock).expect("read handshake");
+            write_frame(&mut sock, 1, r#"{"cmd":"DISPATCH","evt":"READY"}"#)
+                .expect("ack handshake");
+            let payload = read_frame(&mut sock).expect("read activity frame");
+            tx.send(payload).expect("forward payload");
+            let _ = sock.shutdown(std::net::Shutdown::Both);
+        })
+    }
+
+    #[test]
+    fn reconnects_and_restores_activity() {
+        let dir = std::env::temp_dir().join(format!("kopuz-drpc-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("create socket dir");
+        unsafe {
+            std::env::remove_var("SNAP");
+            for key in ["XDG_RUNTIME_DIR", "TMPDIR", "TMP", "TEMP"] {
+                std::env::set_var(key, &dir);
+            }
+        }
+
+        let presence = Presence::new("test-client-id").expect("offline construction succeeds");
+        assert!(presence.lock().client.is_none());
+        assert!(
+            presence
+                .set_now_playing("First Song", "Artist", "Album", 30, 180, None, None)
+                .is_err()
+        );
+        assert!(presence.lock().last_activity.is_some());
+
+        let listener = UnixListener::bind(dir.join("discord-ipc-0")).expect("bind fake IPC");
+        let (tx, rx) = mpsc::channel();
+        let server = serve_one(listener.try_clone().expect("clone listener"), tx.clone());
+        presence.lock().next_retry = None;
+        presence.tick();
+        let payload = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("activity restored after tick");
+        assert!(payload.contains("SET_ACTIVITY"));
+        assert!(payload.contains("First Song"));
+        server.join().expect("server thread");
+        assert!(presence.lock().client.is_some());
+
+        let server = serve_one(listener, tx);
+        presence
+            .set_now_playing("Second Song", "Artist", "Album", 0, 200, None, None)
+            .expect("update resent over new connection");
+        let payload = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("activity resent after reconnect");
+        assert!(payload.contains("Second Song"));
+        server.join().expect("server thread");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -354,6 +354,13 @@ pub fn use_player_task(ctrl: PlayerController) {
                             .map_or("Local", |s| s.display_name())
                     });
                 let source_changed = last_source.peek().as_deref() != discord_source_name;
+
+                // Discord may start after Kopuz or restart mid-session: retry a
+                // dropped IPC connection and restore the last activity once it's up.
+                if discord_enabled && let Some(ref p) = presence {
+                    p.tick();
+                }
+
                 let pos = ctrl.player.read().get_position();
                 let mut defer_player_progress = false;
 

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -113,12 +113,9 @@ fn main() {
         let _ = app_db::DB_HANDLE.set(app_db::init_blocking());
 
         let presence: Option<Arc<Presence>> = match Presence::new("1470087339639443658") {
-            Ok(p) => {
-                tracing::info!("Discord presence connected");
-                Some(Arc::new(p))
-            }
+            Ok(p) => Some(Arc::new(p)),
             Err(e) => {
-                tracing::warn!("Failed to connect to Discord: {e}");
+                tracing::warn!("Discord presence unavailable: {e}");
                 None
             }
         };


### PR DESCRIPTION
Fixed discord rich presence, it was only checking discord at the start and never checked again. But now it checks even if discord boots up later than kopuz.

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
