### PR TITLE
various: add offline scrobbling support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,8 +4408,8 @@ name = "kopuz-scrobble"
 version = "0.9.0"
 dependencies = [
  "dioxus",
- "directories",
  "kopuz-config",
+ "kopuz-db",
  "md5",
  "reqwest 0.13.4",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,6 +4408,7 @@ name = "kopuz-scrobble"
 version = "0.9.0"
 dependencies = [
  "dioxus",
+ "directories",
  "kopuz-config",
  "md5",
  "reqwest 0.13.4",

--- a/crates/db/.sqlx/query-1a4a571619385a4960689839b2262bdb7acd04e421a9d9ab65efa2f111246df5.json
+++ b/crates/db/.sqlx/query-1a4a571619385a4960689839b2262bdb7acd04e421a9d9ab65efa2f111246df5.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT listened_at, artist, title, album, service, listen_info FROM scrobble_queue ORDER BY listened_at ASC, id ASC",
+  "describe": {
+    "columns": [
+      {
+        "name": "listened_at",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "artist",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "title",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "album",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "service",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "listen_info",
+        "ordinal": 5,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "1a4a571619385a4960689839b2262bdb7acd04e421a9d9ab65efa2f111246df5"
+}

--- a/crates/db/.sqlx/query-1af1b4c6f26436e765193eefb97392fff5e4cfd414481cfd633cc4440c87be21.json
+++ b/crates/db/.sqlx/query-1af1b4c6f26436e765193eefb97392fff5e4cfd414481cfd633cc4440c87be21.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM scrobble_queue WHERE listened_at = ?1 AND artist = ?2 AND title = ?3 AND service = ?4",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 4
+    },
+    "nullable": []
+  },
+  "hash": "1af1b4c6f26436e765193eefb97392fff5e4cfd414481cfd633cc4440c87be21"
+}

--- a/crates/db/.sqlx/query-36d0df2683fb8edf928157a40825ecdc3c6d38d9a6df9424ef201ddaa3f56fd0.json
+++ b/crates/db/.sqlx/query-36d0df2683fb8edf928157a40825ecdc3c6d38d9a6df9424ef201ddaa3f56fd0.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO scrobble_queue (listened_at, artist, title, album, service, listen_info) VALUES (?1, ?2, ?3, ?4, ?5, ?6) ON CONFLICT(listened_at, artist, title, service) DO UPDATE SET album = COALESCE(excluded.album, album), listen_info = COALESCE(excluded.listen_info, listen_info)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 6
+    },
+    "nullable": []
+  },
+  "hash": "36d0df2683fb8edf928157a40825ecdc3c6d38d9a6df9424ef201ddaa3f56fd0"
+}

--- a/crates/db/.sqlx/query-57f331cd7caa671bfd20533fac3b7f5fa127c385e7933c0068f259eb1ed5d96c.json
+++ b/crates/db/.sqlx/query-57f331cd7caa671bfd20533fac3b7f5fa127c385e7933c0068f259eb1ed5d96c.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "DELETE FROM scrobble_queue WHERE listened_at NOT IN (SELECT listened_at FROM scrobble_queue GROUP BY listened_at ORDER BY listened_at DESC LIMIT ?1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": []
+  },
+  "hash": "57f331cd7caa671bfd20533fac3b7f5fa127c385e7933c0068f259eb1ed5d96c"
+}

--- a/crates/db/migrations/20260709000000_scrobble_queue.sql
+++ b/crates/db/migrations/20260709000000_scrobble_queue.sql
@@ -1,0 +1,18 @@
+-- Offline scrobble backlog (issue #335). One row per (listen × service): a
+-- scrobble that failed with a transient error is stored here and resubmitted
+-- later with its original listen timestamp. "The same listen owed to two
+-- services" is just two rows sharing (listened_at, artist, title); delivering
+-- one service deletes only its row. `listen_info` holds the ListenBrainz
+-- additional-info payload (that service's own JSON, not the queue's storage
+-- format) and is NULL for Last.fm/Libre.fm. Replaces the earlier JSON queue
+-- file, which never shipped, so there is nothing to migrate in.
+CREATE TABLE scrobble_queue (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    listened_at INTEGER NOT NULL,
+    artist      TEXT    NOT NULL,
+    title       TEXT    NOT NULL,
+    album       TEXT,
+    service     TEXT    NOT NULL,
+    listen_info TEXT,
+    UNIQUE (listened_at, artist, title, service)
+);

--- a/crates/db/src/backend/mod.rs
+++ b/crates/db/src/backend/mod.rs
@@ -16,7 +16,10 @@ mod dump;
 mod migrations;
 mod queries;
 mod rows;
+mod scrobble;
 mod scrobble_queue;
+
+pub use scrobble::{QueuedScrobbleRow, ScrobbleService};
 mod writes;
 
 pub struct Native {
@@ -380,7 +383,7 @@ impl Storage for Native {
         listened_at: i64,
         artist: &str,
         title: &str,
-        service: crate::Service,
+        service: crate::ScrobbleService,
     ) -> Result<(), DbError> {
         scrobble_queue::delete(&self.pool(), listened_at, artist, title, service).await
     }

--- a/crates/db/src/backend/mod.rs
+++ b/crates/db/src/backend/mod.rs
@@ -16,6 +16,7 @@ mod dump;
 mod migrations;
 mod queries;
 mod rows;
+mod scrobble_queue;
 mod writes;
 
 pub struct Native {
@@ -208,6 +209,10 @@ impl ReadStore for Native {
     async fn meta_get(&self, cache_key: &str, kind: &str) -> Result<Option<String>, DbError> {
         writes::meta_get(&self.pool(), cache_key, kind).await
     }
+
+    async fn scrobble_queue_all(&self) -> Result<Vec<crate::QueuedScrobbleRow>, DbError> {
+        scrobble_queue::all(&self.pool()).await
+    }
 }
 
 #[async_trait::async_trait]
@@ -364,6 +369,20 @@ impl Storage for Native {
 
     async fn save_queue(&self, snap: &crate::QueueSnapshot) -> Result<(), DbError> {
         writes::save_queue(&self.pool(), snap).await
+    }
+
+    async fn scrobble_queue_push(&self, row: &crate::QueuedScrobbleRow) -> Result<(), DbError> {
+        scrobble_queue::push(&self.pool(), row).await
+    }
+
+    async fn scrobble_queue_delete(
+        &self,
+        listened_at: i64,
+        artist: &str,
+        title: &str,
+        service: crate::Service,
+    ) -> Result<(), DbError> {
+        scrobble_queue::delete(&self.pool(), listened_at, artist, title, service).await
     }
 
     async fn upsert_tracks(

--- a/crates/db/src/backend/scrobble.rs
+++ b/crates/db/src/backend/scrobble.rs
@@ -1,0 +1,54 @@
+//! Offline scrobble domain types (issue #335). `db` owns the `scrobble_queue`
+//! table these describe, so the enum and row live here; `kopuz-scrobble`
+//! re-exports them so its Last.fm/Libre.fm/ListenBrainz backends and the queue
+//! share one representation. This crate only persists — the retry
+//! orchestration lives in `kopuz-scrobble`.
+
+/// A scrobble destination. Kept in sync with the `service` column tags below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrobbleService {
+    LastFm,
+    LibreFm,
+    ListenBrainz,
+}
+
+impl ScrobbleService {
+    pub fn label(self) -> &'static str {
+        match self {
+            ScrobbleService::LastFm => "Last.fm",
+            ScrobbleService::LibreFm => "Libre.fm",
+            ScrobbleService::ListenBrainz => "ListenBrainz",
+        }
+    }
+
+    pub fn as_tag(self) -> &'static str {
+        match self {
+            ScrobbleService::LastFm => "lastfm",
+            ScrobbleService::LibreFm => "librefm",
+            ScrobbleService::ListenBrainz => "listenbrainz",
+        }
+    }
+
+    pub fn from_tag(tag: &str) -> Option<Self> {
+        match tag {
+            "lastfm" => Some(ScrobbleService::LastFm),
+            "librefm" => Some(ScrobbleService::LibreFm),
+            "listenbrainz" => Some(ScrobbleService::ListenBrainz),
+            _ => None,
+        }
+    }
+}
+
+/// One queued offline scrobble owed to a single service (issue #335). A listen
+/// owed to N services is N rows sharing `(listened_at, artist, title)`.
+/// `listen_info` is the raw ListenBrainz additional-info JSON, `None` otherwise.
+/// The retry orchestration lives in `kopuz-scrobble` — this crate only persists.
+#[derive(Clone, Debug)]
+pub struct QueuedScrobbleRow {
+    pub listened_at: i64,
+    pub artist: String,
+    pub title: String,
+    pub album: Option<String>,
+    pub service: ScrobbleService,
+    pub listen_info: Option<String>,
+}

--- a/crates/db/src/backend/scrobble_queue.rs
+++ b/crates/db/src/backend/scrobble_queue.rs
@@ -4,19 +4,15 @@
 
 use sqlx::SqlitePool;
 
-use crate::{DbError, QueuedScrobbleRow, Service};
+use crate::{DbError, QueuedScrobbleRow, ScrobbleService};
 
 /// Newest listens kept; when the backlog overflows the oldest are dropped. A
 /// "listen" is one `listened_at` group, so a listen owed to three services
 /// still counts as one toward the cap.
 const MAX_QUEUED_LISTENS: i64 = 500;
 
-/// A raw `scrobble_queue` row as selected: `(listened_at, artist, title, album,
-/// service, listen_info)`.
-type QueueRow = (i64, String, String, Option<String>, String, Option<String>);
-
 pub async fn all(pool: &SqlitePool) -> Result<Vec<QueuedScrobbleRow>, DbError> {
-    let rows: Vec<QueueRow> = sqlx::query_as(
+    let rows = sqlx::query!(
         "SELECT listened_at, artist, title, album, service, listen_info \
              FROM scrobble_queue ORDER BY listened_at ASC, id ASC",
     )
@@ -24,45 +20,44 @@ pub async fn all(pool: &SqlitePool) -> Result<Vec<QueuedScrobbleRow>, DbError> {
     .await?;
     Ok(rows
         .into_iter()
-        .filter_map(
-            |(listened_at, artist, title, album, service, listen_info)| {
-                Some(QueuedScrobbleRow {
-                    listened_at,
-                    artist,
-                    title,
-                    album,
-                    service: Service::from_tag(&service)?,
-                    listen_info,
-                })
-            },
-        )
+        .filter_map(|r| {
+            Some(QueuedScrobbleRow {
+                listened_at: r.listened_at,
+                artist: r.artist,
+                title: r.title,
+                album: r.album,
+                service: ScrobbleService::from_tag(&r.service)?,
+                listen_info: r.listen_info,
+            })
+        })
         .collect())
 }
 
 pub async fn push(pool: &SqlitePool, row: &QueuedScrobbleRow) -> Result<(), DbError> {
     let mut tx = pool.begin().await?;
-    sqlx::query(
+    let tag = row.service.as_tag();
+    sqlx::query!(
         "INSERT INTO scrobble_queue \
              (listened_at, artist, title, album, service, listen_info) \
          VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
          ON CONFLICT(listened_at, artist, title, service) DO UPDATE SET \
              album = COALESCE(excluded.album, album), \
              listen_info = COALESCE(excluded.listen_info, listen_info)",
+        row.listened_at,
+        row.artist,
+        row.title,
+        row.album,
+        tag,
+        row.listen_info,
     )
-    .bind(row.listened_at)
-    .bind(&row.artist)
-    .bind(&row.title)
-    .bind(&row.album)
-    .bind(row.service.as_tag())
-    .bind(&row.listen_info)
     .execute(&mut *tx)
     .await?;
-    sqlx::query(
+    sqlx::query!(
         "DELETE FROM scrobble_queue WHERE listened_at NOT IN \
          (SELECT listened_at FROM scrobble_queue \
           GROUP BY listened_at ORDER BY listened_at DESC LIMIT ?1)",
+        MAX_QUEUED_LISTENS,
     )
-    .bind(MAX_QUEUED_LISTENS)
     .execute(&mut *tx)
     .await?;
     tx.commit().await?;
@@ -74,16 +69,17 @@ pub async fn delete(
     listened_at: i64,
     artist: &str,
     title: &str,
-    service: Service,
+    service: ScrobbleService,
 ) -> Result<(), DbError> {
-    sqlx::query(
+    let tag = service.as_tag();
+    sqlx::query!(
         "DELETE FROM scrobble_queue \
          WHERE listened_at = ?1 AND artist = ?2 AND title = ?3 AND service = ?4",
+        listened_at,
+        artist,
+        title,
+        tag,
     )
-    .bind(listened_at)
-    .bind(artist)
-    .bind(title)
-    .bind(service.as_tag())
     .execute(pool)
     .await?;
     Ok(())
@@ -102,7 +98,7 @@ mod tests {
         pool
     }
 
-    fn row(title: &str, ts: i64, service: Service) -> QueuedScrobbleRow {
+    fn row(title: &str, ts: i64, service: ScrobbleService) -> QueuedScrobbleRow {
         QueuedScrobbleRow {
             listened_at: ts,
             artist: "Artist".into(),
@@ -117,7 +113,7 @@ mod tests {
     async fn push_caps_backlog_and_drops_oldest_listens() {
         let pool = mem_pool().await;
         for i in 0..(MAX_QUEUED_LISTENS + 10) {
-            push(&pool, &row(&format!("t{i}"), i, Service::LastFm))
+            push(&pool, &row(&format!("t{i}"), i, ScrobbleService::LastFm))
                 .await
                 .unwrap();
         }
@@ -129,25 +125,25 @@ mod tests {
     #[tokio::test]
     async fn push_merges_same_listen_and_delete_is_per_service() {
         let pool = mem_pool().await;
-        push(&pool, &row("Song", 42, Service::LastFm))
+        push(&pool, &row("Song", 42, ScrobbleService::LastFm))
             .await
             .unwrap();
-        let mut lb = row("Song", 42, Service::ListenBrainz);
+        let mut lb = row("Song", 42, ScrobbleService::ListenBrainz);
         lb.listen_info = Some(r#"{"duration_ms":180000}"#.into());
         push(&pool, &lb).await.unwrap();
-        push(&pool, &row("Song", 42, Service::LastFm))
+        push(&pool, &row("Song", 42, ScrobbleService::LastFm))
             .await
             .unwrap();
 
         let all_rows = all(&pool).await.unwrap();
         assert_eq!(all_rows.len(), 2);
 
-        delete(&pool, 42, "Artist", "Song", Service::LastFm)
+        delete(&pool, 42, "Artist", "Song", ScrobbleService::LastFm)
             .await
             .unwrap();
         let rest = all(&pool).await.unwrap();
         assert_eq!(rest.len(), 1);
-        assert_eq!(rest[0].service, Service::ListenBrainz);
+        assert_eq!(rest[0].service, ScrobbleService::ListenBrainz);
         assert_eq!(
             rest[0].listen_info.as_deref(),
             Some(r#"{"duration_ms":180000}"#)

--- a/crates/db/src/backend/scrobble_queue.rs
+++ b/crates/db/src/backend/scrobble_queue.rs
@@ -1,0 +1,156 @@
+//! Offline scrobble backlog persistence (issue #335). See the `scrobble_queue`
+//! migration; the retry orchestration (submit, give-up per service, drain)
+//! lives in `kopuz-scrobble`, which calls these through the `Storage` trait.
+
+use sqlx::SqlitePool;
+
+use crate::{DbError, QueuedScrobbleRow, Service};
+
+/// Newest listens kept; when the backlog overflows the oldest are dropped. A
+/// "listen" is one `listened_at` group, so a listen owed to three services
+/// still counts as one toward the cap.
+const MAX_QUEUED_LISTENS: i64 = 500;
+
+/// A raw `scrobble_queue` row as selected: `(listened_at, artist, title, album,
+/// service, listen_info)`.
+type QueueRow = (i64, String, String, Option<String>, String, Option<String>);
+
+pub async fn all(pool: &SqlitePool) -> Result<Vec<QueuedScrobbleRow>, DbError> {
+    let rows: Vec<QueueRow> = sqlx::query_as(
+        "SELECT listened_at, artist, title, album, service, listen_info \
+             FROM scrobble_queue ORDER BY listened_at ASC, id ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(
+            |(listened_at, artist, title, album, service, listen_info)| {
+                Some(QueuedScrobbleRow {
+                    listened_at,
+                    artist,
+                    title,
+                    album,
+                    service: Service::from_tag(&service)?,
+                    listen_info,
+                })
+            },
+        )
+        .collect())
+}
+
+pub async fn push(pool: &SqlitePool, row: &QueuedScrobbleRow) -> Result<(), DbError> {
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        "INSERT INTO scrobble_queue \
+             (listened_at, artist, title, album, service, listen_info) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6) \
+         ON CONFLICT(listened_at, artist, title, service) DO UPDATE SET \
+             album = COALESCE(excluded.album, album), \
+             listen_info = COALESCE(excluded.listen_info, listen_info)",
+    )
+    .bind(row.listened_at)
+    .bind(&row.artist)
+    .bind(&row.title)
+    .bind(&row.album)
+    .bind(row.service.as_tag())
+    .bind(&row.listen_info)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "DELETE FROM scrobble_queue WHERE listened_at NOT IN \
+         (SELECT listened_at FROM scrobble_queue \
+          GROUP BY listened_at ORDER BY listened_at DESC LIMIT ?1)",
+    )
+    .bind(MAX_QUEUED_LISTENS)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+pub async fn delete(
+    pool: &SqlitePool,
+    listened_at: i64,
+    artist: &str,
+    title: &str,
+    service: Service,
+) -> Result<(), DbError> {
+    sqlx::query(
+        "DELETE FROM scrobble_queue \
+         WHERE listened_at = ?1 AND artist = ?2 AND title = ?3 AND service = ?4",
+    )
+    .bind(listened_at)
+    .bind(artist)
+    .bind(title)
+    .bind(service.as_tag())
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::QueuedScrobbleRow;
+
+    async fn mem_pool() -> SqlitePool {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::backend::migrations::run_migrations(&pool)
+            .await
+            .unwrap();
+        pool
+    }
+
+    fn row(title: &str, ts: i64, service: Service) -> QueuedScrobbleRow {
+        QueuedScrobbleRow {
+            listened_at: ts,
+            artist: "Artist".into(),
+            title: title.into(),
+            album: None,
+            service,
+            listen_info: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn push_caps_backlog_and_drops_oldest_listens() {
+        let pool = mem_pool().await;
+        for i in 0..(MAX_QUEUED_LISTENS + 10) {
+            push(&pool, &row(&format!("t{i}"), i, Service::LastFm))
+                .await
+                .unwrap();
+        }
+        let all = all(&pool).await.unwrap();
+        assert_eq!(all.len() as i64, MAX_QUEUED_LISTENS);
+        assert_eq!(all.first().unwrap().listened_at, 10);
+    }
+
+    #[tokio::test]
+    async fn push_merges_same_listen_and_delete_is_per_service() {
+        let pool = mem_pool().await;
+        push(&pool, &row("Song", 42, Service::LastFm))
+            .await
+            .unwrap();
+        let mut lb = row("Song", 42, Service::ListenBrainz);
+        lb.listen_info = Some(r#"{"duration_ms":180000}"#.into());
+        push(&pool, &lb).await.unwrap();
+        push(&pool, &row("Song", 42, Service::LastFm))
+            .await
+            .unwrap();
+
+        let all_rows = all(&pool).await.unwrap();
+        assert_eq!(all_rows.len(), 2);
+
+        delete(&pool, 42, "Artist", "Song", Service::LastFm)
+            .await
+            .unwrap();
+        let rest = all(&pool).await.unwrap();
+        assert_eq!(rest.len(), 1);
+        assert_eq!(rest[0].service, Service::ListenBrainz);
+        assert_eq!(
+            rest[0].listen_info.as_deref(),
+            Some(r#"{"duration_ms":180000}"#)
+        );
+    }
+}

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -13,6 +13,8 @@ use std::sync::Arc;
 
 mod backend;
 
+pub use backend::{QueuedScrobbleRow, ScrobbleService};
+
 /// What a one-shot legacy-JSON import did. `ran == false` means it was skipped
 /// (already migrated, or no legacy JSON present); the counts are then all zero.
 #[derive(Debug, Default, Clone)]
@@ -29,62 +31,6 @@ pub struct ImportReport {
 // single type-safe representation of "which source"; re-exported here since the
 // DB layer is its main consumer (`WHERE source = ?`).
 pub use config::Source;
-
-/// A scrobble destination (issue #335). Defined here because `db` owns the
-/// offline-queue table this indexes; `kopuz-scrobble` re-exports it so the
-/// Last.fm/Libre.fm/ListenBrainz backends and the queue share one enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Service {
-    LastFm,
-    LibreFm,
-    ListenBrainz,
-}
-
-impl Service {
-    /// Human-facing name for logs and UI.
-    pub fn label(self) -> &'static str {
-        match self {
-            Service::LastFm => "Last.fm",
-            Service::LibreFm => "Libre.fm",
-            Service::ListenBrainz => "ListenBrainz",
-        }
-    }
-
-    /// Stable lowercase tag stored in the `service` column. Keep in sync with
-    /// [`Service::from_tag`].
-    pub fn as_tag(self) -> &'static str {
-        match self {
-            Service::LastFm => "lastfm",
-            Service::LibreFm => "librefm",
-            Service::ListenBrainz => "listenbrainz",
-        }
-    }
-
-    /// Inverse of [`Service::as_tag`]; an unknown tag (a service renamed or
-    /// removed since the row was written) yields `None`.
-    pub fn from_tag(tag: &str) -> Option<Self> {
-        match tag {
-            "lastfm" => Some(Service::LastFm),
-            "librefm" => Some(Service::LibreFm),
-            "listenbrainz" => Some(Service::ListenBrainz),
-            _ => None,
-        }
-    }
-}
-
-/// One queued offline scrobble owed to a single service (issue #335). A listen
-/// owed to N services is N rows sharing `(listened_at, artist, title)`.
-/// `listen_info` is the raw ListenBrainz additional-info JSON, `None` otherwise.
-/// The retry orchestration lives in `kopuz-scrobble` — this crate only persists.
-#[derive(Clone, Debug)]
-pub struct QueuedScrobbleRow {
-    pub listened_at: i64,
-    pub artist: String,
-    pub title: String,
-    pub album: Option<String>,
-    pub service: Service,
-    pub listen_info: Option<String>,
-}
 
 /// A window into a list query (for virtual-scrolled big lists).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -475,7 +421,7 @@ pub trait Storage: ReadStore {
         listened_at: i64,
         artist: &str,
         title: &str,
-        service: Service,
+        service: ScrobbleService,
     ) -> Result<(), DbError>;
 
     /// Generic metadata-cache write (upsert of `payload` for `(cache_key, kind)`).

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -30,6 +30,62 @@ pub struct ImportReport {
 // DB layer is its main consumer (`WHERE source = ?`).
 pub use config::Source;
 
+/// A scrobble destination (issue #335). Defined here because `db` owns the
+/// offline-queue table this indexes; `kopuz-scrobble` re-exports it so the
+/// Last.fm/Libre.fm/ListenBrainz backends and the queue share one enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Service {
+    LastFm,
+    LibreFm,
+    ListenBrainz,
+}
+
+impl Service {
+    /// Human-facing name for logs and UI.
+    pub fn label(self) -> &'static str {
+        match self {
+            Service::LastFm => "Last.fm",
+            Service::LibreFm => "Libre.fm",
+            Service::ListenBrainz => "ListenBrainz",
+        }
+    }
+
+    /// Stable lowercase tag stored in the `service` column. Keep in sync with
+    /// [`Service::from_tag`].
+    pub fn as_tag(self) -> &'static str {
+        match self {
+            Service::LastFm => "lastfm",
+            Service::LibreFm => "librefm",
+            Service::ListenBrainz => "listenbrainz",
+        }
+    }
+
+    /// Inverse of [`Service::as_tag`]; an unknown tag (a service renamed or
+    /// removed since the row was written) yields `None`.
+    pub fn from_tag(tag: &str) -> Option<Self> {
+        match tag {
+            "lastfm" => Some(Service::LastFm),
+            "librefm" => Some(Service::LibreFm),
+            "listenbrainz" => Some(Service::ListenBrainz),
+            _ => None,
+        }
+    }
+}
+
+/// One queued offline scrobble owed to a single service (issue #335). A listen
+/// owed to N services is N rows sharing `(listened_at, artist, title)`.
+/// `listen_info` is the raw ListenBrainz additional-info JSON, `None` otherwise.
+/// The retry orchestration lives in `kopuz-scrobble` — this crate only persists.
+#[derive(Clone, Debug)]
+pub struct QueuedScrobbleRow {
+    pub listened_at: i64,
+    pub artist: String,
+    pub title: String,
+    pub album: Option<String>,
+    pub service: Service,
+    pub listen_info: Option<String>,
+}
+
 /// A window into a list query (for virtual-scrolled big lists).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Page {
@@ -253,6 +309,9 @@ pub trait ReadStore: Send + Sync {
 
     /// Pending-unlike tombstones (`dirty=2`) not yet pushed to the server.
     async fn dirty_unlikes(&self, server_id: &str) -> Result<Vec<String>, DbError>;
+
+    /// The whole offline scrobble backlog, oldest listen first (drain order).
+    async fn scrobble_queue_all(&self) -> Result<Vec<QueuedScrobbleRow>, DbError>;
 }
 
 /// The persistence API: every mutation plus admin/dev ops, layered on top of the
@@ -404,6 +463,20 @@ pub trait Storage: ReadStore {
 
     /// Persist the queue/progress snapshot to the single `queue_state` row.
     async fn save_queue(&self, snap: &QueueSnapshot) -> Result<(), DbError>;
+
+    /// Enqueue a failed scrobble (issue #335). A repeat of the same
+    /// `(listen, service)` folds into the existing row; the backlog is capped to
+    /// the newest listens, dropping the oldest first.
+    async fn scrobble_queue_push(&self, row: &QueuedScrobbleRow) -> Result<(), DbError>;
+
+    /// Drop one delivered (or permanently-failed) `(listen, service)` row.
+    async fn scrobble_queue_delete(
+        &self,
+        listened_at: i64,
+        artist: &str,
+        title: &str,
+        service: Service,
+    ) -> Result<(), DbError>;
 
     /// Generic metadata-cache write (upsert of `payload` for `(cache_key, kind)`).
     async fn meta_put(&self, cache_key: &str, kind: &str, payload: &str) -> Result<(), DbError>;

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -188,7 +188,7 @@ pub fn schedule(
                         if scrobble::queue::is_transient(&error) {
                             scrobble::queue::enqueue(
                                 &db,
-                                scrobble::queue::Service::LastFm,
+                                scrobble::queue::ScrobbleService::LastFm,
                                 &track.artist,
                                 &track.title,
                                 Some(&track.album),
@@ -225,7 +225,7 @@ pub fn schedule(
                         if scrobble::queue::is_transient(&error) {
                             scrobble::queue::enqueue(
                                 &db,
-                                scrobble::queue::Service::LibreFm,
+                                scrobble::queue::ScrobbleService::LibreFm,
                                 &track.artist,
                                 &track.title,
                                 Some(&track.album),
@@ -262,7 +262,7 @@ pub fn schedule(
                         if scrobble::queue::is_transient(&error) {
                             scrobble::queue::enqueue(
                                 &db,
-                                scrobble::queue::Service::ListenBrainz,
+                                scrobble::queue::ScrobbleService::ListenBrainz,
                                 &track.artist,
                                 &track.title,
                                 Some(&track.album),

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -32,6 +32,7 @@ impl ScrobbleOptions {
     };
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn schedule(
     track: Track,
     item_id: Option<String>,
@@ -41,6 +42,7 @@ pub fn schedule(
     is_playing: Signal<bool>,
     active_source: Option<Signal<::server::source::ActiveSource>>,
     options: ScrobbleOptions,
+    db: db::Db,
 ) {
     let duration_secs = track.duration;
     let threshold_secs = std::cmp::min(240, duration_secs / 2);
@@ -160,7 +162,6 @@ pub fn schedule(
             // a transient error are queued with the original listen timestamp
             // (`started_at`) and resubmitted later; one success means we're
             // online, so drain the backlog.
-            let queue_path = scrobble::queue::default_queue_path();
             let mut scrobble_ok = false;
 
             if has_lastfm {
@@ -184,11 +185,9 @@ pub fn schedule(
                     }
                     Err(error) => {
                         tracing::warn!("Last.fm scrobble failed: {}", error);
-                        if scrobble::queue::is_transient(&error)
-                            && let Some(qp) = &queue_path
-                        {
+                        if scrobble::queue::is_transient(&error) {
                             scrobble::queue::enqueue(
-                                qp,
+                                &db,
                                 scrobble::queue::Service::LastFm,
                                 &track.artist,
                                 &track.title,
@@ -223,11 +222,9 @@ pub fn schedule(
                     }
                     Err(error) => {
                         tracing::warn!("Libre.fm scrobble failed: {}", error);
-                        if scrobble::queue::is_transient(&error)
-                            && let Some(qp) = &queue_path
-                        {
+                        if scrobble::queue::is_transient(&error) {
                             scrobble::queue::enqueue(
-                                qp,
+                                &db,
                                 scrobble::queue::Service::LibreFm,
                                 &track.artist,
                                 &track.title,
@@ -262,11 +259,9 @@ pub fn schedule(
                     }
                     Err(error) => {
                         tracing::warn!("MusicBrainz scrobble failed: {}", error);
-                        if scrobble::queue::is_transient(&error)
-                            && let Some(qp) = &queue_path
-                        {
+                        if scrobble::queue::is_transient(&error) {
                             scrobble::queue::enqueue(
-                                qp,
+                                &db,
                                 scrobble::queue::Service::ListenBrainz,
                                 &track.artist,
                                 &track.title,
@@ -281,7 +276,7 @@ pub fn schedule(
             }
 
             // One success means we're online again: flush queued scrobbles.
-            if scrobble_ok && let Some(qp) = &queue_path {
+            if scrobble_ok {
                 let musicbrainz_token = config.read().musicbrainz_token.clone();
                 let creds = scrobble::queue::Credentials {
                     lastfm: has_lastfm.then(|| {
@@ -295,7 +290,7 @@ pub fn schedule(
                     listenbrainz_token: (!musicbrainz_token.trim().is_empty())
                         .then(|| musicbrainz_token.clone()),
                 };
-                scrobble::queue::drain(qp, &creds).await;
+                scrobble::queue::drain(&db, &creds).await;
             }
         }
         .instrument(span),

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -275,7 +275,7 @@ pub fn schedule(
 
             // One success means we're online again: flush queued scrobbles.
             if scrobble_ok && let Some(qp) = &queue_path {
-                let cfg = config.read();
+                let musicbrainz_token = config.read().musicbrainz_token.clone();
                 let creds = scrobble::queue::Credentials {
                     lastfm: has_lastfm.then(|| {
                         (
@@ -285,10 +285,9 @@ pub fn schedule(
                         )
                     }),
                     librefm_session_key: has_librefm.then(|| librefm_session_key.clone()),
-                    listenbrainz_token: (!cfg.musicbrainz_token.trim().is_empty())
-                        .then(|| cfg.musicbrainz_token.clone()),
+                    listenbrainz_token: (!musicbrainz_token.trim().is_empty())
+                        .then(|| musicbrainz_token.clone()),
                 };
-                drop(cfg);
                 scrobble::queue::drain(qp, &creds).await;
             }
         }

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -156,11 +156,19 @@ pub fn schedule(
                 }
             }
 
+            // Offline queue bookkeeping (issue #335): scrobbles that fail with
+            // a transient error are queued with the original listen timestamp
+            // (`started_at`) and resubmitted later; one success means we're
+            // online, so drain the backlog.
+            let queue_path = scrobble::queue::default_queue_path();
+            let mut scrobble_ok = false;
+
             if has_lastfm {
-                let scrobble = scrobble::lastfm::make_scrobble(
+                let scrobble = scrobble::lastfm::make_scrobble_at(
                     &track.artist,
                     &track.title,
                     Some(&track.album),
+                    started_at,
                 );
                 match scrobble::lastfm::submit_scrobble(
                     &lastfm_api_key,
@@ -171,17 +179,34 @@ pub fn schedule(
                 .await
                 {
                     Ok(_) => {
+                        scrobble_ok = true;
                         tracing::info!("Last.fm scrobbled: {} - {}", track.artist, track.title)
                     }
-                    Err(error) => tracing::warn!("Last.fm scrobble failed: {}", error),
+                    Err(error) => {
+                        tracing::warn!("Last.fm scrobble failed: {}", error);
+                        if scrobble::queue::is_transient(&error)
+                            && let Some(qp) = &queue_path
+                        {
+                            scrobble::queue::enqueue(
+                                qp,
+                                scrobble::queue::Service::LastFm,
+                                &track.artist,
+                                &track.title,
+                                Some(&track.album),
+                                started_at,
+                            )
+                            .await;
+                        }
+                    }
                 }
             }
 
             if has_librefm {
-                let scrobble = scrobble::librefm::make_scrobble(
+                let scrobble = scrobble::librefm::make_scrobble_at(
                     &track.artist,
                     &track.title,
                     Some(&track.album),
+                    started_at,
                 );
                 match scrobble::librefm::submit_scrobble(
                     scrobble::librefm::API_KEY,
@@ -192,9 +217,25 @@ pub fn schedule(
                 .await
                 {
                     Ok(_) => {
+                        scrobble_ok = true;
                         tracing::info!("Libre.fm scrobbled: {} - {}", track.artist, track.title)
                     }
-                    Err(error) => tracing::warn!("Libre.fm scrobble failed: {}", error),
+                    Err(error) => {
+                        tracing::warn!("Libre.fm scrobble failed: {}", error);
+                        if scrobble::queue::is_transient(&error)
+                            && let Some(qp) = &queue_path
+                        {
+                            scrobble::queue::enqueue(
+                                qp,
+                                scrobble::queue::Service::LibreFm,
+                                &track.artist,
+                                &track.title,
+                                Some(&track.album),
+                                started_at,
+                            )
+                            .await;
+                        }
+                    }
                 }
             }
 
@@ -210,10 +251,45 @@ pub fn schedule(
                 );
                 match scrobble::musicbrainz::submit_listens(&token, vec![listen], "single").await {
                     Ok(_) => {
+                        scrobble_ok = true;
                         tracing::info!("MusicBrainz scrobbled: {} - {}", track.artist, track.title)
                     }
-                    Err(error) => tracing::warn!("MusicBrainz scrobble failed: {}", error),
+                    Err(error) => {
+                        tracing::warn!("MusicBrainz scrobble failed: {}", error);
+                        if scrobble::queue::is_transient(&error)
+                            && let Some(qp) = &queue_path
+                        {
+                            scrobble::queue::enqueue(
+                                qp,
+                                scrobble::queue::Service::ListenBrainz,
+                                &track.artist,
+                                &track.title,
+                                Some(&track.album),
+                                started_at,
+                            )
+                            .await;
+                        }
+                    }
                 }
+            }
+
+            // One success means we're online again: flush queued scrobbles.
+            if scrobble_ok && let Some(qp) = &queue_path {
+                let cfg = config.read();
+                let creds = scrobble::queue::Credentials {
+                    lastfm: has_lastfm.then(|| {
+                        (
+                            lastfm_api_key.clone(),
+                            lastfm_api_secret.clone(),
+                            lastfm_session_key.clone(),
+                        )
+                    }),
+                    librefm_session_key: has_librefm.then(|| librefm_session_key.clone()),
+                    listenbrainz_token: (!cfg.musicbrainz_token.trim().is_empty())
+                        .then(|| cfg.musicbrainz_token.clone()),
+                };
+                drop(cfg);
+                scrobble::queue::drain(qp, &creds).await;
             }
         }
         .instrument(span),

--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -194,6 +194,7 @@ pub fn schedule(
                                 &track.title,
                                 Some(&track.album),
                                 started_at,
+                                None,
                             )
                             .await;
                         }
@@ -232,6 +233,7 @@ pub fn schedule(
                                 &track.title,
                                 Some(&track.album),
                                 started_at,
+                                None,
                             )
                             .await;
                         }
@@ -242,6 +244,10 @@ pub fn schedule(
             let token = config.read().musicbrainz_token.clone();
             if !token.trim().is_empty() {
                 let info = listen_additional_info(&track, options.include_musicbrainz_ids);
+                let queued_info: serde_json::Map<String, serde_json::Value> = info
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), v.clone()))
+                    .collect();
                 let listen = scrobble::musicbrainz::make_listen(
                     &track.artist,
                     &track.title,
@@ -266,6 +272,7 @@ pub fn schedule(
                                 &track.title,
                                 Some(&track.album),
                                 started_at,
+                                Some(queued_info),
                             )
                             .await;
                         }

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -1020,6 +1020,33 @@ pub fn use_player_controller(
     let db = use_signal(move || db_handle);
     let active_source = use_context::<Signal<::server::source::ActiveSource>>();
 
+    // Scrobbles queued while offline (issue #335): retry once on startup, in
+    // case connectivity came back between sessions.
+    use_future(move || async move {
+        let Some(queue_path) = scrobble::queue::default_queue_path() else {
+            return;
+        };
+        let creds = {
+            let cfg = config.peek();
+            scrobble::queue::Credentials {
+                lastfm: (!cfg.lastfm_api_key.is_empty() && !cfg.lastfm_api_secret.is_empty()).then(
+                    || {
+                        (
+                            cfg.lastfm_api_key.clone(),
+                            cfg.lastfm_api_secret.clone(),
+                            cfg.lastfm_session_key.clone(),
+                        )
+                    },
+                ),
+                librefm_session_key: (!cfg.librefm_session_key.is_empty())
+                    .then(|| cfg.librefm_session_key.clone()),
+                listenbrainz_token: (!cfg.musicbrainz_token.trim().is_empty())
+                    .then(|| cfg.musicbrainz_token.clone()),
+            }
+        };
+        scrobble::queue::drain(&queue_path, &creds).await;
+    });
+
     PlayerController {
         player,
         is_playing,

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -595,6 +595,7 @@ impl PlayerController {
                     let mut pending_resume = self.pending_resume;
                     let cfg_signal = self.config;
                     let active_source = self.active_source;
+                    let db = self.db;
                     let mut radio_task = self.radio_task;
                     let mut current_song_title = self.current_song_title;
                     let mut current_song_artist = self.current_song_artist;
@@ -869,6 +870,7 @@ impl PlayerController {
                                         is_playing,
                                         Some(active_source),
                                         ScrobbleOptions::REMOTE_NATIVE,
+                                        db.peek().clone(),
                                     );
 
                                     let cover_url = cover_url.clone();
@@ -977,6 +979,7 @@ impl PlayerController {
                                 self.is_playing,
                                 None,
                                 ScrobbleOptions::LOCAL,
+                                self.db.peek().clone(),
                             );
                         }
                     }
@@ -1047,11 +1050,9 @@ pub fn use_player_controller(
                     .then(|| cfg.musicbrainz_token.clone()),
             }
         };
+        let db_handle = db.peek().clone();
         spawn(async move {
-            let Some(queue_path) = scrobble::queue::default_queue_path() else {
-                return;
-            };
-            scrobble::queue::drain(&queue_path, &creds).await;
+            scrobble::queue::drain(&db_handle, &creds).await;
         });
     });
 

--- a/crates/hooks/src/use_player_controller.rs
+++ b/crates/hooks/src/use_player_controller.rs
@@ -1003,6 +1003,7 @@ pub fn use_player_controller(
     current_track_snapshot: Signal<Option<Track>>,
     volume: Signal<f32>,
     config: Signal<AppConfig>,
+    config_loaded_ok: Signal<bool>,
     db_handle: db::Db,
 ) -> PlayerController {
     let play_generation = use_signal(|| 0);
@@ -1022,10 +1023,12 @@ pub fn use_player_controller(
 
     // Scrobbles queued while offline (issue #335): retry once on startup, in
     // case connectivity came back between sessions.
-    use_future(move || async move {
-        let Some(queue_path) = scrobble::queue::default_queue_path() else {
+    let mut drained = use_signal(|| false);
+    use_effect(move || {
+        if !*config_loaded_ok.read() || *drained.peek() {
             return;
-        };
+        }
+        drained.set(true);
         let creds = {
             let cfg = config.peek();
             scrobble::queue::Credentials {
@@ -1044,7 +1047,12 @@ pub fn use_player_controller(
                     .then(|| cfg.musicbrainz_token.clone()),
             }
         };
-        scrobble::queue::drain(&queue_path, &creds).await;
+        spawn(async move {
+            let Some(queue_path) = scrobble::queue::default_queue_path() else {
+                return;
+            };
+            scrobble::queue::drain(&queue_path, &creds).await;
+        });
     });
 
     PlayerController {

--- a/crates/kopuz/src/main.rs
+++ b/crates/kopuz/src/main.rs
@@ -682,6 +682,7 @@ fn App() -> Element {
         current_track_snapshot,
         volume,
         config,
+        config_loaded_ok,
         db.clone(),
     );
 

--- a/crates/player/src/systemint/macos.rs
+++ b/crates/player/src/systemint/macos.rs
@@ -87,18 +87,20 @@ pub enum SystemEvent {
     Prev,
 }
 
-static BACKGROUND_HANDLER: OnceLock<Arc<StdMutex<Option<Box<dyn Fn(SystemEvent) + Send + Sync>>>>> =
-    OnceLock::new();
+type BgHandler = Arc<StdMutex<Option<Box<dyn Fn(SystemEvent) + Send + Sync>>>>;
+type TokioWaker = Arc<StdMutex<Option<Box<dyn Fn() + Send + Sync>>>>;
 
-static TOKIO_WAKER: OnceLock<Arc<StdMutex<Option<Box<dyn Fn() + Send + Sync>>>>> = OnceLock::new();
+static BACKGROUND_HANDLER: OnceLock<BgHandler> = OnceLock::new();
 
-fn get_bg_handler() -> Arc<StdMutex<Option<Box<dyn Fn(SystemEvent) + Send + Sync>>>> {
+static TOKIO_WAKER: OnceLock<TokioWaker> = OnceLock::new();
+
+fn get_bg_handler() -> BgHandler {
     BACKGROUND_HANDLER
         .get_or_init(|| Arc::new(StdMutex::new(None)))
         .clone()
 }
 
-fn get_tokio_waker() -> Arc<StdMutex<Option<Box<dyn Fn() + Send + Sync>>>> {
+fn get_tokio_waker() -> TokioWaker {
     TOKIO_WAKER
         .get_or_init(|| Arc::new(StdMutex::new(None)))
         .clone()
@@ -111,10 +113,10 @@ pub fn set_tokio_waker(waker: impl Fn() + Send + Sync + 'static) {
 }
 
 fn wake_tokio() {
-    if let Ok(guard) = get_tokio_waker().lock() {
-        if let Some(ref waker) = *guard {
-            waker();
-        }
+    if let Ok(guard) = get_tokio_waker().lock()
+        && let Some(ref waker) = *guard
+    {
+        waker();
     }
 }
 
@@ -125,10 +127,10 @@ pub fn set_background_handler(handler: impl Fn(SystemEvent) + Send + Sync + 'sta
 }
 
 fn dispatch_event(event: SystemEvent) {
-    if let Ok(guard) = get_bg_handler().lock() {
-        if let Some(ref handler) = *guard {
-            handler(event);
-        }
+    if let Ok(guard) = get_bg_handler().lock()
+        && let Some(ref handler) = *guard
+    {
+        handler(event);
     }
     wake_run_loop();
 }
@@ -186,13 +188,9 @@ pub fn init() {
             let assertion_reason = NSString::from_str("Kopuz is playing audio");
             let mut assertion_id: IOPMAssertionID = 0;
             let kr = IOPMAssertionCreateWithName(
-                std::mem::transmute::<&objc2_foundation::NSString, *const std::ffi::c_void>(
-                    &*assertion_type,
-                ),
+                &*assertion_type as *const objc2_foundation::NSString as *const std::ffi::c_void,
                 255,
-                std::mem::transmute::<&objc2_foundation::NSString, *const std::ffi::c_void>(
-                    &*assertion_reason,
-                ),
+                &*assertion_reason as *const objc2_foundation::NSString as *const std::ffi::c_void,
                 &mut assertion_id,
             );
             if kr == 0 {
@@ -357,8 +355,9 @@ pub fn update_now_playing(
                     let retained: objc2::rc::Retained<MPMediaItemArtwork> =
                         objc2::rc::Retained::from_raw(artwork_raw).expect("retained artwork");
 
-                    let artwork_ref: &AnyObject =
-                        &*(std::mem::transmute::<_, *const AnyObject>(&*retained));
+                    let artwork_ref: &AnyObject = &*(&*retained
+                        as *const objc2_media_player::MPMediaItemArtwork
+                        as *const AnyObject);
                     info.setObject_forKey(
                         artwork_ref,
                         ProtocolObject::from_ref(MPMediaItemPropertyArtwork),

--- a/crates/scrobble/Cargo.toml
+++ b/crates/scrobble/Cargo.toml
@@ -20,8 +20,8 @@ md5 = { workspace = true }
 tracing = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 config.workspace = true
+db.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 dioxus.workspace = true
-directories = { workspace = true }

--- a/crates/scrobble/Cargo.toml
+++ b/crates/scrobble/Cargo.toml
@@ -24,3 +24,4 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 dioxus.workspace = true
+directories = { workspace = true }

--- a/crates/scrobble/src/lastfm.rs
+++ b/crates/scrobble/src/lastfm.rs
@@ -221,8 +221,19 @@ pub fn make_scrobble<'a>(
         .unwrap_or_default()
         .as_secs() as i64;
 
+    make_scrobble_at(artist, track, release, now_unix)
+}
+
+/// Like [`make_scrobble`], but with an explicit listen timestamp. Used when
+/// resubmitting queued offline scrobbles so they keep their original time.
+pub fn make_scrobble_at<'a>(
+    artist: &'a str,
+    track: &'a str,
+    release: Option<&'a str>,
+    timestamp: i64,
+) -> Scrobble<'a> {
     Scrobble {
-        timestamp: now_unix,
+        timestamp,
         track_metadata: TrackMetadata {
             artist_name: artist,
             track_name: track,

--- a/crates/scrobble/src/lib.rs
+++ b/crates/scrobble/src/lib.rs
@@ -5,3 +5,8 @@ pub mod lastfm;
 pub mod librefm;
 pub mod musicbrainz;
 pub mod queue;
+
+// The scrobble destination enum is defined in `kopuz-db` (which owns the
+// offline-queue table it indexes); re-exported here so the backends and queue
+// share one type.
+pub use db::Service;

--- a/crates/scrobble/src/lib.rs
+++ b/crates/scrobble/src/lib.rs
@@ -4,3 +4,4 @@
 pub mod lastfm;
 pub mod librefm;
 pub mod musicbrainz;
+pub mod queue;

--- a/crates/scrobble/src/lib.rs
+++ b/crates/scrobble/src/lib.rs
@@ -9,4 +9,4 @@ pub mod queue;
 // The scrobble destination enum is defined in `kopuz-db` (which owns the
 // offline-queue table it indexes); re-exported here so the backends and queue
 // share one type.
-pub use db::Service;
+pub use db::ScrobbleService;

--- a/crates/scrobble/src/librefm.rs
+++ b/crates/scrobble/src/librefm.rs
@@ -227,8 +227,19 @@ pub fn make_scrobble<'a>(
         .unwrap_or_default()
         .as_secs() as i64;
 
+    make_scrobble_at(artist, track, release, now_unix)
+}
+
+/// Like [`make_scrobble`], but with an explicit listen timestamp. Used when
+/// resubmitting queued offline scrobbles so they keep their original time.
+pub fn make_scrobble_at<'a>(
+    artist: &'a str,
+    track: &'a str,
+    release: Option<&'a str>,
+    timestamp: i64,
+) -> Scrobble<'a> {
     Scrobble {
-        timestamp: now_unix,
+        timestamp,
         track_metadata: TrackMetadata {
             artist_name: artist,
             track_name: track,

--- a/crates/scrobble/src/queue.rs
+++ b/crates/scrobble/src/queue.rs
@@ -6,97 +6,17 @@
 //! `track.scrobble` takes a `timestamp`, ListenBrainz takes `listened_at`.
 //! Permanent failures (4xx, e.g. bad credentials) are never queued, retrying
 //! them can't succeed.
+//!
+//! Persistence lives in `kopuz-db` (the `scrobble_queue` table); this module
+//! is the retry orchestration on top of it. One listen owed to several services
+//! is several rows sharing a timestamp, so delivering one service never blocks
+//! the others.
 
 use crate::{lastfm, librefm, musicbrainz};
-use serde::{Deserialize, Serialize};
+use db::{Db, QueuedScrobbleRow};
 use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use tokio::sync::Mutex;
 
-/// Queue size cap; the oldest entries are dropped first.
-const MAX_QUEUED: usize = 500;
-
-/// Serializes all queue file access so two finished tracks can't race on the
-/// load-modify-save cycle.
-static QUEUE_LOCK: Mutex<()> = Mutex::const_new(());
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Service {
-    LastFm,
-    LibreFm,
-    ListenBrainz,
-}
-
-impl Service {
-    pub fn label(self) -> &'static str {
-        match self {
-            Service::LastFm => "Last.fm",
-            Service::LibreFm => "Libre.fm",
-            Service::ListenBrainz => "ListenBrainz",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueuedScrobble {
-    pub artist: String,
-    pub title: String,
-    pub album: Option<String>,
-    /// Unix timestamp of the original listen.
-    pub timestamp: i64,
-    /// Services this scrobble is still owed to.
-    pub pending: Vec<Service>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub listen_info: Option<serde_json::Map<String, serde_json::Value>>,
-}
-
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct ScrobbleQueue {
-    pub items: Vec<QueuedScrobble>,
-}
-
-impl ScrobbleQueue {
-    /// Load the queue; a missing or unreadable file is an empty queue
-    /// (same forgiving pattern as the app config).
-    pub fn load(path: &Path) -> Self {
-        std::fs::read_to_string(path)
-            .ok()
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_default()
-    }
-
-    /// Write-to-temp-then-rename so an interrupted write can't leave a
-    /// truncated file behind; `load` treats corrupt JSON as an empty queue,
-    /// which would silently drop the whole backlog.
-    pub fn save(&self, path: &Path) -> Result<(), String> {
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
-        }
-        let json = serde_json::to_string(self).map_err(|e| e.to_string())?;
-        let tmp = path.with_extension("json.tmp");
-        std::fs::write(&tmp, json).map_err(|e| e.to_string())?;
-        std::fs::rename(&tmp, path).map_err(|e| e.to_string())
-    }
-
-    /// Append a scrobble, dropping the oldest entries beyond the cap.
-    pub fn push(&mut self, item: QueuedScrobble) {
-        self.items.push(item);
-        if self.items.len() > MAX_QUEUED {
-            let overflow = self.items.len() - MAX_QUEUED;
-            self.items.drain(..overflow);
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.items.is_empty()
-    }
-}
-
-/// Default queue location, next to config.json.
-pub fn default_queue_path() -> Option<PathBuf> {
-    directories::ProjectDirs::from("com", "temidaradev", "kopuz")
-        .map(|dirs| dirs.config_dir().join("scrobble_queue.json"))
-}
+pub use db::Service;
 
 /// Whether a failed request is worth retrying later: no response at all
 /// (offline, DNS, timeout) or a server-side 5xx. A 4xx means the server
@@ -118,11 +38,11 @@ pub struct Credentials {
     pub listenbrainz_token: Option<String>,
 }
 
-/// Enqueue a failed scrobble for the given service, merging with an existing
-/// entry for the same listen so one track failing on two services stays one
-/// queue item with two pending services.
+/// Enqueue a failed scrobble for the given service. A repeat of the same listen
+/// on the same service folds into the existing row (see `scrobble_queue_push`),
+/// so one track failing on two services is two rows, one per service.
 pub async fn enqueue(
-    path: &Path,
+    db: &Db,
     service: Service,
     artist: &str,
     title: &str,
@@ -130,32 +50,17 @@ pub async fn enqueue(
     timestamp: i64,
     listen_info: Option<serde_json::Map<String, serde_json::Value>>,
 ) {
-    let _guard = QUEUE_LOCK.lock().await;
-    let mut queue = ScrobbleQueue::load(path);
+    let listen_info = listen_info.and_then(|m| serde_json::to_string(&m).ok());
+    let row = QueuedScrobbleRow {
+        listened_at: timestamp,
+        artist: artist.to_string(),
+        title: title.to_string(),
+        album: album.map(str::to_string),
+        service,
+        listen_info,
+    };
 
-    if let Some(existing) = queue
-        .items
-        .iter_mut()
-        .find(|i| i.timestamp == timestamp && i.artist == artist && i.title == title)
-    {
-        if !existing.pending.contains(&service) {
-            existing.pending.push(service);
-        }
-        if listen_info.is_some() {
-            existing.listen_info = listen_info;
-        }
-    } else {
-        queue.push(QueuedScrobble {
-            artist: artist.to_string(),
-            title: title.to_string(),
-            album: album.map(|s| s.to_string()),
-            timestamp,
-            pending: vec![service],
-            listen_info,
-        });
-    }
-
-    if let Err(e) = queue.save(path) {
+    if let Err(e) = db.scrobble_queue_push(&row).await {
         tracing::warn!(error = %e, "failed to persist scrobble queue");
     } else {
         tracing::info!(
@@ -169,76 +74,64 @@ pub async fn enqueue(
 
 /// Resubmit queued scrobbles. Per service, the first transient failure skips
 /// that service for the rest of this run (still unreachable); a permanent
-/// failure drops the service from that entry. Progress is checkpointed to
-/// disk after every entry, so an interrupted drain re-sends at most the one
-/// in-flight item instead of replaying everything already delivered.
-///
-/// The mutex is held only around file I/O; network submissions run outside
-/// the lock so concurrent `enqueue()` calls are never blocked by the wire.
-/// Each checkpoint re-loads the on-disk queue and merges progress into it,
-/// preserving any entries added by `enqueue()` while drain was in flight.
-pub async fn drain(path: &Path, creds: &Credentials) {
-    let queue = {
-        let _guard = QUEUE_LOCK.lock().await;
-        ScrobbleQueue::load(path)
+/// failure drops the row. Each delivered row is removed immediately, so an
+/// interrupted drain re-sends at most the one in-flight item instead of
+/// replaying everything already delivered — and `enqueue()` calls that arrive
+/// mid-drain simply insert new rows the current pass won't touch.
+pub async fn drain(db: &Db, creds: &Credentials) {
+    let rows = match db.scrobble_queue_all().await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to load scrobble queue");
+            return;
+        }
     };
-    if queue.is_empty() {
+    if rows.is_empty() {
         return;
     }
-    tracing::info!("draining scrobble queue ({} items)", queue.items.len());
+    tracing::info!("draining scrobble queue ({} items)", rows.len());
 
     let mut give_up: Vec<Service> = Vec::new();
 
-    for item in &queue.items {
-        let mut done: Vec<Service> = Vec::new();
-        for &service in &item.pending {
-            if give_up.contains(&service) {
-                continue;
-            }
-            match submit_one(service, item, creds).await {
-                Outcome::Sent => {
-                    tracing::info!(
-                        service = service.label(),
-                        "resubmitted queued scrobble: {} - {}",
-                        item.artist,
-                        item.title
-                    );
-                    done.push(service);
-                }
-                Outcome::NoCredentials => {
-                    // Not configured (anymore); nothing to deliver to.
-                    done.push(service);
-                }
-                Outcome::Transient => {
-                    give_up.push(service);
-                }
-                Outcome::Permanent(e) => {
-                    tracing::warn!(
-                        service = service.label(),
-                        error = %e,
-                        "dropping queued scrobble after permanent error: {} - {}",
-                        item.artist,
-                        item.title
-                    );
-                    done.push(service);
-                }
-            }
+    for row in &rows {
+        let service = row.service;
+        if give_up.contains(&service) {
+            continue;
         }
-        if !done.is_empty() {
-            // Re-acquire the lock only for the checkpoint write. Reload the
-            // on-disk queue to merge any enqueue() calls that arrived while
-            // we were on the wire, then remove the services we just delivered.
-            let _guard = QUEUE_LOCK.lock().await;
-            let mut on_disk = ScrobbleQueue::load(path);
-            if let Some(disk_item) = on_disk.items.iter_mut().find(|i| {
-                i.timestamp == item.timestamp && i.artist == item.artist && i.title == item.title
-            }) {
-                disk_item.pending.retain(|s| !done.contains(s));
+
+        let delivered = match submit_one(service, row, creds).await {
+            Outcome::Sent => {
+                tracing::info!(
+                    service = service.label(),
+                    "resubmitted queued scrobble: {} - {}",
+                    row.artist,
+                    row.title
+                );
+                true
             }
-            on_disk.items.retain(|i| !i.pending.is_empty());
-            if let Err(e) = on_disk.save(path) {
-                tracing::warn!(error = %e, "failed to checkpoint scrobble queue");
+            Outcome::NoCredentials => true,
+            Outcome::Transient => {
+                give_up.push(service);
+                false
             }
+            Outcome::Permanent(e) => {
+                tracing::warn!(
+                    service = service.label(),
+                    error = %e,
+                    "dropping queued scrobble after permanent error: {} - {}",
+                    row.artist,
+                    row.title
+                );
+                true
+            }
+        };
+
+        if delivered
+            && let Err(e) = db
+                .scrobble_queue_delete(row.listened_at, &row.artist, &row.title, service)
+                .await
+        {
+            tracing::warn!(error = %e, "failed to checkpoint scrobble queue");
         }
     }
 }
@@ -250,7 +143,7 @@ enum Outcome {
     NoCredentials,
 }
 
-async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials) -> Outcome {
+async fn submit_one(service: Service, item: &QueuedScrobbleRow, creds: &Credentials) -> Outcome {
     let album = item.album.as_deref();
     let result = match service {
         Service::LastFm => {
@@ -258,7 +151,7 @@ async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials
                 return Outcome::NoCredentials;
             };
             let scrobble =
-                lastfm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
+                lastfm::make_scrobble_at(&item.artist, &item.title, album, item.listened_at);
             lastfm::submit_scrobble(key, secret, session, &scrobble)
                 .await
                 .map(|_| ())
@@ -268,7 +161,7 @@ async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials
                 return Outcome::NoCredentials;
             };
             let scrobble =
-                librefm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
+                librefm::make_scrobble_at(&item.artist, &item.title, album, item.listened_at);
             librefm::submit_scrobble(librefm::API_KEY, librefm::API_SECRET, session, &scrobble)
                 .await
                 .map(|_| ())
@@ -282,12 +175,15 @@ async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials
             } else {
                 format!("Token {token}")
             };
-            let info: Option<HashMap<&str, serde_json::Value>> = item
+            let parsed: Option<serde_json::Map<String, serde_json::Value>> = item
                 .listen_info
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok());
+            let info: Option<HashMap<&str, serde_json::Value>> = parsed
                 .as_ref()
                 .map(|m| m.iter().map(|(k, v)| (k.as_str(), v.clone())).collect());
             let listen =
-                musicbrainz::make_listen(&item.artist, &item.title, album, info, item.timestamp);
+                musicbrainz::make_listen(&item.artist, &item.title, album, info, item.listened_at);
             musicbrainz::submit_listens(&auth, vec![listen], "import")
                 .await
                 .map(|_| ())
@@ -305,71 +201,40 @@ async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials
 mod tests {
     use super::*;
 
-    fn entry(title: &str, ts: i64, pending: Vec<Service>) -> QueuedScrobble {
-        QueuedScrobble {
-            artist: "Artist".into(),
-            title: title.into(),
-            album: None,
-            timestamp: ts,
-            pending,
-            listen_info: None,
+    /// A fresh isolated on-disk DB per test (WAL sidecar files cleaned up too).
+    struct TempDb {
+        db: Db,
+        path: std::path::PathBuf,
+    }
+
+    impl Drop for TempDb {
+        fn drop(&mut self) {
+            for ext in ["", "-wal", "-shm"] {
+                let mut p = self.path.clone().into_os_string();
+                p.push(ext);
+                let _ = std::fs::remove_file(p);
+            }
         }
     }
 
-    fn temp_path(name: &str) -> PathBuf {
-        std::env::temp_dir().join(format!("kopuz-queue-test-{}-{name}", std::process::id()))
-    }
-
-    #[test]
-    fn push_caps_queue_and_drops_oldest() {
-        let mut q = ScrobbleQueue::default();
-        for i in 0..(MAX_QUEUED + 10) {
-            q.push(entry(&format!("t{i}"), i as i64, vec![Service::LastFm]));
+    async fn temp_db(name: &str) -> TempDb {
+        let path =
+            std::env::temp_dir().join(format!("kopuz-queue-test-{}-{name}.db", std::process::id()));
+        for ext in ["", "-wal", "-shm"] {
+            let mut p = path.clone().into_os_string();
+            p.push(ext);
+            let _ = std::fs::remove_file(p);
         }
-        assert_eq!(q.items.len(), MAX_QUEUED);
-        // The 10 oldest entries were dropped.
-        assert_eq!(q.items.first().unwrap().title, "t10");
-    }
-
-    #[test]
-    fn save_and_load_roundtrip() {
-        let path = temp_path("roundtrip.json");
-        let mut q = ScrobbleQueue::default();
-        q.push(entry(
-            "song",
-            1700000000,
-            vec![Service::LibreFm, Service::ListenBrainz],
-        ));
-        q.save(&path).unwrap();
-
-        let loaded = ScrobbleQueue::load(&path);
-        assert_eq!(loaded.items.len(), 1);
-        assert_eq!(loaded.items[0].title, "song");
-        assert_eq!(
-            loaded.items[0].pending,
-            vec![Service::LibreFm, Service::ListenBrainz]
-        );
-        let _ = std::fs::remove_file(&path);
-    }
-
-    #[test]
-    fn corrupt_or_missing_file_loads_empty() {
-        let missing = temp_path("missing.json");
-        assert!(ScrobbleQueue::load(&missing).is_empty());
-
-        let corrupt = temp_path("corrupt.json");
-        std::fs::write(&corrupt, "not json at all").unwrap();
-        assert!(ScrobbleQueue::load(&corrupt).is_empty());
-        let _ = std::fs::remove_file(&corrupt);
+        let db = db::init(&path).await.unwrap();
+        TempDb { db, path }
     }
 
     #[tokio::test]
     async fn enqueue_merges_same_listen_across_services() {
-        let path = temp_path("merge.json");
-        let _ = std::fs::remove_file(&path);
+        let t = temp_db("merge").await;
 
         enqueue(
-            &path,
+            &t.db,
             Service::LastFm,
             "Artist",
             "Song",
@@ -381,7 +246,7 @@ mod tests {
         let mut info = serde_json::Map::new();
         info.insert("duration_ms".into(), serde_json::Value::from(180000));
         enqueue(
-            &path,
+            &t.db,
             Service::ListenBrainz,
             "Artist",
             "Song",
@@ -390,9 +255,8 @@ mod tests {
             Some(info.clone()),
         )
         .await;
-        // Duplicate service on the same listen must not double up.
         enqueue(
-            &path,
+            &t.db,
             Service::LastFm,
             "Artist",
             "Song",
@@ -402,27 +266,25 @@ mod tests {
         )
         .await;
 
-        let q = ScrobbleQueue::load(&path);
-        assert_eq!(q.items.len(), 1);
-        assert_eq!(
-            q.items[0].pending,
-            vec![Service::LastFm, Service::ListenBrainz]
-        );
-        assert_eq!(q.items[0].listen_info, Some(info));
-        let _ = std::fs::remove_file(&path);
+        let rows = t.db.scrobble_queue_all().await.unwrap();
+        assert_eq!(rows.len(), 2);
+        let services: Vec<Service> = rows.iter().map(|r| r.service).collect();
+        assert!(services.contains(&Service::LastFm));
+        assert!(services.contains(&Service::ListenBrainz));
+        let lb = rows
+            .iter()
+            .find(|r| r.service == Service::ListenBrainz)
+            .unwrap();
+        assert_eq!(lb.listen_info.as_deref(), Some(r#"{"duration_ms":180000}"#));
     }
 
     #[tokio::test]
     async fn drain_without_credentials_clears_queue() {
-        // No credentials configured: nothing to deliver to, entries are
-        // released instead of sitting in the queue forever.
-        let path = temp_path("nocreds.json");
-        let _ = std::fs::remove_file(&path);
-        enqueue(&path, Service::LastFm, "Artist", "Song", None, 42, None).await;
+        let t = temp_db("nocreds").await;
+        enqueue(&t.db, Service::LastFm, "Artist", "Song", None, 42, None).await;
 
-        drain(&path, &Credentials::default()).await;
+        drain(&t.db, &Credentials::default()).await;
 
-        assert!(ScrobbleQueue::load(&path).is_empty());
-        let _ = std::fs::remove_file(&path);
+        assert!(t.db.scrobble_queue_all().await.unwrap().is_empty());
     }
 }

--- a/crates/scrobble/src/queue.rs
+++ b/crates/scrobble/src/queue.rs
@@ -9,6 +9,7 @@
 
 use crate::{lastfm, librefm, musicbrainz};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tokio::sync::Mutex;
 
@@ -45,6 +46,8 @@ pub struct QueuedScrobble {
     pub timestamp: i64,
     /// Services this scrobble is still owed to.
     pub pending: Vec<Service>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub listen_info: Option<serde_json::Map<String, serde_json::Value>>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -125,6 +128,7 @@ pub async fn enqueue(
     title: &str,
     album: Option<&str>,
     timestamp: i64,
+    listen_info: Option<serde_json::Map<String, serde_json::Value>>,
 ) {
     let _guard = QUEUE_LOCK.lock().await;
     let mut queue = ScrobbleQueue::load(path);
@@ -137,6 +141,9 @@ pub async fn enqueue(
         if !existing.pending.contains(&service) {
             existing.pending.push(service);
         }
+        if listen_info.is_some() {
+            existing.listen_info = listen_info;
+        }
     } else {
         queue.push(QueuedScrobble {
             artist: artist.to_string(),
@@ -144,6 +151,7 @@ pub async fn enqueue(
             album: album.map(|s| s.to_string()),
             timestamp,
             pending: vec![service],
+            listen_info,
         });
     }
 
@@ -274,8 +282,12 @@ async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials
             } else {
                 format!("Token {token}")
             };
+            let info: Option<HashMap<&str, serde_json::Value>> = item
+                .listen_info
+                .as_ref()
+                .map(|m| m.iter().map(|(k, v)| (k.as_str(), v.clone())).collect());
             let listen =
-                musicbrainz::make_listen(&item.artist, &item.title, album, None, item.timestamp);
+                musicbrainz::make_listen(&item.artist, &item.title, album, info, item.timestamp);
             musicbrainz::submit_listens(&auth, vec![listen], "import")
                 .await
                 .map(|_| ())
@@ -300,6 +312,7 @@ mod tests {
             album: None,
             timestamp: ts,
             pending,
+            listen_info: None,
         }
     }
 
@@ -355,7 +368,18 @@ mod tests {
         let path = temp_path("merge.json");
         let _ = std::fs::remove_file(&path);
 
-        enqueue(&path, Service::LastFm, "Artist", "Song", Some("Album"), 42).await;
+        enqueue(
+            &path,
+            Service::LastFm,
+            "Artist",
+            "Song",
+            Some("Album"),
+            42,
+            None,
+        )
+        .await;
+        let mut info = serde_json::Map::new();
+        info.insert("duration_ms".into(), serde_json::Value::from(180000));
         enqueue(
             &path,
             Service::ListenBrainz,
@@ -363,10 +387,20 @@ mod tests {
             "Song",
             Some("Album"),
             42,
+            Some(info.clone()),
         )
         .await;
         // Duplicate service on the same listen must not double up.
-        enqueue(&path, Service::LastFm, "Artist", "Song", Some("Album"), 42).await;
+        enqueue(
+            &path,
+            Service::LastFm,
+            "Artist",
+            "Song",
+            Some("Album"),
+            42,
+            None,
+        )
+        .await;
 
         let q = ScrobbleQueue::load(&path);
         assert_eq!(q.items.len(), 1);
@@ -374,6 +408,7 @@ mod tests {
             q.items[0].pending,
             vec![Service::LastFm, Service::ListenBrainz]
         );
+        assert_eq!(q.items[0].listen_info, Some(info));
         let _ = std::fs::remove_file(&path);
     }
 
@@ -383,7 +418,7 @@ mod tests {
         // released instead of sitting in the queue forever.
         let path = temp_path("nocreds.json");
         let _ = std::fs::remove_file(&path);
-        enqueue(&path, Service::LastFm, "Artist", "Song", None, 42).await;
+        enqueue(&path, Service::LastFm, "Artist", "Song", None, 42, None).await;
 
         drain(&path, &Credentials::default()).await;
 

--- a/crates/scrobble/src/queue.rs
+++ b/crates/scrobble/src/queue.rs
@@ -1,0 +1,393 @@
+//! Offline scrobble queue (issue #335).
+//!
+//! A scrobble that fails with a transient error (no response or a 5xx) is
+//! persisted here and resubmitted later with its original listen timestamp.
+//! Both protocols support backdated submissions: Last.fm/Libre.fm
+//! `track.scrobble` takes a `timestamp`, ListenBrainz takes `listened_at`.
+//! Permanent failures (4xx, e.g. bad credentials) are never queued, retrying
+//! them can't succeed.
+
+use crate::{lastfm, librefm, musicbrainz};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use tokio::sync::Mutex;
+
+/// Queue size cap; the oldest entries are dropped first.
+const MAX_QUEUED: usize = 500;
+
+/// Serializes all queue file access so two finished tracks can't race on the
+/// load-modify-save cycle.
+static QUEUE_LOCK: Mutex<()> = Mutex::const_new(());
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Service {
+    LastFm,
+    LibreFm,
+    ListenBrainz,
+}
+
+impl Service {
+    pub fn label(self) -> &'static str {
+        match self {
+            Service::LastFm => "Last.fm",
+            Service::LibreFm => "Libre.fm",
+            Service::ListenBrainz => "ListenBrainz",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct QueuedScrobble {
+    pub artist: String,
+    pub title: String,
+    pub album: Option<String>,
+    /// Unix timestamp of the original listen.
+    pub timestamp: i64,
+    /// Services this scrobble is still owed to.
+    pub pending: Vec<Service>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct ScrobbleQueue {
+    pub items: Vec<QueuedScrobble>,
+}
+
+impl ScrobbleQueue {
+    /// Load the queue; a missing or unreadable file is an empty queue
+    /// (same forgiving pattern as the app config).
+    pub fn load(path: &Path) -> Self {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    }
+
+    /// Write-to-temp-then-rename so an interrupted write can't leave a
+    /// truncated file behind; `load` treats corrupt JSON as an empty queue,
+    /// which would silently drop the whole backlog.
+    pub fn save(&self, path: &Path) -> Result<(), String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let json = serde_json::to_string(self).map_err(|e| e.to_string())?;
+        let tmp = path.with_extension("json.tmp");
+        std::fs::write(&tmp, json).map_err(|e| e.to_string())?;
+        std::fs::rename(&tmp, path).map_err(|e| e.to_string())
+    }
+
+    /// Append a scrobble, dropping the oldest entries beyond the cap.
+    pub fn push(&mut self, item: QueuedScrobble) {
+        self.items.push(item);
+        if self.items.len() > MAX_QUEUED {
+            let overflow = self.items.len() - MAX_QUEUED;
+            self.items.drain(..overflow);
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+/// Default queue location, next to config.json.
+pub fn default_queue_path() -> Option<PathBuf> {
+    directories::ProjectDirs::from("com", "temidaradev", "kopuz")
+        .map(|dirs| dirs.config_dir().join("scrobble_queue.json"))
+}
+
+/// Whether a failed request is worth retrying later: no response at all
+/// (offline, DNS, timeout) or a server-side 5xx. A 4xx means the server
+/// understood and refused (bad credentials etc.), retrying can't help.
+pub fn is_transient(error: &reqwest::Error) -> bool {
+    match error.status() {
+        Some(status) => status.is_server_error(),
+        None => true,
+    }
+}
+
+/// Credentials snapshot for draining; `None` skips that service.
+#[derive(Debug, Clone, Default)]
+pub struct Credentials {
+    /// (api_key, api_secret, session_key)
+    pub lastfm: Option<(String, String, String)>,
+    pub librefm_session_key: Option<String>,
+    /// Raw token as stored in config; "Token " prefix added when missing.
+    pub listenbrainz_token: Option<String>,
+}
+
+/// Enqueue a failed scrobble for the given service, merging with an existing
+/// entry for the same listen so one track failing on two services stays one
+/// queue item with two pending services.
+pub async fn enqueue(
+    path: &Path,
+    service: Service,
+    artist: &str,
+    title: &str,
+    album: Option<&str>,
+    timestamp: i64,
+) {
+    let _guard = QUEUE_LOCK.lock().await;
+    let mut queue = ScrobbleQueue::load(path);
+
+    if let Some(existing) = queue
+        .items
+        .iter_mut()
+        .find(|i| i.timestamp == timestamp && i.artist == artist && i.title == title)
+    {
+        if !existing.pending.contains(&service) {
+            existing.pending.push(service);
+        }
+    } else {
+        queue.push(QueuedScrobble {
+            artist: artist.to_string(),
+            title: title.to_string(),
+            album: album.map(|s| s.to_string()),
+            timestamp,
+            pending: vec![service],
+        });
+    }
+
+    if let Err(e) = queue.save(path) {
+        tracing::warn!(error = %e, "failed to persist scrobble queue");
+    } else {
+        tracing::info!(
+            service = service.label(),
+            "queued offline scrobble: {} - {}",
+            artist,
+            title
+        );
+    }
+}
+
+/// Resubmit queued scrobbles. Per service, the first transient failure skips
+/// that service for the rest of this run (still unreachable); a permanent
+/// failure drops the service from that entry. Progress is checkpointed to
+/// disk after every entry, so an interrupted drain re-sends at most the one
+/// in-flight item instead of replaying everything already delivered.
+///
+/// The mutex is held only around file I/O; network submissions run outside
+/// the lock so concurrent `enqueue()` calls are never blocked by the wire.
+/// Each checkpoint re-loads the on-disk queue and merges progress into it,
+/// preserving any entries added by `enqueue()` while drain was in flight.
+pub async fn drain(path: &Path, creds: &Credentials) {
+    let queue = {
+        let _guard = QUEUE_LOCK.lock().await;
+        ScrobbleQueue::load(path)
+    };
+    if queue.is_empty() {
+        return;
+    }
+    tracing::info!("draining scrobble queue ({} items)", queue.items.len());
+
+    let mut give_up: Vec<Service> = Vec::new();
+
+    for item in &queue.items {
+        let mut done: Vec<Service> = Vec::new();
+        for &service in &item.pending {
+            if give_up.contains(&service) {
+                continue;
+            }
+            match submit_one(service, item, creds).await {
+                Outcome::Sent => {
+                    tracing::info!(
+                        service = service.label(),
+                        "resubmitted queued scrobble: {} - {}",
+                        item.artist,
+                        item.title
+                    );
+                    done.push(service);
+                }
+                Outcome::NoCredentials => {
+                    // Not configured (anymore); nothing to deliver to.
+                    done.push(service);
+                }
+                Outcome::Transient => {
+                    give_up.push(service);
+                }
+                Outcome::Permanent(e) => {
+                    tracing::warn!(
+                        service = service.label(),
+                        error = %e,
+                        "dropping queued scrobble after permanent error: {} - {}",
+                        item.artist,
+                        item.title
+                    );
+                    done.push(service);
+                }
+            }
+        }
+        if !done.is_empty() {
+            // Re-acquire the lock only for the checkpoint write. Reload the
+            // on-disk queue to merge any enqueue() calls that arrived while
+            // we were on the wire, then remove the services we just delivered.
+            let _guard = QUEUE_LOCK.lock().await;
+            let mut on_disk = ScrobbleQueue::load(path);
+            if let Some(disk_item) = on_disk.items.iter_mut().find(|i| {
+                i.timestamp == item.timestamp && i.artist == item.artist && i.title == item.title
+            }) {
+                disk_item.pending.retain(|s| !done.contains(s));
+            }
+            on_disk.items.retain(|i| !i.pending.is_empty());
+            if let Err(e) = on_disk.save(path) {
+                tracing::warn!(error = %e, "failed to checkpoint scrobble queue");
+            }
+        }
+    }
+}
+
+enum Outcome {
+    Sent,
+    Transient,
+    Permanent(reqwest::Error),
+    NoCredentials,
+}
+
+async fn submit_one(service: Service, item: &QueuedScrobble, creds: &Credentials) -> Outcome {
+    let album = item.album.as_deref();
+    let result = match service {
+        Service::LastFm => {
+            let Some((key, secret, session)) = &creds.lastfm else {
+                return Outcome::NoCredentials;
+            };
+            let scrobble =
+                lastfm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
+            lastfm::submit_scrobble(key, secret, session, &scrobble)
+                .await
+                .map(|_| ())
+        }
+        Service::LibreFm => {
+            let Some(session) = &creds.librefm_session_key else {
+                return Outcome::NoCredentials;
+            };
+            let scrobble =
+                librefm::make_scrobble_at(&item.artist, &item.title, album, item.timestamp);
+            librefm::submit_scrobble(librefm::API_KEY, librefm::API_SECRET, session, &scrobble)
+                .await
+                .map(|_| ())
+        }
+        Service::ListenBrainz => {
+            let Some(token) = &creds.listenbrainz_token else {
+                return Outcome::NoCredentials;
+            };
+            let auth = if token.contains(' ') {
+                token.clone()
+            } else {
+                format!("Token {token}")
+            };
+            let listen =
+                musicbrainz::make_listen(&item.artist, &item.title, album, None, item.timestamp);
+            musicbrainz::submit_listens(&auth, vec![listen], "import")
+                .await
+                .map(|_| ())
+        }
+    };
+
+    match result {
+        Ok(()) => Outcome::Sent,
+        Err(e) if is_transient(&e) => Outcome::Transient,
+        Err(e) => Outcome::Permanent(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(title: &str, ts: i64, pending: Vec<Service>) -> QueuedScrobble {
+        QueuedScrobble {
+            artist: "Artist".into(),
+            title: title.into(),
+            album: None,
+            timestamp: ts,
+            pending,
+        }
+    }
+
+    fn temp_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("kopuz-queue-test-{}-{name}", std::process::id()))
+    }
+
+    #[test]
+    fn push_caps_queue_and_drops_oldest() {
+        let mut q = ScrobbleQueue::default();
+        for i in 0..(MAX_QUEUED + 10) {
+            q.push(entry(&format!("t{i}"), i as i64, vec![Service::LastFm]));
+        }
+        assert_eq!(q.items.len(), MAX_QUEUED);
+        // The 10 oldest entries were dropped.
+        assert_eq!(q.items.first().unwrap().title, "t10");
+    }
+
+    #[test]
+    fn save_and_load_roundtrip() {
+        let path = temp_path("roundtrip.json");
+        let mut q = ScrobbleQueue::default();
+        q.push(entry(
+            "song",
+            1700000000,
+            vec![Service::LibreFm, Service::ListenBrainz],
+        ));
+        q.save(&path).unwrap();
+
+        let loaded = ScrobbleQueue::load(&path);
+        assert_eq!(loaded.items.len(), 1);
+        assert_eq!(loaded.items[0].title, "song");
+        assert_eq!(
+            loaded.items[0].pending,
+            vec![Service::LibreFm, Service::ListenBrainz]
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn corrupt_or_missing_file_loads_empty() {
+        let missing = temp_path("missing.json");
+        assert!(ScrobbleQueue::load(&missing).is_empty());
+
+        let corrupt = temp_path("corrupt.json");
+        std::fs::write(&corrupt, "not json at all").unwrap();
+        assert!(ScrobbleQueue::load(&corrupt).is_empty());
+        let _ = std::fs::remove_file(&corrupt);
+    }
+
+    #[tokio::test]
+    async fn enqueue_merges_same_listen_across_services() {
+        let path = temp_path("merge.json");
+        let _ = std::fs::remove_file(&path);
+
+        enqueue(&path, Service::LastFm, "Artist", "Song", Some("Album"), 42).await;
+        enqueue(
+            &path,
+            Service::ListenBrainz,
+            "Artist",
+            "Song",
+            Some("Album"),
+            42,
+        )
+        .await;
+        // Duplicate service on the same listen must not double up.
+        enqueue(&path, Service::LastFm, "Artist", "Song", Some("Album"), 42).await;
+
+        let q = ScrobbleQueue::load(&path);
+        assert_eq!(q.items.len(), 1);
+        assert_eq!(
+            q.items[0].pending,
+            vec![Service::LastFm, Service::ListenBrainz]
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn drain_without_credentials_clears_queue() {
+        // No credentials configured: nothing to deliver to, entries are
+        // released instead of sitting in the queue forever.
+        let path = temp_path("nocreds.json");
+        let _ = std::fs::remove_file(&path);
+        enqueue(&path, Service::LastFm, "Artist", "Song", None, 42).await;
+
+        drain(&path, &Credentials::default()).await;
+
+        assert!(ScrobbleQueue::load(&path).is_empty());
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/scrobble/src/queue.rs
+++ b/crates/scrobble/src/queue.rs
@@ -16,7 +16,7 @@ use crate::{lastfm, librefm, musicbrainz};
 use db::{Db, QueuedScrobbleRow};
 use std::collections::HashMap;
 
-pub use db::Service;
+pub use db::ScrobbleService;
 
 /// Whether a failed request is worth retrying later: no response at all
 /// (offline, DNS, timeout) or a server-side 5xx. A 4xx means the server
@@ -43,7 +43,7 @@ pub struct Credentials {
 /// so one track failing on two services is two rows, one per service.
 pub async fn enqueue(
     db: &Db,
-    service: Service,
+    service: ScrobbleService,
     artist: &str,
     title: &str,
     album: Option<&str>,
@@ -91,7 +91,7 @@ pub async fn drain(db: &Db, creds: &Credentials) {
     }
     tracing::info!("draining scrobble queue ({} items)", rows.len());
 
-    let mut give_up: Vec<Service> = Vec::new();
+    let mut give_up: Vec<ScrobbleService> = Vec::new();
 
     for row in &rows {
         let service = row.service;
@@ -142,10 +142,14 @@ enum Outcome {
     NoCredentials,
 }
 
-async fn submit_one(service: Service, item: &QueuedScrobbleRow, creds: &Credentials) -> Outcome {
+async fn submit_one(
+    service: ScrobbleService,
+    item: &QueuedScrobbleRow,
+    creds: &Credentials,
+) -> Outcome {
     let album = item.album.as_deref();
     let result = match service {
-        Service::LastFm => {
+        ScrobbleService::LastFm => {
             let Some((key, secret, session)) = &creds.lastfm else {
                 return Outcome::NoCredentials;
             };
@@ -155,7 +159,7 @@ async fn submit_one(service: Service, item: &QueuedScrobbleRow, creds: &Credenti
                 .await
                 .map(|_| ())
         }
-        Service::LibreFm => {
+        ScrobbleService::LibreFm => {
             let Some(session) = &creds.librefm_session_key else {
                 return Outcome::NoCredentials;
             };
@@ -165,7 +169,7 @@ async fn submit_one(service: Service, item: &QueuedScrobbleRow, creds: &Credenti
                 .await
                 .map(|_| ())
         }
-        Service::ListenBrainz => {
+        ScrobbleService::ListenBrainz => {
             let Some(token) = &creds.listenbrainz_token else {
                 return Outcome::NoCredentials;
             };
@@ -234,7 +238,7 @@ mod tests {
 
         enqueue(
             &t.db,
-            Service::LastFm,
+            ScrobbleService::LastFm,
             "Artist",
             "Song",
             Some("Album"),
@@ -246,7 +250,7 @@ mod tests {
         info.insert("duration_ms".into(), serde_json::Value::from(180000));
         enqueue(
             &t.db,
-            Service::ListenBrainz,
+            ScrobbleService::ListenBrainz,
             "Artist",
             "Song",
             Some("Album"),
@@ -256,7 +260,7 @@ mod tests {
         .await;
         enqueue(
             &t.db,
-            Service::LastFm,
+            ScrobbleService::LastFm,
             "Artist",
             "Song",
             Some("Album"),
@@ -267,12 +271,12 @@ mod tests {
 
         let rows = t.db.scrobble_queue_all().await.unwrap();
         assert_eq!(rows.len(), 2);
-        let services: Vec<Service> = rows.iter().map(|r| r.service).collect();
-        assert!(services.contains(&Service::LastFm));
-        assert!(services.contains(&Service::ListenBrainz));
+        let services: Vec<ScrobbleService> = rows.iter().map(|r| r.service).collect();
+        assert!(services.contains(&ScrobbleService::LastFm));
+        assert!(services.contains(&ScrobbleService::ListenBrainz));
         let lb = rows
             .iter()
-            .find(|r| r.service == Service::ListenBrainz)
+            .find(|r| r.service == ScrobbleService::ListenBrainz)
             .unwrap();
         assert_eq!(lb.listen_info.as_deref(), Some(r#"{"duration_ms":180000}"#));
     }
@@ -280,7 +284,16 @@ mod tests {
     #[tokio::test]
     async fn drain_without_credentials_retains_queue() {
         let t = temp_db("nocreds").await;
-        enqueue(&t.db, Service::LastFm, "Artist", "Song", None, 42, None).await;
+        enqueue(
+            &t.db,
+            ScrobbleService::LastFm,
+            "Artist",
+            "Song",
+            None,
+            42,
+            None,
+        )
+        .await;
 
         drain(&t.db, &Credentials::default()).await;
 

--- a/crates/scrobble/src/queue.rs
+++ b/crates/scrobble/src/queue.rs
@@ -109,8 +109,7 @@ pub async fn drain(db: &Db, creds: &Credentials) {
                 );
                 true
             }
-            Outcome::NoCredentials => true,
-            Outcome::Transient => {
+            Outcome::NoCredentials | Outcome::Transient => {
                 give_up.push(service);
                 false
             }
@@ -279,12 +278,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn drain_without_credentials_clears_queue() {
+    async fn drain_without_credentials_retains_queue() {
         let t = temp_db("nocreds").await;
         enqueue(&t.db, Service::LastFm, "Artist", "Song", None, 42, None).await;
 
         drain(&t.db, &Credentials::default()).await;
 
-        assert!(t.db.scrobble_queue_all().await.unwrap().is_empty());
+        assert_eq!(t.db.scrobble_queue_all().await.unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
i took the stuff from pr #445 and yeah thats it but i will improve this fixed #335

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
