### PR TITLE
server/cookies: never split a browser path on spaces (fixes #513)

### DIFF
--- a/crates/server/src/cookies/browser.rs
+++ b/crates/server/src/cookies/browser.rs
@@ -3,6 +3,25 @@ use std::path::PathBuf;
 use config::Browser;
 use tokio::process::Command;
 
+/// How to invoke the browser. The two shapes must not be conflated: a `Path`
+/// may contain spaces (macOS app bundles, Windows Program Files) and is never
+/// split, while a `CommandLine` is multi-token by construction (`flatpak run
+/// <id>`, `$KOPUZ_BROWSER_COMMAND`) and is split on whitespace. Guessing the
+/// shape from the string is exactly what broke spawning `/Applications/Google
+/// Chrome.app/...` (#513) and `C:\Program Files\...` before it (#435).
+#[derive(Debug, Clone)]
+pub(crate) enum BrowserBin {
+    Path(String),
+    CommandLine(String),
+}
+
+impl std::fmt::Display for BrowserBin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (Self::Path(s) | Self::CommandLine(s)) = self;
+        f.write_str(s)
+    }
+}
+
 pub(crate) fn browser_candidates(browser: Browser) -> &'static [&'static str] {
     match browser {
         Browser::Brave => &["brave", "brave-browser"],
@@ -111,7 +130,7 @@ pub(crate) async fn check_browser_command(arg: String) -> bool {
         .unwrap_or(false)
 }
 
-pub(crate) async fn find_browser_bin(browser: Browser) -> Option<String> {
+pub(crate) async fn find_browser_bin(browser: Browser) -> Option<BrowserBin> {
     let env_key = format!(
         "KOPUZ_{}_BIN",
         browser.id().to_uppercase().replace('-', "_")
@@ -119,13 +138,13 @@ pub(crate) async fn find_browser_bin(browser: Browser) -> Option<String> {
     if let Some(v) = std::env::var_os(&env_key)
         && !v.is_empty()
     {
-        return Some(v.to_string_lossy().into_owned());
+        return Some(BrowserBin::Path(v.to_string_lossy().into_owned()));
     }
 
     if in_flatpak() {
         for cand in browser_candidates(browser) {
             if check_browser_command(format!("command -v {cand}")).await {
-                return Some(cand.to_string());
+                return Some(BrowserBin::Path(cand.to_string()));
             }
         }
     } else {
@@ -135,7 +154,7 @@ pub(crate) async fn find_browser_bin(browser: Browser) -> Option<String> {
             for dir in &dirs {
                 let p = dir.join(candidate);
                 if p.is_file() {
-                    return Some(candidate.to_string());
+                    return Some(BrowserBin::Path(candidate.to_string()));
                 }
             }
         }
@@ -146,26 +165,26 @@ pub(crate) async fn find_browser_bin(browser: Browser) -> Option<String> {
     {
         let id = v.to_string().to_owned();
         if check_browser_command(format!("flatpak info {id}")).await {
-            return Some(format!("flatpak run {id}"));
+            return Some(BrowserBin::CommandLine(format!("flatpak run {id}")));
         }
     }
 
     for cand in browser_flatpak_ids(browser) {
         if check_browser_command(format!("flatpak info {cand}")).await {
-            return Some(format!("flatpak run {cand}"));
+            return Some(BrowserBin::CommandLine(format!("flatpak run {cand}")));
         }
     }
 
     #[cfg(target_os = "macos")]
     for path in macos_app_paths(browser) {
         if std::path::Path::new(path).is_file() {
-            return Some((*path).to_string());
+            return Some(BrowserBin::Path((*path).to_string()));
         }
     }
     #[cfg(target_os = "windows")]
     for path in windows_install_paths(browser) {
         if path.is_file() {
-            return Some(path.to_string_lossy().into_owned());
+            return Some(BrowserBin::Path(path.to_string_lossy().into_owned()));
         }
     }
     None
@@ -173,26 +192,59 @@ pub(crate) async fn find_browser_bin(browser: Browser) -> Option<String> {
 
 /// Plain `Command` natively; `flatpak-spawn --host --watch-bus` when packaged,
 /// so `child.kill()`/`kill_on_drop` still tears the host browser down.
-pub(crate) fn browser_command(bin: &str) -> Command {
-    // On Windows `bin` is a single executable path that can contain spaces
-    // (e.g. `C:\Program Files\...`), so it must not be split. Elsewhere `bin`
-    // may be a multi-token command like `flatpak run <id>`, so split on spaces.
-    #[cfg(windows)]
-    {
-        Command::new(bin)
-    }
-    #[cfg(not(windows))]
-    {
-        let cmd: Vec<&str> = bin.split(' ').collect();
-        if in_flatpak() {
-            let mut c = Command::new("flatpak-spawn");
-            c.args(["--host", "--watch-bus"]);
-            c.args(cmd);
-            c
-        } else {
-            let mut c = Command::new(cmd[0]);
-            c.args(&cmd[1..]);
-            c
+pub(crate) fn browser_command(bin: &BrowserBin) -> Command {
+    let tokens: Vec<&str> = match bin {
+        BrowserBin::Path(p) => vec![p.as_str()],
+        BrowserBin::CommandLine(c) => {
+            let split: Vec<&str> = c.split_whitespace().collect();
+            if split.is_empty() {
+                vec![c.as_str()]
+            } else {
+                split
+            }
         }
+    };
+    if in_flatpak() {
+        let mut c = Command::new("flatpak-spawn");
+        c.args(["--host", "--watch-bus"]);
+        c.args(&tokens);
+        c
+    } else {
+        let mut c = Command::new(tokens[0]);
+        c.args(&tokens[1..]);
+        c
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_path_with_spaces_is_never_split() {
+        // The #513 shape: a macOS app-bundle binary. Splitting it spawned
+        // "/Applications/Google" and failed with ENOENT.
+        let bin = BrowserBin::Path(
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome".to_string(),
+        );
+        let cmd = browser_command(&bin);
+        assert_eq!(
+            cmd.as_std().get_program().to_string_lossy(),
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+        );
+        assert_eq!(cmd.as_std().get_args().count(), 0);
+    }
+
+    #[test]
+    fn a_command_line_is_split_into_tokens() {
+        let bin = BrowserBin::CommandLine("flatpak run com.google.Chrome".to_string());
+        let cmd = browser_command(&bin);
+        assert_eq!(cmd.as_std().get_program().to_string_lossy(), "flatpak");
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(args, ["run", "com.google.Chrome"]);
     }
 }

--- a/crates/server/src/cookies/signin.rs
+++ b/crates/server/src/cookies/signin.rs
@@ -5,7 +5,9 @@ use std::time::{Duration, Instant};
 use config::Browser;
 use tokio::process::Child;
 
-use super::browser::{browser_candidates, browser_command, find_browser_bin, in_flatpak};
+use super::browser::{
+    BrowserBin, browser_candidates, browser_command, find_browser_bin, in_flatpak,
+};
 use super::profile::profile_dir;
 
 /// Wipe the `<prefix>-<server_id>` profile, launch `browser` at `signin_url`,
@@ -46,7 +48,7 @@ where
         && !v.trim().is_empty()
     {
         tracing::info!("$KOPUZ_BROWSER_COMMAND used to override browser command");
-        v.to_string().to_owned()
+        BrowserBin::CommandLine(v)
     } else {
         let error = if in_flatpak() {
             format!(
@@ -102,7 +104,7 @@ where
 struct SigninWait<'a> {
     browser: Browser,
     profile: &'a Path,
-    bin: &'a str,
+    bin: &'a BrowserBin,
     timeout: Duration,
 }
 
@@ -149,7 +151,7 @@ where
                 .map(|_| " — note: the browser exited early (likely detached UI); close all browser windows and try again")
                 .unwrap_or_default();
             tracing::warn!(
-                bin = w.bin,
+                bin = %w.bin,
                 timeout_s = w.timeout.as_secs(),
                 exited_early = child_exited_at.is_some(),
                 "sign-in timed out"
@@ -162,13 +164,13 @@ where
         if child_exited_at.is_none()
             && let Ok(Some(status)) = child.try_wait()
         {
-            tracing::debug!(bin = w.bin, %status, "browser exited — still polling cookies");
+            tracing::debug!(bin = %w.bin, %status, "browser exited — still polling cookies");
             child_exited_at = Some(Instant::now());
         }
         match extract(w.browser, w.profile.to_path_buf()).await {
             Ok(Some(value)) => {
                 tracing::info!(
-                    bin = w.bin,
+                    bin = %w.bin,
                     elapsed_ms = started.elapsed().as_millis(),
                     "sign-in detected"
                 );
@@ -212,7 +214,7 @@ where
                 .map(|e| format!("; last extract error: {e}"))
                 .unwrap_or_default();
             tracing::warn!(
-                bin = w.bin,
+                bin = %w.bin,
                 timeout_s = w.timeout.as_secs(),
                 saw_browser,
                 "sign-in timed out"
@@ -232,7 +234,7 @@ where
         match extract(w.browser, w.profile.to_path_buf()).await {
             Ok(Some(value)) => {
                 tracing::info!(
-                    bin = w.bin,
+                    bin = %w.bin,
                     elapsed_ms = started.elapsed().as_millis(),
                     "sign-in detected after browser close"
                 );


### PR DESCRIPTION
Fixed macos whitespace in path causing browser discoverability issues.
Needs testing on macos' Google Chrome (as it has whitespace in it) to figure out if the fix worked.
<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
