### PR TITLE
various: support seeking from the macOS now playing widget

### DIFF
--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -24,6 +24,7 @@ enum BgCmd {
     Toggle,
     Next,
     Prev,
+    Seek(f64),
 }
 
 static BG_CMD_TX: std::sync::OnceLock<std::sync::Mutex<std::sync::mpsc::Sender<BgCmd>>> =
@@ -119,6 +120,7 @@ pub fn use_player_task(ctrl: PlayerController) {
                 SystemEvent::Toggle => BgCmd::Toggle,
                 SystemEvent::Next => BgCmd::Next,
                 SystemEvent::Prev => BgCmd::Prev,
+                SystemEvent::Seek(secs) => BgCmd::Seek(secs),
             };
             send_bg_cmd(cmd);
             nudge_event_loop();
@@ -297,13 +299,19 @@ pub fn use_player_task(ctrl: PlayerController) {
 
                 nudge_event_loop();
 
-                for cmd in drain_bg_cmds() {
+                let cmds = drain_bg_cmds();
+                let last_seek = cmds.iter().rposition(|c| matches!(c, BgCmd::Seek(_)));
+                for (i, cmd) in cmds.into_iter().enumerate() {
                     match cmd {
                         BgCmd::Play => ctrl.resume(),
                         BgCmd::Pause => ctrl.pause(),
                         BgCmd::Toggle => ctrl.toggle(),
                         BgCmd::Next => ctrl.play_next(),
                         BgCmd::Prev => ctrl.play_prev(),
+                        BgCmd::Seek(secs) if Some(i) == last_seek => {
+                            ctrl.seek(std::time::Duration::from_secs_f64(secs));
+                        }
+                        BgCmd::Seek(_) => {}
                     }
                 }
 

--- a/crates/hooks/src/use_player_task.rs
+++ b/crates/hooks/src/use_player_task.rs
@@ -309,7 +309,9 @@ pub fn use_player_task(ctrl: PlayerController) {
                         BgCmd::Next => ctrl.play_next(),
                         BgCmd::Prev => ctrl.play_prev(),
                         BgCmd::Seek(secs) if Some(i) == last_seek => {
-                            ctrl.seek(std::time::Duration::from_secs_f64(secs));
+                            let pos = std::time::Duration::try_from_secs_f64(secs)
+                                .unwrap_or(std::time::Duration::ZERO);
+                            ctrl.seek(pos);
                         }
                         BgCmd::Seek(_) => {}
                     }

--- a/crates/player/Cargo.toml
+++ b/crates/player/Cargo.toml
@@ -40,6 +40,7 @@ objc2-media-player = { workspace = true, features = [
   "MPMediaItem",
   "MPRemoteCommandCenter",
   "MPRemoteCommand",
+  "MPRemoteCommandEvent",
 ] }
 objc2-app-kit = { workspace = true, features = ["NSImage"] }
 objc2-av-foundation = { workspace = true, features = ["AVAudioSession"] }

--- a/crates/player/src/systemint/macos.rs
+++ b/crates/player/src/systemint/macos.rs
@@ -22,9 +22,9 @@ use objc2_foundation::{
     NSCopying, NSDictionary, NSMutableDictionary, NSNumber, NSProcessInfo, NSString,
 };
 use objc2_media_player::{
-    MPMediaItemArtwork, MPMediaItemPropertyAlbumTitle, MPMediaItemPropertyArtist,
-    MPMediaItemPropertyArtwork, MPMediaItemPropertyPlaybackDuration, MPMediaItemPropertyTitle,
-    MPNowPlayingInfoCenter, MPNowPlayingInfoPropertyElapsedPlaybackTime,
+    MPChangePlaybackPositionCommandEvent, MPMediaItemArtwork, MPMediaItemPropertyAlbumTitle,
+    MPMediaItemPropertyArtist, MPMediaItemPropertyArtwork, MPMediaItemPropertyPlaybackDuration,
+    MPMediaItemPropertyTitle, MPNowPlayingInfoCenter, MPNowPlayingInfoPropertyElapsedPlaybackTime,
     MPNowPlayingInfoPropertyPlaybackRate, MPRemoteCommandCenter, MPRemoteCommandEvent,
     MPRemoteCommandHandlerStatus,
 };
@@ -85,6 +85,7 @@ pub enum SystemEvent {
     Toggle,
     Next,
     Prev,
+    Seek(f64),
 }
 
 type BgHandler = Arc<StdMutex<Option<Box<dyn Fn(SystemEvent) + Send + Sync>>>>;
@@ -250,6 +251,23 @@ pub fn init() {
                     MPRemoteCommandHandlerStatus::Success
                 }));
 
+            center
+                .changePlaybackPositionCommand()
+                .addTargetWithHandler(&RcBlock::new(
+                    move |event: NonNull<MPRemoteCommandEvent>| {
+                        match event
+                            .as_ref()
+                            .downcast_ref::<MPChangePlaybackPositionCommandEvent>()
+                        {
+                            Some(event) => {
+                                dispatch_event(SystemEvent::Seek(event.positionTime()));
+                                MPRemoteCommandHandlerStatus::Success
+                            }
+                            None => MPRemoteCommandHandlerStatus::CommandFailed,
+                        }
+                    },
+                ));
+
             let fire_date = CFAbsoluteTimeGetCurrent();
             let timer = CFRunLoopTimerCreate(
                 std::ptr::null(),
@@ -277,6 +295,51 @@ pub fn init() {
     });
 }
 
+/// Cached `MPMediaItemArtwork` keyed by source path. Building one decodes the
+/// whole image file, far too slow to repeat on every position push (scrubbing
+/// floods them); a cache hit is just a retain.
+struct ArtworkCache {
+    path: String,
+    artwork: objc2::rc::Retained<MPMediaItemArtwork>,
+}
+
+// SAFETY: MPMediaItemArtwork is a MediaPlayer framework object documented as
+// thread-safe (it is designed to be handed to MPNowPlayingInfoCenter from any
+// thread), and the cache only clones retains out of it under the mutex.
+unsafe impl Send for ArtworkCache {}
+
+static ARTWORK_CACHE: StdMutex<Option<ArtworkCache>> = StdMutex::new(None);
+
+fn artwork_for_path(path: &str) -> Option<objc2::rc::Retained<MPMediaItemArtwork>> {
+    let mut cache = ARTWORK_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(c) = cache.as_ref()
+        && c.path == path
+    {
+        return Some(c.artwork.clone());
+    }
+
+    // SAFETY:
+    // - initWithContentsOfFile returns nil for unreadable files, mapped to
+    //   None by objc2.
+    // - initWithImage: follows the alloc-init convention (+1 retain), so
+    //   Retained::from_raw takes ownership without over-releasing; the null
+    //   check guards a failed init.
+    let artwork = unsafe {
+        let ns_path = NSString::from_str(path);
+        let image = NSImage::initWithContentsOfFile(NSImage::alloc(), &ns_path)?;
+        use objc2::msg_send;
+        let artwork_alloc = MPMediaItemArtwork::alloc();
+        let artwork_ptr: *mut MPMediaItemArtwork = std::mem::transmute(artwork_alloc);
+        let artwork_raw: *mut MPMediaItemArtwork = msg_send![artwork_ptr, initWithImage: &*image];
+        objc2::rc::Retained::from_raw(artwork_raw)?
+    };
+    *cache = Some(ArtworkCache {
+        path: path.to_string(),
+        artwork: artwork.clone(),
+    });
+    Some(artwork)
+}
+
 pub fn update_now_playing(
     title: &str,
     artist: &str,
@@ -299,12 +362,6 @@ pub fn update_now_playing(
     // - transmute from NSMutableDictionary to NSDictionary is safe because
     //   NSMutableDictionary is a subclass of NSDictionary; the upcast is
     //   valid in Objective-C and matches what the framework expects.
-    // - Retained::from_raw on the artwork pointer is safe because the
-    //   pointer was just returned by initWithImage: which follows the
-    //   "alloc-init" convention (returns +1 retain count), and from_raw
-    //   takes ownership without over-releasing.
-    // - The artwork pointer null-check ensures we only convert valid
-    //   pointers to Retained.
     unsafe {
         let center = MPNowPlayingInfoCenter::defaultCenter();
 
@@ -342,28 +399,13 @@ pub fn update_now_playing(
             ProtocolObject::from_ref(MPNowPlayingInfoPropertyPlaybackRate),
         );
 
-        if let Some(path) = artwork_path {
-            let ns_path = NSString::from_str(path);
-            if let Some(image) = NSImage::initWithContentsOfFile(NSImage::alloc(), &ns_path) {
-                use objc2::msg_send;
-                let artwork_alloc = MPMediaItemArtwork::alloc();
-                let artwork_ptr: *mut MPMediaItemArtwork = std::mem::transmute(artwork_alloc);
-                let artwork_raw: *mut MPMediaItemArtwork =
-                    msg_send![artwork_ptr, initWithImage: &*image];
-
-                if !artwork_raw.is_null() {
-                    let retained: objc2::rc::Retained<MPMediaItemArtwork> =
-                        objc2::rc::Retained::from_raw(artwork_raw).expect("retained artwork");
-
-                    let artwork_ref: &AnyObject = &*(&*retained
-                        as *const objc2_media_player::MPMediaItemArtwork
-                        as *const AnyObject);
-                    info.setObject_forKey(
-                        artwork_ref,
-                        ProtocolObject::from_ref(MPMediaItemPropertyArtwork),
-                    );
-                }
-            }
+        if let Some(retained) = artwork_path.and_then(artwork_for_path) {
+            let artwork_ref: &AnyObject =
+                &*(&*retained as *const objc2_media_player::MPMediaItemArtwork as *const AnyObject);
+            info.setObject_forKey(
+                artwork_ref,
+                ProtocolObject::from_ref(MPMediaItemPropertyArtwork),
+            );
         }
 
         center.setNowPlayingInfo(Some(std::mem::transmute::<


### PR DESCRIPTION
Adds seek support to the macOS Now Playing widget, matching what MPRIS already supports on Linux. (except shuffle and loop buttons since they dont exist)

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
