### PR TITLE
various: add TIDAL source via public API v2 with PKCE sign in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,6 +4458,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid 1.23.5",
+ "webbrowser",
 ]
 
 [[package]]
@@ -4559,6 +4560,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4565,6 +4565,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid 1.23.5",
+ "webbrowser",
  "windows 0.62.2",
  "windows-core 0.62.2",
 ]

--- a/crates/components/src/settings_popups.rs
+++ b/crates/components/src/settings_popups.rs
@@ -11,6 +11,10 @@ pub fn AddServerPopup(
     /// YouTube Music anonymous mode — true = no sign-in, browse + play
     /// public surfaces only.
     yt_anonymous: Signal<bool>,
+    /// TIDAL public-API app credentials (the user's own developer.tidal.com
+    /// client). Secret is optional for a public PKCE client.
+    tidal_client_id: Signal<String>,
+    tidal_client_secret: Signal<String>,
     error: Signal<Option<String>>,
     on_close: EventHandler<()>,
     on_save: EventHandler<()>,
@@ -21,6 +25,7 @@ pub fn AddServerPopup(
         MusicService::Custom => "custom",
         MusicService::YtMusic => "ytmusic",
         MusicService::SoundCloud => "soundcloud",
+        MusicService::Tidal => "tidal",
     };
 
     let server_name_label = i18n::t("server_name").to_string();
@@ -56,6 +61,8 @@ pub fn AddServerPopup(
                     server_url,
                     yt_browser,
                     yt_anonymous,
+                    tidal_client_id,
+                    tidal_client_secret,
                     server_url_placeholder: server_url_placeholder.clone(),
                 }
 
@@ -66,6 +73,7 @@ pub fn AddServerPopup(
                             "custom" => MusicService::Custom,
                             "ytmusic" => MusicService::YtMusic,
                             "soundcloud" => MusicService::SoundCloud,
+                            "tidal" => MusicService::Tidal,
                             _ => MusicService::Jellyfin,
                         };
                         server_service.set(service);
@@ -95,6 +103,11 @@ pub fn AddServerPopup(
                         value: "soundcloud",
                         selected: server_service() == MusicService::SoundCloud,
                         "SoundCloud"
+                    }
+                    option {
+                        value: "tidal",
+                        selected: server_service() == MusicService::Tidal,
+                        "TIDAL"
                     }
                 }
 
@@ -237,6 +250,8 @@ fn ServerServiceFields(
     server_url: Signal<String>,
     yt_browser: Signal<Browser>,
     yt_anonymous: Signal<bool>,
+    tidal_client_id: Signal<String>,
+    tidal_client_secret: Signal<String>,
     server_url_placeholder: String,
 ) -> Element {
     match server_service() {
@@ -298,11 +313,53 @@ fn ServerServiceFields(
                 }
             }
         }
+        // SoundCloud is browser sign-in only (no URL); pick the browser for the
+        // isolated sign-in window.
         MusicService::SoundCloud => rsx! {
-            // SoundCloud is browser sign-in only (no URL); pick the browser for
-            // the isolated sign-in window.
             p { class: "text-xs text-white/60",
                 "Pick which browser kopuz should use for the SoundCloud sign-in window. It opens in an isolated profile (a fresh, separate session) — your normal browsing is untouched. Make sure the browser is installed."
+            }
+            select {
+                onchange: move |e| {
+                    if let Some(b) = Browser::from_id(&e.value()) {
+                        yt_browser.set(b);
+                    }
+                },
+                onkeydown: move |e| e.stop_propagation(),
+                for browser in Browser::ALL.iter().copied() {
+                    option {
+                        value: "{browser.id()}",
+                        selected: yt_browser() == browser,
+                        "{browser.label()}"
+                    }
+                }
+            }
+        },
+        // TIDAL uses the public API with the user's own registered app: enter
+        // its client ID (+ secret if a confidential client). After Save, the
+        // default browser opens the TIDAL login and kopuz captures the redirect.
+        MusicService::Tidal => rsx! {
+            p { class: "text-xs text-white/60",
+                "Register an app at developer.tidal.com and add the redirect URI http://localhost:8765/callback. Paste its Client ID below (Client Secret only if it's a confidential client). A paid TIDAL subscription is required for playback."
+            }
+            input {
+                placeholder: "Client ID",
+                value: "{tidal_client_id()}",
+                oninput: move |e| tidal_client_id.set(e.value()),
+                onkeydown: move |e| e.stop_propagation()
+            }
+            input {
+                r#type: "password",
+                placeholder: "Client secret (optional)",
+                value: "{tidal_client_secret()}",
+                oninput: move |e| tidal_client_secret.set(e.value()),
+                onkeydown: move |e| e.stop_propagation()
+            }
+            // TIDAL's login rejects Firefox / privacy-hardened browsers
+            // (DataDome → UNSUPPORTED_OS), so sign-in runs in a clean isolated
+            // Chromium-family profile regardless of your default browser.
+            p { class: "text-xs text-white/60 mt-2",
+                "Pick a Chromium-family browser for the sign-in window — it opens in an isolated profile (a fresh session; your normal browsing is untouched). Firefox is not supported by TIDAL's login."
             }
             select {
                 onchange: move |e| {

--- a/crates/components/src/settings_popups.rs
+++ b/crates/components/src/settings_popups.rs
@@ -355,27 +355,6 @@ fn ServerServiceFields(
                 oninput: move |e| tidal_client_secret.set(e.value()),
                 onkeydown: move |e| e.stop_propagation()
             }
-            // TIDAL's login rejects Firefox / privacy-hardened browsers
-            // (DataDome → UNSUPPORTED_OS), so sign-in runs in a clean isolated
-            // Chromium-family profile regardless of your default browser.
-            p { class: "text-xs text-white/60 mt-2",
-                "Pick a Chromium-family browser for the sign-in window — it opens in an isolated profile (a fresh session; your normal browsing is untouched). Firefox is not supported by TIDAL's login."
-            }
-            select {
-                onchange: move |e| {
-                    if let Some(b) = Browser::from_id(&e.value()) {
-                        yt_browser.set(b);
-                    }
-                },
-                onkeydown: move |e| e.stop_propagation(),
-                for browser in Browser::ALL.iter().copied() {
-                    option {
-                        value: "{browser.id()}",
-                        selected: yt_browser() == browser,
-                        "{browser.label()}"
-                    }
-                }
-            }
         },
         _ => rsx! {
             input {

--- a/crates/components/src/source_switcher.rs
+++ b/crates/components/src/source_switcher.rs
@@ -94,6 +94,7 @@ fn service_style(service: MusicService) -> (&'static str, &'static str) {
     match service {
         MusicService::YtMusic => ("fa-brands fa-youtube", "#ff3355"),
         MusicService::SoundCloud => ("fa-brands fa-soundcloud", "#ff7a33"),
+        MusicService::Tidal => ("fa-solid fa-water", "#33e0e0"),
         MusicService::Jellyfin => ("fa-solid fa-server", "#b277ee"),
         MusicService::Subsonic | MusicService::Custom => ("fa-solid fa-compact-disc", "#f0a84b"),
     }

--- a/crates/config/src/source.rs
+++ b/crates/config/src/source.rs
@@ -45,6 +45,7 @@ pub enum MusicService {
     Custom,
     YtMusic,
     SoundCloud,
+    Tidal,
 }
 
 impl MusicService {
@@ -55,6 +56,7 @@ impl MusicService {
             Self::Custom => "Custom",
             Self::YtMusic => "YouTube Music",
             Self::SoundCloud => "SoundCloud",
+            Self::Tidal => "TIDAL",
         }
     }
 
@@ -62,6 +64,13 @@ impl MusicService {
     /// rather than a URL + username/password form.
     pub fn uses_browser_signin(&self) -> bool {
         matches!(self, Self::YtMusic | Self::SoundCloud)
+    }
+
+    /// Backends that sign in via the OAuth device flow — kopuz opens the
+    /// default browser on an approval page and polls for the grant. No URL,
+    /// no password form, no isolated browser profile.
+    pub fn uses_device_signin(&self) -> bool {
+        matches!(self, Self::Tidal)
     }
 }
 

--- a/crates/db/src/backend/cfg_store.rs
+++ b/crates/db/src/backend/cfg_store.rs
@@ -287,6 +287,7 @@ fn parse_service(s: &str) -> MusicService {
         "Custom" => MusicService::Custom,
         "YtMusic" => MusicService::YtMusic,
         "SoundCloud" => MusicService::SoundCloud,
+        "Tidal" => MusicService::Tidal,
         _ => MusicService::Jellyfin,
     }
 }
@@ -298,6 +299,7 @@ fn service_str(s: MusicService) -> &'static str {
         MusicService::Custom => "Custom",
         MusicService::YtMusic => "YtMusic",
         MusicService::SoundCloud => "SoundCloud",
+        MusicService::Tidal => "Tidal",
     }
 }
 

--- a/crates/db/src/backend/migrations.rs
+++ b/crates/db/src/backend/migrations.rs
@@ -885,6 +885,7 @@ fn service_str(s: config::MusicService) -> &'static str {
         config::MusicService::Custom => "Custom",
         config::MusicService::YtMusic => "YtMusic",
         config::MusicService::SoundCloud => "SoundCloud",
+        config::MusicService::Tidal => "Tidal",
     }
 }
 

--- a/crates/db/src/backend/rows.rs
+++ b/crates/db/src/backend/rows.rs
@@ -90,6 +90,7 @@ pub fn parse_service(s: &str) -> config::MusicService {
         "Custom" => config::MusicService::Custom,
         "YtMusic" => config::MusicService::YtMusic,
         "SoundCloud" => config::MusicService::SoundCloud,
+        "Tidal" => config::MusicService::Tidal,
         _ => config::MusicService::Jellyfin,
     }
 }

--- a/crates/db/src/backend/writes.rs
+++ b/crates/db/src/backend/writes.rs
@@ -14,6 +14,7 @@ fn service_str(s: config::MusicService) -> &'static str {
         config::MusicService::Custom => "Custom",
         config::MusicService::YtMusic => "YtMusic",
         config::MusicService::SoundCloud => "SoundCloud",
+        config::MusicService::Tidal => "Tidal",
     }
 }
 

--- a/crates/hooks/src/playback_ref.rs
+++ b/crates/hooks/src/playback_ref.rs
@@ -21,11 +21,13 @@ impl<'a> PlaybackItemRef<'a> {
                 station_id: parts.next().unwrap_or_default(),
                 stream_id: parts.next().unwrap_or_default(),
             },
-            "jellyfin" | "subsonic" | "custom" | "ytmusic" | "soundcloud" => Self::Server {
-                service: scheme,
-                item_id: parts.next().unwrap_or_default(),
-                extra: parts.next(),
-            },
+            "jellyfin" | "subsonic" | "custom" | "ytmusic" | "soundcloud" | "tidal" => {
+                Self::Server {
+                    service: scheme,
+                    item_id: parts.next().unwrap_or_default(),
+                    extra: parts.next(),
+                }
+            }
             _ => Self::Local(value),
         }
     }

--- a/crates/pages/Cargo.toml
+++ b/crates/pages/Cargo.toml
@@ -31,6 +31,7 @@ config = { workspace = true }
 utils = { workspace = true }
 kopuz_route = { workspace = true }
 server = { workspace = true }
+webbrowser = { workspace = true }
 radio = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }

--- a/crates/pages/src/server/mod.rs
+++ b/crates/pages/src/server/mod.rs
@@ -48,7 +48,7 @@ pub fn build_download_url(item_id: &str, config: &AppConfig) -> Option<(String, 
             )
             .ok()?
         }
-        MusicService::YtMusic | MusicService::SoundCloud => return None,
+        MusicService::YtMusic | MusicService::SoundCloud | MusicService::Tidal => return None,
     };
     Some((url, ext))
 }

--- a/crates/pages/src/settings.rs
+++ b/crates/pages/src/settings.rs
@@ -198,6 +198,10 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
     // Anonymous YT mode for the add-server popup. Defaults to browser sign-in on
     // every platform (Windows cookie decryption is now supported natively).
     let yt_anonymous = use_signal(|| false);
+    // TIDAL public-API app credentials for the add-server popup (the user's own
+    // developer.tidal.com client).
+    let tidal_client_id = use_signal(String::new);
+    let tidal_client_secret = use_signal(String::new);
 
     let mut username = use_signal(String::new);
     let mut password = use_signal(String::new);
@@ -234,6 +238,8 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
             server_service,
             yt_browser,
             yt_anonymous,
+            tidal_client_id,
+            tidal_client_secret,
             error,
             show_add_server,
             show_login,
@@ -875,6 +881,8 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                         server_service,
                         yt_browser,
                         yt_anonymous,
+                        tidal_client_id,
+                        tidal_client_secret,
                         error,
                         on_close: move |_| show_add_server.set(false),
                         on_save: handle_add_server

--- a/crates/pages/src/settings_actions.rs
+++ b/crates/pages/src/settings_actions.rs
@@ -255,18 +255,15 @@ fn apply_tidal_login(
 /// form on first sign-in; re-logins read the stored pair (pass empty strings).
 pub fn tidal_auto_login(
     config: Signal<AppConfig>,
-    yt_browser: Signal<Browser>,
     client_id: String,
     client_secret: String,
     mut error: Signal<Option<String>>,
     mut playback_error: Signal<Option<String>>,
 ) {
-    let (browser, server_id, stored, stored_user) = {
+    let (stored, stored_user) = {
         let cfg = config.peek();
         let srv = cfg.server.as_ref();
         (
-            srv.and_then(|s| s.yt_browser).unwrap_or(*yt_browser.peek()),
-            srv.and_then(|s| s.id.clone()).unwrap_or_default(),
             srv.and_then(|s| s.access_token.as_deref())
                 .and_then(::server::tidal::unpack_creds),
             srv.and_then(|s| s.user_id.clone()),
@@ -313,14 +310,7 @@ pub fn tidal_auto_login(
             playback_error.set(Some(
                 "Complete the TIDAL sign-in in the browser window…".to_string(),
             ));
-            match ::server::tidal::signin(
-                browser,
-                &cid,
-                &csecret,
-                &server_id,
-                std::time::Duration::from_secs(300),
-            )
-            .await
+            match ::server::tidal::signin(&cid, &csecret, std::time::Duration::from_secs(300)).await
             {
                 Ok(grant) => {
                     apply_tidal_login(config, grant, stored, stored_user, cid, csecret);
@@ -428,7 +418,6 @@ pub fn add_server(
             } else if is_tidal {
                 tidal_auto_login(
                     config,
-                    yt_browser,
                     tidal_client_id.peek().clone(),
                     tidal_client_secret.peek().clone(),
                     error,
@@ -467,14 +456,9 @@ pub fn switch_server(
             MusicService::SoundCloud => {
                 soundcloud_auto_login(config, yt_browser, error, playback_error)
             }
-            MusicService::Tidal => tidal_auto_login(
-                config,
-                yt_browser,
-                String::new(),
-                String::new(),
-                error,
-                playback_error,
-            ),
+            MusicService::Tidal => {
+                tidal_auto_login(config, String::new(), String::new(), error, playback_error)
+            }
             _ => show_login.set(true),
         }
     });

--- a/crates/pages/src/settings_actions.rs
+++ b/crates/pages/src/settings_actions.rs
@@ -215,6 +215,131 @@ pub fn soundcloud_auto_login(
     });
 }
 
+/// Persist a granted TIDAL token set onto the active server: tokens + country
+/// pack into `access_token`, and `user_id` carries TIDAL's numeric userId.
+/// `old` is the previously-stored creds, so a refresh grant (which omits the
+/// refresh token / user object) keeps them.
+fn apply_tidal_login(
+    mut config: Signal<AppConfig>,
+    grant: ::server::tidal::TokenGrant,
+    old: Option<::server::tidal::Creds>,
+    old_user_id: Option<String>,
+    client_id: String,
+    client_secret: String,
+) {
+    let creds = ::server::tidal::Creds {
+        access: grant.access,
+        refresh: grant
+            .refresh
+            .or_else(|| old.as_ref().map(|c| c.refresh.clone()))
+            .unwrap_or_default(),
+        country: grant.country,
+        client_id,
+        client_secret,
+    };
+    let user_id = if grant.user_id.is_empty() {
+        old_user_id.unwrap_or_default()
+    } else {
+        grant.user_id
+    };
+    if let Some(server) = config.write().server.as_mut() {
+        server.access_token = Some(::server::tidal::pack_creds(&creds));
+        server.user_id = Some(user_id);
+    }
+}
+
+/// TIDAL sign-in via Authorization Code + PKCE against the user's own registered
+/// app: refresh silently with the stored token when possible, else open the
+/// default browser on the TIDAL authorize page and capture the redirect code on
+/// a loopback listener. `client_id`/`client_secret` come from the add-server
+/// form on first sign-in; re-logins read the stored pair (pass empty strings).
+pub fn tidal_auto_login(
+    config: Signal<AppConfig>,
+    yt_browser: Signal<Browser>,
+    client_id: String,
+    client_secret: String,
+    mut error: Signal<Option<String>>,
+    mut playback_error: Signal<Option<String>>,
+) {
+    let (browser, server_id, stored, stored_user) = {
+        let cfg = config.peek();
+        let srv = cfg.server.as_ref();
+        (
+            srv.and_then(|s| s.yt_browser).unwrap_or(*yt_browser.peek()),
+            srv.and_then(|s| s.id.clone()).unwrap_or_default(),
+            srv.and_then(|s| s.access_token.as_deref())
+                .and_then(::server::tidal::unpack_creds),
+            srv.and_then(|s| s.user_id.clone()),
+        )
+    };
+    // Prefer the freshly-entered client pair; fall back to the stored one on a
+    // re-login (the add-server form is gone by then).
+    let (cid, csecret) = match &stored {
+        Some(c) if client_id.trim().is_empty() => (c.client_id.clone(), c.client_secret.clone()),
+        _ => (
+            client_id.trim().to_string(),
+            client_secret.trim().to_string(),
+        ),
+    };
+    spawn(
+        async move {
+            if cid.is_empty() {
+                report_signin_failure(
+                    error,
+                    playback_error,
+                    "TIDAL sign-in needs a client ID from your developer.tidal.com app".to_string(),
+                );
+                return;
+            }
+
+            // A stored refresh token gets a new access token without a browser.
+            if let Some(creds) = &stored
+                && !creds.refresh.is_empty()
+                && let Ok(grant) =
+                    ::server::tidal::refresh_access(&cid, &csecret, &creds.refresh).await
+            {
+                apply_tidal_login(
+                    config,
+                    grant,
+                    stored.clone(),
+                    stored_user.clone(),
+                    cid,
+                    csecret,
+                );
+                error.set(None);
+                return;
+            }
+
+            playback_error.set(Some(
+                "Complete the TIDAL sign-in in the browser window…".to_string(),
+            ));
+            match ::server::tidal::signin(
+                browser,
+                &cid,
+                &csecret,
+                &server_id,
+                std::time::Duration::from_secs(300),
+            )
+            .await
+            {
+                Ok(grant) => {
+                    apply_tidal_login(config, grant, stored, stored_user, cid, csecret);
+                    error.set(None);
+                    playback_error.set(None);
+                }
+                Err(err) => {
+                    report_signin_failure(
+                        error,
+                        playback_error,
+                        format!("TIDAL sign-in failed: {err}"),
+                    );
+                }
+            }
+        }
+        .instrument(tracing::info_span!("tidal.auto_login")),
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn add_server(
     mut config: Signal<AppConfig>,
@@ -223,6 +348,8 @@ pub fn add_server(
     mut server_service: Signal<MusicService>,
     yt_browser: Signal<Browser>,
     yt_anonymous: Signal<bool>,
+    tidal_client_id: Signal<String>,
+    tidal_client_secret: Signal<String>,
     mut error: Signal<Option<String>>,
     mut show_add_server: Signal<bool>,
     mut show_login: Signal<bool>,
@@ -231,6 +358,7 @@ pub fn add_server(
     let selected_service = server_service();
     let is_ytmusic = selected_service == MusicService::YtMusic;
     let is_soundcloud = selected_service == MusicService::SoundCloud;
+    let is_tidal = selected_service == MusicService::Tidal;
     let is_browser_signin = selected_service.uses_browser_signin();
 
     if server_name().trim().is_empty() {
@@ -238,8 +366,15 @@ pub fn add_server(
         return;
     }
 
-    if !is_browser_signin && !server_url().starts_with("http") {
+    if !is_browser_signin && !is_tidal && !server_url().starts_with("http") {
         error.set(Some(i18n::t("invalid_server_url").to_string()));
+        return;
+    }
+
+    if is_tidal && tidal_client_id().trim().is_empty() {
+        error.set(Some(
+            "TIDAL needs a client ID from your developer.tidal.com app".to_string(),
+        ));
         return;
     }
 
@@ -254,6 +389,8 @@ pub fn add_server(
                 "https://music.youtube.com".to_string()
             } else if is_soundcloud {
                 "https://soundcloud.com".to_string()
+            } else if is_tidal {
+                "https://tidal.com".to_string()
             } else {
                 url_input
             };
@@ -268,7 +405,8 @@ pub fn add_server(
             if is_anon {
                 new_server.access_token = Some(String::new());
             }
-            new_server.yt_browser = (is_browser_signin && !is_anon).then(|| *yt_browser.peek());
+            new_server.yt_browser =
+                ((is_browser_signin && !is_anon) || is_tidal).then(|| *yt_browser.peek());
 
             let saved = config::SavedServer::from_music_server(&new_server);
             {
@@ -287,6 +425,15 @@ pub fn add_server(
                 ytmusic_auto_login(config, yt_browser, error, playback_error);
             } else if is_soundcloud {
                 soundcloud_auto_login(config, yt_browser, error, playback_error);
+            } else if is_tidal {
+                tidal_auto_login(
+                    config,
+                    yt_browser,
+                    tidal_client_id.peek().clone(),
+                    tidal_client_secret.peek().clone(),
+                    error,
+                    playback_error,
+                );
             } else if !is_browser_signin {
                 show_login.set(true);
             }
@@ -320,6 +467,14 @@ pub fn switch_server(
             MusicService::SoundCloud => {
                 soundcloud_auto_login(config, yt_browser, error, playback_error)
             }
+            MusicService::Tidal => tidal_auto_login(
+                config,
+                yt_browser,
+                String::new(),
+                String::new(),
+                error,
+                playback_error,
+            ),
             _ => show_login.set(true),
         }
     });
@@ -337,6 +492,9 @@ pub fn delete_saved(mut config: Signal<AppConfig>, id: String) {
         }
         Some(MusicService::SoundCloud) => {
             let _ = ::server::soundcloud::signin::delete_profile(&id);
+        }
+        Some(MusicService::Tidal) => {
+            let _ = ::server::tidal::delete_profile(&id);
         }
         _ => {}
     }

--- a/crates/reader/src/models.rs
+++ b/crates/reader/src/models.rs
@@ -85,6 +85,7 @@ impl TrackId {
             ("subsonic", config::MusicService::Subsonic),
             ("custom", config::MusicService::Custom),
             ("soundcloud", config::MusicService::SoundCloud),
+            ("tidal", config::MusicService::Tidal),
         ] {
             if let Some(rest) = s.strip_prefix(prefix).and_then(|r| r.strip_prefix(':')) {
                 let item_id = rest.split(':').next().unwrap_or("").to_string();
@@ -105,6 +106,7 @@ fn service_prefix(s: config::MusicService) -> &'static str {
         config::MusicService::Subsonic => "subsonic",
         config::MusicService::Custom => "custom",
         config::MusicService::SoundCloud => "soundcloud",
+        config::MusicService::Tidal => "tidal",
     }
 }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 tracing = { workspace = true }
+webbrowser = { workspace = true }
 directories = { workspace = true }
 jellyfin-sdk-rust = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -29,7 +29,17 @@ md5 = { workspace = true }
 sha1 = { workspace = true }
 httpdate = { workspace = true }
 hex = { workspace = true }
-tokio = { workspace = true, features = ["fs", "process", "rt", "sync"] }
+base64 = { workspace = true }
+sha2 = { workspace = true }
+tokio = { workspace = true, features = [
+    "fs",
+    "process",
+    "rt",
+    "sync",
+    "net",
+    "io-util",
+    "time",
+] }
 reader = { workspace = true }
 db = { workspace = true }
 utils = { workspace = true }
@@ -50,7 +60,6 @@ rustypipe-botguard = { workspace = true }
 # Windows native cookie decryption (v10 DPAPI + planted v20 app-bound). Reuses
 # the project's sqlx/sqlite (NOT rusqlite — that would double-link libsqlite3).
 [target.'cfg(windows)'.dependencies]
-base64 = { workspace = true }
 aes-gcm = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"] }
 windows-core = "0.62"

--- a/crates/server/src/cookies/browser.rs
+++ b/crates/server/src/cookies/browser.rs
@@ -176,14 +176,21 @@ pub(crate) async fn find_browser_bin(browser: Browser) -> Option<String> {
 pub(crate) fn browser_command(bin: &str) -> Command {
     // On Windows `bin` is a single executable path that can contain spaces
     // (e.g. `C:\Program Files\...`), so it must not be split. Elsewhere `bin`
-    // may be a multi-token command like `flatpak run <id>`, so split on spaces.
+    // is either a single executable path — which can also contain spaces, e.g.
+    // macOS `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` —
+    // or a multi-token command like `flatpak run <id>`, so split on spaces
+    // only when the whole string isn't an existing file.
     #[cfg(windows)]
     {
         Command::new(bin)
     }
     #[cfg(not(windows))]
     {
-        let cmd: Vec<&str> = bin.split(' ').collect();
+        let cmd: Vec<&str> = if std::path::Path::new(bin).is_file() {
+            vec![bin]
+        } else {
+            bin.split(' ').collect()
+        };
         if in_flatpak() {
             let mut c = Command::new("flatpak-spawn");
             c.args(["--host", "--watch-bus"]);

--- a/crates/server/src/cookies/mod.rs
+++ b/crates/server/src/cookies/mod.rs
@@ -8,5 +8,27 @@ pub(crate) mod windows_native;
 pub use profile::{delete_profile, profile_dir};
 pub use signin::launch_signin_and_extract;
 
+/// Pick an installed Chromium-family browser for sign-in, honoring `preferred`
+/// but demoting Brave (its fingerprint shields make TIDAL's DataDome device
+/// check fail with `UNSUPPORTED_OS`). Returns `None` if none are installed.
+pub async fn first_available_browser(preferred: config::Browser) -> Option<config::Browser> {
+    let mut order: Vec<config::Browser> = std::iter::once(preferred)
+        .chain(
+            config::Browser::ALL
+                .iter()
+                .copied()
+                .filter(|b| *b != preferred),
+        )
+        .collect();
+    // Stable sort keeps the preference order but sinks Brave below the rest.
+    order.sort_by_key(|b| (*b == config::Browser::Brave) as u8);
+    for b in order {
+        if browser::find_browser_bin(b).await.is_some() {
+            return Some(b);
+        }
+    }
+    None
+}
+
 pub(crate) use profile::has_cookie;
 pub(crate) use store::read_cookies;

--- a/crates/server/src/cookies/signin.rs
+++ b/crates/server/src/cookies/signin.rs
@@ -67,6 +67,7 @@ where
     let mut cmd = browser_command(&bin);
     cmd.arg("--no-first-run")
         .arg("--no-default-browser-check")
+        .arg("--disable-blink-features=AutomationControlled")
         .arg(format!("--user-data-dir={}", profile.display()));
     // Windows: kopuz's WebView2 UI runs us inside a job object whose sandbox
     // quota (1 active process) stops a spawned Chrome from creating the nested

--- a/crates/server/src/cover.rs
+++ b/crates/server/src/cover.rs
@@ -150,8 +150,7 @@ pub fn track(config: &AppConfig, track: &Track, max_width: u32) -> Option<CoverU
             max_width,
             80,
         ),
-        // SoundCloud stores the artwork URL directly in `cover` — no encoding.
-        MusicService::SoundCloud => track.cover.clone(),
+        MusicService::SoundCloud | MusicService::Tidal => track.cover.clone(),
     };
     utils::map_cover_url(url)
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,5 +1,5 @@
 //! Streaming server backends for Kopuz: Jellyfin, Subsonic/Navidrome,
-//! YouTube Music, and the local download queue manager.
+//! YouTube Music, TIDAL, and the local download queue manager.
 
 pub mod cookies;
 pub mod cover;
@@ -11,6 +11,7 @@ pub mod soundcloud;
 pub mod source;
 pub mod subsonic;
 pub mod sync;
+pub mod tidal;
 pub mod ytmusic;
 
 pub use download_queue::{DownloadItem, DownloadProgress, DownloadQueue, DownloadStatus};

--- a/crates/server/src/provider.rs
+++ b/crates/server/src/provider.rs
@@ -63,6 +63,11 @@ impl ProviderClient {
                  instead of username/password login"
                     .to_string(),
             ),
+            MusicService::Tidal => Err(
+                "TIDAL uses the OAuth device flow; sign in when adding the server instead of \
+                 username/password login"
+                    .to_string(),
+            ),
         }
     }
 

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -37,6 +37,7 @@ mod local;
 mod offline;
 mod soundcloud;
 mod subsonic;
+mod tidal;
 mod types;
 mod youtube_music;
 use jellyfin::JellyfinSource;
@@ -44,6 +45,7 @@ use local::LocalSource;
 use offline::OfflineServerSource;
 use soundcloud::SoundcloudSource;
 use subsonic::SubsonicSource;
+use tidal::TidalSource;
 pub use types::*;
 use youtube_music::YtSource;
 
@@ -768,6 +770,7 @@ fn remote_source(db: Db, source: Source, conn: &ServerConn) -> Box<dyn MediaSour
         }
         MusicService::YtMusic => Box::new(YtSource::new(db, source, conn)),
         MusicService::SoundCloud => Box::new(SoundcloudSource::new(db, source, conn)),
+        MusicService::Tidal => Box::new(TidalSource::new(db, source, conn)),
     }
 }
 

--- a/crates/server/src/source/tidal.rs
+++ b/crates/server/src/source/tidal.rs
@@ -1,0 +1,184 @@
+use async_trait::async_trait;
+use config::Source;
+use db::Db;
+
+use crate::server_ops::ServerConn;
+use crate::tidal::Creds;
+
+use super::{
+    AlbumType, ArtistView, AuthOutcome, Capabilities, FavoritesPage, FavoritesSync,
+    LibrarySnapshot, MediaSource, PlaylistMeta, PlaylistOps, SourceError, StreamInfo,
+};
+
+pub(super) struct TidalSource {
+    db: Db,
+    source: Source,
+    /// Unpacked device-flow credentials; `None` when the stored token isn't a
+    /// packed TIDAL credential set (never signed in / legacy value).
+    creds: Option<Creds>,
+    /// TIDAL's numeric userId (the favorites/playlists path segment).
+    user_id: String,
+}
+
+impl TidalSource {
+    pub(super) fn new(db: Db, source: Source, conn: &ServerConn) -> Self {
+        Self {
+            db,
+            source,
+            creds: crate::tidal::unpack_creds(&conn.token),
+            user_id: conn.user_id.clone(),
+        }
+    }
+
+    fn creds(&self) -> Result<&Creds, SourceError> {
+        self.creds.as_ref().ok_or(SourceError::Auth)
+    }
+}
+
+#[async_trait]
+impl MediaSource for TidalSource {
+    fn source(&self) -> &Source {
+        &self.source
+    }
+    fn db(&self) -> &Db {
+        &self.db
+    }
+
+    fn capabilities(&self) -> Capabilities {
+        Capabilities {
+            edit_tags: false,
+            delete_from_disk: false,
+            scan_folders: false,
+            folders: false,
+            sync: true,
+            downloads: false,
+            discover: false,
+            radio: false,
+            // Read-only for now: playlist mutation isn't wired.
+            playlists: PlaylistOps::None,
+            artist_view: ArtistView::Library,
+            albums: AlbumType::Standard,
+            favorites_sync: FavoritesSync::Paginated,
+        }
+    }
+
+    async fn resolve_stream(&self, item_id: &str) -> Result<StreamInfo, SourceError> {
+        let url = crate::tidal::resolve_stream(self.creds()?, item_id).await?;
+        Ok(StreamInfo {
+            url,
+            format: None,
+            user_agent: None,
+            duration_secs: None,
+            bitrate: None,
+            content_length: None,
+        })
+    }
+
+    async fn validate(&self) -> AuthOutcome {
+        let Some(creds) = self.creds.as_ref() else {
+            return AuthOutcome::Expired;
+        };
+        match crate::tidal::get_session(creds).await {
+            Ok(_) => AuthOutcome::Valid,
+            // The ~7-day access token lapsed — the sign-in flow refreshes it.
+            Err(e) if e.contains("401") => AuthOutcome::Expired,
+            Err(_) => AuthOutcome::Unreachable,
+        }
+    }
+
+    async fn fetch_library(&self) -> Result<LibrarySnapshot, SourceError> {
+        let (albums, tracks, artist_images) =
+            crate::tidal::fetch_library(self.creds()?, &self.user_id).await?;
+        Ok(LibrarySnapshot {
+            albums,
+            tracks,
+            artist_images,
+        })
+    }
+
+    async fn fetch_favorites(&self) -> Result<Vec<String>, SourceError> {
+        let creds = self.creds()?;
+        let mut ids = Vec::new();
+        let mut cursor: Option<String> = None;
+        loop {
+            let (tracks, next) =
+                crate::tidal::favorite_tracks_page(creds, &self.user_id, cursor.as_deref()).await?;
+            ids.extend(tracks.iter().map(|t| t.id.key().into_owned()));
+            match next {
+                Some(c) => cursor = Some(c),
+                None => break,
+            }
+        }
+        Ok(ids)
+    }
+
+    async fn fetch_favorites_page(
+        &self,
+        cursor: Option<String>,
+    ) -> Result<FavoritesPage, SourceError> {
+        let (tracks, next) =
+            crate::tidal::favorite_tracks_page(self.creds()?, &self.user_id, cursor.as_deref())
+                .await?;
+        Ok(FavoritesPage { tracks, next })
+    }
+
+    async fn push_favorite(&self, item_id: &str, on: bool) -> Result<(), SourceError> {
+        crate::tidal::set_track_favorite(self.creds()?, &self.user_id, item_id, on)
+            .await
+            .map_err(SourceError::from)
+    }
+
+    async fn search(
+        &self,
+        query: &str,
+    ) -> Result<(Vec<reader::Track>, Vec<reader::Album>), SourceError> {
+        let tracks = crate::tidal::search_tracks(self.creds()?, query).await?;
+        Ok((tracks, Vec::new()))
+    }
+
+    async fn fetch_playlists(&self) -> Result<Vec<PlaylistMeta>, SourceError> {
+        Ok(crate::tidal::list_playlists(self.creds()?, &self.user_id)
+            .await?
+            .into_iter()
+            .map(|p| PlaylistMeta {
+                id: p.id,
+                name: p.title,
+                image_tag: p.image_url,
+            })
+            .collect())
+    }
+
+    async fn fetch_playlist_entries(
+        &self,
+        playlist_id: &str,
+    ) -> Result<Vec<reader::Track>, SourceError> {
+        crate::tidal::get_playlist_entries(self.creds()?, playlist_id)
+            .await
+            .map_err(SourceError::from)
+    }
+
+    async fn add_to_playlist(
+        &self,
+        _playlist_id: &str,
+        _item_refs: &[String],
+    ) -> Result<Vec<String>, SourceError> {
+        Err(SourceError::unsupported("playlist add"))
+    }
+
+    async fn create_playlist(
+        &self,
+        _name: &str,
+        _item_refs: &[String],
+    ) -> Result<String, SourceError> {
+        Err(SourceError::unsupported("playlist create"))
+    }
+
+    async fn remove_from_playlist(
+        &self,
+        _playlist_id: &str,
+        _track: &reader::Track,
+        _position: usize,
+    ) -> Result<(), SourceError> {
+        Err(SourceError::unsupported("playlist remove"))
+    }
+}

--- a/crates/server/src/tidal.rs
+++ b/crates/server/src/tidal.rs
@@ -1,0 +1,1122 @@
+//! TIDAL integration via the **public** Developer API (`openapi.tidal.com/v2`,
+//! [JSON:API]) + the OAuth2 Authorization-Code-with-PKCE flow.
+//!
+//! Sign-in uses the **user's own registered app** (developer.tidal.com) — its
+//! client id is entered when adding the server; nothing is baked into the repo.
+//! kopuz opens the TIDAL authorize page in a **clean, isolated Chromium-family
+//! profile** (see [`signin`]), the user logs in, and TIDAL redirects to a
+//! loopback callback ([`REDIRECT_URI`]) that a short-lived local listener
+//! captures the authorization code from. The code + PKCE verifier are exchanged
+//! for tokens. No SPA, no cookie/localStorage scraping.
+//!
+//! The isolated profile is required because `login.tidal.com` is fronted by
+//! DataDome: it rejects Firefox and privacy-hardened/extension-laden browsers as
+//! `UNSUPPORTED_OS` (error 11102). For the authorize page to then load instead
+//! of erroring on the OAuth side, the developer.tidal.com app **must** also have
+//! (1) [`REDIRECT_URI`] registered verbatim and (2) every scope in [`SCOPE`]
+//! enabled — TIDAL errors the authorize request otherwise.
+//!
+//! Access tokens are refreshed with the stored refresh token against the same
+//! client. The token set + the client id/secret are packed into the single
+//! `access_token` config column (see [`Creds`]); `user_id` holds TIDAL's numeric
+//! userId, resolved from `/users/me` right after the grant (the public token
+//! response doesn't carry it).
+//!
+//! Catalog/collection/search all go through the v2 JSON:API. **Playback is not
+//! wired**: the v2 `trackManifests` endpoint returns Widevine-encrypted MPEG-DASH
+//! for every format, and full-length streams additionally require an access tier
+//! TIDAL grants selectively — see [`resolve_stream`]. Metadata browsing works;
+//! audio bytes do not.
+//!
+//! Track encoding mirrors SoundCloud: `TrackId::Server { Tidal, <trackId> }`,
+//! the artwork URL directly in `Track::cover`, and the album grid uses the
+//! subsonic-style `tidal:<albumId>:urlhex_<hex>` ref the shared cover resolver
+//! already understands.
+//!
+//! [JSON:API]: https://jsonapi.org/
+
+use std::collections::HashMap;
+
+use reader::models::Track;
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+/// Public Developer API base (JSON:API).
+const API_V2: &str = "https://openapi.tidal.com/v2";
+/// OAuth authorize page (browser) + token endpoint.
+const AUTHORIZE_URL: &str = "https://login.tidal.com/authorize";
+const TOKEN_URL: &str = "https://auth.tidal.com/v1/oauth2/token";
+/// Loopback redirect the local listener binds; the user must register this
+/// exact URI on their developer.tidal.com app.
+const REDIRECT_URI: &str = "http://localhost:8765/callback";
+const REDIRECT_PORT: u16 = 8765;
+/// JSON:API content type — v2 rejects requests without it.
+const JSON_API: &str = "application/vnd.api+json";
+
+/// OAuth scopes requested at sign-in. **Every one of these must be enabled on
+/// the developer.tidal.com app**, or the authorize page errors before login.
+/// `collection.write` powers favoriting; `playback`/`entitlements.read` are for
+/// the (currently DRM-blocked) stream endpoint.
+const SCOPE: &str = "user.read collection.read collection.write playlists.read search.read entitlements.read playback";
+
+/// A browser-shaped UA — the token/API hosts sit behind a WAF that drops
+/// UA-less requests.
+const USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(20))
+        .user_agent(USER_AGENT)
+        .build()
+        .unwrap_or_default()
+}
+
+/// Everything a signed-in TIDAL server needs, packed into the `access_token`
+/// config column: the tokens, the account country, and the user's own client
+/// id/secret (so a background refresh works without the add-server form). Secret
+/// is empty for a public PKCE client.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Creds {
+    pub access: String,
+    pub refresh: String,
+    /// The account's `country` — v2 catalog endpoints take it as `countryCode`.
+    pub country: String,
+    pub client_id: String,
+    pub client_secret: String,
+}
+
+pub fn pack_creds(c: &Creds) -> String {
+    format!(
+        "{}\n{}\n{}\n{}\n{}",
+        c.access, c.refresh, c.country, c.client_id, c.client_secret
+    )
+}
+
+pub fn unpack_creds(packed: &str) -> Option<Creds> {
+    let mut lines = packed.lines();
+    let creds = Creds {
+        access: lines.next()?.to_string(),
+        refresh: lines.next()?.to_string(),
+        country: lines.next().unwrap_or("US").to_string(),
+        client_id: lines.next().unwrap_or_default().to_string(),
+        client_secret: lines.next().unwrap_or_default().to_string(),
+    };
+    (!creds.access.is_empty()).then_some(creds)
+}
+
+/// A granted token set. `refresh` is absent on refresh-grant responses — the
+/// caller keeps the old one.
+#[derive(Debug, Clone)]
+pub struct TokenGrant {
+    pub access: String,
+    pub refresh: Option<String>,
+    pub user_id: String,
+    pub country: String,
+}
+
+/// A PKCE verifier + its S256 challenge for one sign-in attempt.
+struct Pkce {
+    verifier: String,
+    challenge: String,
+}
+
+fn b64url(bytes: &[u8]) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn new_pkce() -> Pkce {
+    let mut raw = [0u8; 32];
+    for b in raw.iter_mut() {
+        *b = rand::random::<u8>();
+    }
+    let verifier = b64url(&raw);
+    let challenge = b64url(&Sha256::digest(verifier.as_bytes()));
+    Pkce {
+        verifier,
+        challenge,
+    }
+}
+
+/// The authorize URL kopuz opens in the isolated sign-in browser.
+fn authorize_url(client_id: &str, challenge: &str, state: &str) -> String {
+    reqwest::Url::parse_with_params(
+        AUTHORIZE_URL,
+        &[
+            ("response_type", "code"),
+            ("client_id", client_id),
+            ("redirect_uri", REDIRECT_URI),
+            ("scope", SCOPE),
+            ("code_challenge_method", "S256"),
+            ("code_challenge", challenge),
+            ("state", state),
+        ],
+    )
+    .map(String::from)
+    .unwrap_or_default()
+}
+
+/// Legacy isolated-profile prefix. The public flow no longer creates one, but a
+/// server removed after an older sign-in may still have it on disk — keep the
+/// cleanup path so uninstalling a server tidies up.
+const PROFILE_PREFIX: &str = "tidal-profile";
+
+/// Remove any leftover isolated sign-in profile for a server (no-op if none).
+pub fn delete_profile(server_id: &str) -> std::io::Result<()> {
+    crate::cookies::delete_profile(PROFILE_PREFIX, server_id)
+}
+
+/// Run the PKCE sign-in in a **clean, isolated Chromium-family profile** — NOT
+/// the user's default browser.
+///
+/// TIDAL's `login.tidal.com/authorize` page is fronted by DataDome, whose device
+/// check rejects Firefox, privacy-hardened browsers, and profiles carrying
+/// ad-block/privacy extensions as `UNSUPPORTED_OS` (error 11102) — the authorize
+/// page then shows "Something went wrong". A fresh extension-less Chromium
+/// profile passes it, so we launch one (preferring plain Chrome/Chromium/Edge
+/// over Brave, whose shields also trip DataDome) rather than `webbrowser::open`,
+/// which would hand the URL to the user's default browser.
+///
+/// A background task owns the single loopback accept; the launcher's extract
+/// closure (polled while the browser is open) reads the captured code.
+#[tracing::instrument(name = "tidal.signin", skip(client_id, client_secret, server_id), fields(browser = %browser))]
+pub async fn signin(
+    browser: config::Browser,
+    client_id: &str,
+    client_secret: &str,
+    server_id: &str,
+    timeout: std::time::Duration,
+) -> Result<TokenGrant, String> {
+    let browser = crate::cookies::first_available_browser(browser)
+        .await
+        .ok_or(
+            "TIDAL sign-in needs Google Chrome, Chromium, or Edge installed — TIDAL's login page \
+         blocks Firefox and privacy-hardened browsers (DataDome error 11102 / UNSUPPORTED_OS)."
+                .to_string(),
+        )?;
+
+    let pkce = new_pkce();
+    let state = b64url(&rand::random::<[u8; 12]>());
+    let listener = bind_loopback().await?;
+
+    let slot: std::sync::Arc<tokio::sync::Mutex<Option<Result<String, String>>>> =
+        std::sync::Arc::new(tokio::sync::Mutex::new(None));
+    let cap_slot = slot.clone();
+    let cap_state = state.clone();
+    tokio::spawn(async move {
+        let r = capture_redirect_code(listener, &cap_state, timeout).await;
+        *cap_slot.lock().await = Some(r);
+    });
+
+    let url = authorize_url(client_id, &pkce.challenge, &state);
+    let poll_slot = slot.clone();
+    let launch = crate::cookies::launch_signin_and_extract(
+        browser,
+        server_id,
+        PROFILE_PREFIX,
+        &url,
+        timeout,
+        move |_browser, _profile| {
+            let slot = poll_slot.clone();
+            async move {
+                match &*slot.lock().await {
+                    None => Ok(None),
+                    Some(Ok(code)) => Ok(Some(code.clone())),
+                    Some(Err(e)) => Err(e.clone()),
+                }
+            }
+        },
+    )
+    .await;
+
+    let code = match launch {
+        Ok(code) => code,
+        Err(launch_err) => match slot.lock().await.take() {
+            Some(Err(e)) => return Err(e),
+            _ => return Err(launch_err),
+        },
+    };
+    exchange_code(client_id, client_secret, &code, &pkce.verifier).await
+}
+
+async fn bind_loopback() -> Result<tokio::net::TcpListener, String> {
+    tokio::net::TcpListener::bind(("127.0.0.1", REDIRECT_PORT))
+        .await
+        .map_err(|e| {
+            format!(
+                "TIDAL sign-in: couldn't bind the loopback callback on port {REDIRECT_PORT} ({e}) \
+                 — another sign-in may be in progress"
+            )
+        })
+}
+
+/// Accept one loopback request, parse `GET /callback?code=…&state=…`, verify the
+/// state, send a small close-me page, and return the code. Times out if the user
+/// never completes the browser login.
+async fn capture_redirect_code(
+    listener: tokio::net::TcpListener,
+    expect_state: &str,
+    timeout: std::time::Duration,
+) -> Result<String, String> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let accept = tokio::time::timeout_at(deadline, listener.accept()).await;
+        let (mut stream, _) = match accept {
+            Ok(Ok(pair)) => pair,
+            Ok(Err(e)) => return Err(format!("TIDAL sign-in: loopback accept failed: {e}")),
+            Err(_) => return Err("TIDAL sign-in timed out waiting for the browser".to_string()),
+        };
+
+        let mut buf = [0u8; 4096];
+        let n = stream.read(&mut buf).await.unwrap_or(0);
+        let req = String::from_utf8_lossy(&buf[..n]);
+        let target = req
+            .lines()
+            .next()
+            .and_then(|l| l.split_whitespace().nth(1))
+            .unwrap_or("");
+
+        if !target.starts_with("/callback") {
+            let _ = stream.write_all(b"HTTP/1.1 204 No Content\r\n\r\n").await;
+            continue;
+        }
+
+        let (body, result) = match parse_callback(target, expect_state) {
+            Ok(code) => ("TIDAL sign-in complete — you can close this tab.", Ok(code)),
+            Err(e) => ("TIDAL sign-in failed — return to kopuz.", Err(e)),
+        };
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\n\
+             Content-Length: {}\r\nConnection: close\r\n\r\n<html><body>{body}</body></html>",
+            body.len() + 26
+        );
+        let _ = stream.write_all(resp.as_bytes()).await;
+        let _ = stream.flush().await;
+        return result;
+    }
+}
+
+/// Pull the `code` from a `/callback?…` target, verifying `state` and surfacing
+/// an OAuth `error` param.
+fn parse_callback(target: &str, expect_state: &str) -> Result<String, String> {
+    let query = target.split_once('?').map(|(_, q)| q).unwrap_or("");
+    let mut code = None;
+    let mut state = None;
+    let mut error = None;
+    for pair in query.split('&') {
+        let Some((k, v)) = pair.split_once('=') else {
+            continue;
+        };
+        match k {
+            "code" => code = Some(v.to_string()),
+            "state" => state = Some(v.to_string()),
+            "error" => error = Some(v.to_string()),
+            _ => {}
+        }
+    }
+    if let Some(err) = error {
+        return Err(format!("TIDAL denied the sign-in: {err}"));
+    }
+    if state.as_deref() != Some(expect_state) {
+        return Err("TIDAL sign-in: state mismatch (possible CSRF) — try again".to_string());
+    }
+    code.filter(|c| !c.is_empty())
+        .ok_or_else(|| "TIDAL sign-in: redirect carried no code".to_string())
+}
+
+/// Exchange a redirect authorization code + its verifier for tokens, then fill
+/// in the account identity.
+async fn exchange_code(
+    client_id: &str,
+    client_secret: &str,
+    code: &str,
+    verifier: &str,
+) -> Result<TokenGrant, String> {
+    let (status, json) = post_token_form(
+        client_id,
+        client_secret,
+        &[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", REDIRECT_URI),
+            ("code_verifier", verifier),
+        ],
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(token_error(status, &json));
+    }
+    grant_with_identity(&json, None).await
+}
+
+/// Exchange a refresh token for a fresh access token, against the user's client.
+#[tracing::instrument(name = "tidal.refresh", skip_all)]
+pub async fn refresh_access(
+    client_id: &str,
+    client_secret: &str,
+    refresh: &str,
+) -> Result<TokenGrant, String> {
+    if refresh.is_empty() {
+        return Err("TIDAL: no refresh token stored".to_string());
+    }
+    let (status, json) = post_token_form(
+        client_id,
+        client_secret,
+        &[("grant_type", "refresh_token"), ("refresh_token", refresh)],
+    )
+    .await?;
+    if !status.is_success() {
+        return Err(token_error(status, &json));
+    }
+    grant_with_identity(&json, Some(refresh.to_string())).await
+}
+
+fn token_error(status: reqwest::StatusCode, json: &Value) -> String {
+    let err = str_field(json, "error").unwrap_or_else(|| status.to_string());
+    let detail = str_field(json, "error_description").unwrap_or_default();
+    format!("TIDAL token {status}: {err} {detail}")
+        .trim()
+        .to_string()
+}
+
+/// POST the token endpoint (client id + optional secret as form params — a
+/// public PKCE client sends an empty/absent secret) and return status + JSON.
+async fn post_token_form(
+    client_id: &str,
+    client_secret: &str,
+    extra: &[(&str, &str)],
+) -> Result<(reqwest::StatusCode, Value), String> {
+    let mut form: Vec<(&str, &str)> = vec![("client_id", client_id), ("scope", SCOPE)];
+    if !client_secret.is_empty() {
+        form.push(("client_secret", client_secret));
+    }
+    form.extend_from_slice(extra);
+    let resp = http_client()
+        .post(TOKEN_URL)
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| format!("TIDAL token HTTP: {e}"))?;
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("TIDAL token body: {e}"))?;
+    let json: Value = serde_json::from_str(&body)
+        .map_err(|e| format!("TIDAL token JSON ({status}): {e}; body: {body}"))?;
+    Ok((status, json))
+}
+
+/// Turn a raw token response into a [`TokenGrant`], resolving the numeric userId
+/// and account country from `/users/me` (the public token doesn't carry them).
+async fn grant_with_identity(
+    json: &Value,
+    keep_refresh: Option<String>,
+) -> Result<TokenGrant, String> {
+    let access = str_field(json, "access_token").ok_or("TIDAL grant: no access_token")?;
+    let refresh = str_field(json, "refresh_token").or(keep_refresh);
+    let (user_id, country) = fetch_me(&access).await?;
+    tracing::info!(user_id = %user_id, country = %country, "TIDAL grant parsed");
+    Ok(TokenGrant {
+        access,
+        refresh,
+        user_id,
+        country,
+    })
+}
+
+/// `GET /users/me` → `(numeric user id, country code)`. This is the first
+/// authenticated call, so a failure here is the earliest place a
+/// missing-scope/insufficient-tier problem surfaces.
+async fn fetch_me(access: &str) -> Result<(String, String), String> {
+    let doc = http_client()
+        .get(format!("{API_V2}/users/me"))
+        .bearer_auth(access)
+        .header(reqwest::header::ACCEPT, JSON_API)
+        .send()
+        .await
+        .map_err(|e| format!("TIDAL /users/me HTTP: {e}"))?
+        .error_for_status()
+        .map_err(|e| {
+            format!(
+                "TIDAL /users/me: {e} — is `user.read` enabled on your developer.tidal.com app?"
+            )
+        })?
+        .json::<Value>()
+        .await
+        .map_err(|e| format!("TIDAL /users/me JSON: {e}"))?;
+    let data = doc.get("data").cloned().unwrap_or_default();
+    let user_id = str_field(&data, "id")
+        .filter(|s| !s.is_empty())
+        .ok_or("TIDAL /users/me carried no user id")?;
+    let country = data
+        .get("attributes")
+        .and_then(|a| str_field(a, "country"))
+        .unwrap_or_else(|| "US".to_string());
+    Ok((user_id, country))
+}
+
+/// Build a `openapi.tidal.com/v2` URL from path segments (each percent-encoded),
+/// used for the search endpoint whose id is a raw query string.
+fn v2_url(segments: &[&str]) -> reqwest::Url {
+    let mut url = reqwest::Url::parse(API_V2).expect("valid base");
+    if let Ok(mut seg) = url.path_segments_mut() {
+        seg.extend(segments);
+    }
+    url
+}
+
+/// GET a JSON:API document. `segments` are appended (encoded) to `/v2`;
+/// `countryCode` + caller `query` are added. Returns the parsed document.
+async fn api_get(
+    creds: &Creds,
+    segments: &[&str],
+    query: &[(&str, &str)],
+) -> Result<Value, String> {
+    let url = v2_url(segments);
+    http_client()
+        .get(url)
+        .bearer_auth(&creds.access)
+        .header(reqwest::header::ACCEPT, JSON_API)
+        .query(&[("countryCode", creds.country.as_str())])
+        .query(query)
+        .send()
+        .await
+        .map_err(|e| format!("TIDAL API HTTP: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("TIDAL API HTTP: {e}"))?
+        .json::<Value>()
+        .await
+        .map_err(|e| format!("TIDAL API JSON: {e}"))
+}
+
+/// Validate the access token via `/users/me`. An error containing `401` means
+/// the token expired.
+pub(crate) async fn get_session(creds: &Creds) -> Result<Value, String> {
+    fetch_me(&creds.access)
+        .await
+        .map(|(id, country)| serde_json::json!({ "userId": id, "countryCode": country }))
+}
+
+/// A `(type, id)` key into a document's resource index.
+type ResKey = (String, String);
+
+fn ident(v: &Value) -> Option<ResKey> {
+    Some((
+        v.get("type")?.as_str()?.to_string(),
+        v.get("id")?.as_str()?.to_string(),
+    ))
+}
+
+/// Index every full resource (has `attributes`) in `data` + `included` by
+/// `(type, id)` so relationships can be resolved.
+fn index_resources(doc: &Value) -> HashMap<ResKey, Value> {
+    let mut map = HashMap::new();
+    for key in ["data", "included"] {
+        let arr = match doc.get(key) {
+            Some(Value::Array(a)) => a.clone(),
+            Some(v @ Value::Object(_)) => vec![v.clone()],
+            _ => continue,
+        };
+        for r in arr {
+            if r.get("attributes").is_none() {
+                continue;
+            }
+            if let Some(k) = ident(&r) {
+                map.insert(k, r);
+            }
+        }
+    }
+    map
+}
+
+/// The `data` resource identifiers of a document, in order.
+fn data_idents(doc: &Value) -> Vec<ResKey> {
+    match doc.get("data") {
+        Some(Value::Array(a)) => a.iter().filter_map(ident).collect(),
+        Some(v @ Value::Object(_)) => ident(v).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Resource identifiers of a to-one/to-many relationship on `res`.
+fn rel_idents(res: &Value, name: &str) -> Vec<ResKey> {
+    let data = res
+        .get("relationships")
+        .and_then(|r| r.get(name))
+        .and_then(|r| r.get("data"));
+    match data {
+        Some(Value::Array(a)) => a.iter().filter_map(ident).collect(),
+        Some(v @ Value::Object(_)) => ident(v).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// The `page[cursor]` value from `links.next`, if the listing continues.
+fn next_cursor(doc: &Value) -> Option<String> {
+    let next = doc.get("links").and_then(|l| l.get("next"))?.as_str()?;
+    let query = next.split_once('?').map(|(_, q)| q).unwrap_or(next);
+    for pair in query.split('&') {
+        if let Some(v) = pair
+            .strip_prefix("page%5Bcursor%5D=")
+            .or_else(|| pair.strip_prefix("page[cursor]="))
+        {
+            return Some(v.to_string());
+        }
+    }
+    None
+}
+
+/// Parse an ISO-8601 duration (`PT3M35S`) into whole seconds.
+fn parse_iso_duration(s: &str) -> u64 {
+    let s = s.strip_prefix("PT").unwrap_or(s);
+    let (mut total, mut num) = (0u64, 0u64);
+    for c in s.chars() {
+        match c {
+            '0'..='9' => num = num * 10 + (c as u64 - '0' as u64),
+            'H' => {
+                total += num * 3600;
+                num = 0;
+            }
+            'M' => {
+                total += num * 60;
+                num = 0;
+            }
+            'S' => {
+                total += num;
+                num = 0;
+            }
+            _ => num = 0,
+        }
+    }
+    total
+}
+
+/// The largest artwork file URL from a resolved `artworks` resource.
+fn artwork_url(idx: &HashMap<ResKey, Value>, res: &Value, rel: &str) -> Option<String> {
+    let art_key = rel_idents(res, rel).into_iter().next()?;
+    let art = idx.get(&art_key)?;
+    let files = art.get("attributes")?.get("files")?.as_array()?;
+    files
+        .iter()
+        .max_by_key(|f| {
+            f.get("meta")
+                .and_then(|m| m.get("width"))
+                .and_then(Value::as_u64)
+                .unwrap_or(0)
+        })
+        .and_then(|f| str_field(f, "href"))
+}
+
+fn str_field(v: &Value, key: &str) -> Option<String> {
+    v.get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// The album-grid ref for the shared cover resolver: subsonic-style
+/// `tidal:<albumId>:urlhex_<hex-of-url>` (or `:none` without art).
+fn album_ref(album_id: &str, cover_url: Option<&str>) -> String {
+    match cover_url {
+        Some(url) => format!("tidal:{album_id}:urlhex_{}", hex::encode(url.as_bytes())),
+        None => format!("tidal:{album_id}:none"),
+    }
+}
+
+/// Parse a v2 `tracks` resource (with its `artists`/`albums`/cover art already
+/// in `idx`) into the domain model.
+fn parse_track(res: &Value, idx: &HashMap<ResKey, Value>) -> Option<Track> {
+    let track_id = res.get("id")?.as_str()?.to_string();
+    let attrs = res.get("attributes")?;
+    let title = str_field(attrs, "title").unwrap_or_default();
+    let duration = str_field(attrs, "duration")
+        .map(|d| parse_iso_duration(&d))
+        .unwrap_or(0);
+
+    let artists: Vec<String> = rel_idents(res, "artists")
+        .iter()
+        .filter_map(|k| idx.get(k))
+        .filter_map(|a| a.get("attributes").and_then(|at| str_field(at, "name")))
+        .collect();
+
+    let (album_title, album_id, cover) = match rel_idents(res, "albums")
+        .into_iter()
+        .next()
+        .and_then(|k| idx.get(&k).cloned())
+    {
+        Some(album) => {
+            let a_id = album
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let a_title = album
+                .get("attributes")
+                .and_then(|at| str_field(at, "title"))
+                .unwrap_or_default();
+            let cover = artwork_url(idx, &album, "coverArt");
+            (a_title, a_id, cover)
+        }
+        None => (String::new(), String::new(), None),
+    };
+
+    Some(Track {
+        id: reader::models::TrackId::Server {
+            service: config::MusicService::Tidal,
+            item_id: track_id,
+        },
+        cover: cover.clone(),
+        album_id: if album_id.is_empty() {
+            String::new()
+        } else {
+            album_ref(&album_id, cover.as_deref())
+        },
+        title,
+        artist: artists.first().cloned().unwrap_or_default(),
+        album: album_title,
+        duration,
+        khz: 0,
+        bitrate: 0,
+        track_number: None,
+        disc_number: None,
+        musicbrainz_release_id: None,
+        musicbrainz_recording_id: None,
+        musicbrainz_track_id: None,
+        playlist_item_id: None,
+        artists,
+    })
+}
+
+/// Include paths that pull a track's artists + album + album cover into the same
+/// document, prefixed by the primary relationship name (`tracks`/`items`).
+fn track_includes(prefix: &str) -> String {
+    format!("{prefix}.artists,{prefix}.albums,{prefix}.albums.coverArt")
+}
+
+/// Resolve every `tracks` identifier in `doc`'s `data` to a domain [`Track`].
+fn tracks_from_doc(doc: &Value) -> Vec<Track> {
+    let idx = index_resources(doc);
+    data_idents(doc)
+        .iter()
+        .filter(|(t, _)| t == "tracks")
+        .filter_map(|k| idx.get(k))
+        .filter_map(|res| parse_track(res, &idx))
+        .collect()
+}
+
+/// One page of the user's collection tracks. `cursor` is the opaque
+/// `page[cursor]`; pass `None` first, then the returned value until `None`.
+#[tracing::instrument(name = "tidal.favorite_tracks_page", skip(creds, user_id))]
+pub(crate) async fn favorite_tracks_page(
+    creds: &Creds,
+    user_id: &str,
+    cursor: Option<&str>,
+) -> Result<(Vec<Track>, Option<String>), String> {
+    let includes = track_includes("tracks");
+    let mut query: Vec<(&str, &str)> = vec![("include", includes.as_str())];
+    if let Some(c) = cursor {
+        query.push(("page[cursor]", c));
+    }
+    let doc = api_get(
+        creds,
+        &["userCollections", user_id, "relationships", "tracks"],
+        &query,
+    )
+    .await?;
+    Ok((tracks_from_doc(&doc), next_cursor(&doc)))
+}
+
+/// Favorite / unfavorite one track on the account. Needs the `collection.write`
+/// scope enabled on the app.
+pub(crate) async fn set_track_favorite(
+    creds: &Creds,
+    user_id: &str,
+    track_id: &str,
+    on: bool,
+) -> Result<(), String> {
+    let url = v2_url(&["userCollections", user_id, "relationships", "tracks"]);
+    let body = serde_json::json!({ "data": [{ "type": "tracks", "id": track_id }] });
+    let http = http_client();
+    let req = if on { http.post(url) } else { http.delete(url) };
+    req.bearer_auth(&creds.access)
+        .header(reqwest::header::CONTENT_TYPE, JSON_API)
+        .header(reqwest::header::ACCEPT, JSON_API)
+        .query(&[("countryCode", creds.country.as_str())])
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("TIDAL favorite HTTP: {e}"))?
+        .error_for_status()
+        .map_err(|e| format!("TIDAL favorite HTTP: {e}"))?;
+    Ok(())
+}
+
+/// `(collected albums, their tracks, (artist name, photo URL) pairs)`.
+type LibrarySnapshot = (Vec<reader::Album>, Vec<Track>, Vec<(String, String)>);
+
+/// The user's library snapshot: collected albums (with their full track
+/// listings) + collected-artist photos. Collection *tracks* stay in the
+/// favorites partition (see [`favorite_tracks_page`]), matching how the other
+/// backends split library vs. likes.
+#[tracing::instrument(name = "tidal.fetch_library", skip_all)]
+pub(crate) async fn fetch_library(creds: &Creds, user_id: &str) -> Result<LibrarySnapshot, String> {
+    let mut albums = Vec::new();
+    let mut tracks = Vec::new();
+
+    let mut cursor: Option<String> = None;
+    loop {
+        let mut query: Vec<(&str, &str)> = vec![("include", "albums.artists,albums.coverArt")];
+        if let Some(c) = &cursor {
+            query.push(("page[cursor]", c));
+        }
+        let doc = api_get(
+            creds,
+            &["userCollections", user_id, "relationships", "albums"],
+            &query,
+        )
+        .await?;
+        let idx = index_resources(&doc);
+        for key in data_idents(&doc).into_iter().filter(|(t, _)| t == "albums") {
+            let Some(album) = idx.get(&key) else { continue };
+            let album_id = key.1.clone();
+            let attrs = album.get("attributes").cloned().unwrap_or_default();
+            let cover = artwork_url(&idx, album, "coverArt");
+            let id_ref = album_ref(&album_id, cover.as_deref());
+            let year = str_field(&attrs, "releaseDate")
+                .and_then(|d| d.get(..4).and_then(|y| y.parse::<u16>().ok()))
+                .unwrap_or(0);
+            let artist = rel_idents(album, "artists")
+                .iter()
+                .filter_map(|k| idx.get(k))
+                .find_map(|a| a.get("attributes").and_then(|at| str_field(at, "name")))
+                .unwrap_or_default();
+            albums.push(reader::Album {
+                id: id_ref.clone(),
+                title: str_field(&attrs, "title").unwrap_or_default(),
+                artist,
+                genre: String::new(),
+                year,
+                cover_path: Some(std::path::PathBuf::from(&id_ref)),
+                manual_cover: false,
+            });
+            match album_tracks(creds, &album_id).await {
+                Ok(items) => tracks.extend(items),
+                Err(e) => {
+                    tracing::warn!(album_id, error = %e, "TIDAL album tracks fetch failed; skipping")
+                }
+            }
+        }
+        match next_cursor(&doc) {
+            Some(c) => cursor = Some(c),
+            None => break,
+        }
+    }
+
+    let artist_images = collected_artist_images(creds, user_id)
+        .await
+        .unwrap_or_default();
+    Ok((albums, tracks, artist_images))
+}
+
+/// A collected album's full track list, in order (paginated).
+async fn album_tracks(creds: &Creds, album_id: &str) -> Result<Vec<Track>, String> {
+    let includes = track_includes("items");
+    let mut out = Vec::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let mut query: Vec<(&str, &str)> = vec![("include", includes.as_str())];
+        if let Some(c) = &cursor {
+            query.push(("page[cursor]", c));
+        }
+        let doc = api_get(
+            creds,
+            &["albums", album_id, "relationships", "items"],
+            &query,
+        )
+        .await?;
+        out.extend(tracks_from_doc(&doc));
+        match next_cursor(&doc) {
+            Some(c) => cursor = Some(c),
+            None => return Ok(out),
+        }
+    }
+}
+
+/// `(artist name, photo URL)` for each collected artist.
+async fn collected_artist_images(
+    creds: &Creds,
+    user_id: &str,
+) -> Result<Vec<(String, String)>, String> {
+    let mut out = Vec::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let mut query: Vec<(&str, &str)> = vec![("include", "artists.profileArt")];
+        if let Some(c) = &cursor {
+            query.push(("page[cursor]", c));
+        }
+        let doc = api_get(
+            creds,
+            &["userCollections", user_id, "relationships", "artists"],
+            &query,
+        )
+        .await?;
+        let idx = index_resources(&doc);
+        for key in data_idents(&doc)
+            .into_iter()
+            .filter(|(t, _)| t == "artists")
+        {
+            let Some(artist) = idx.get(&key) else {
+                continue;
+            };
+            let Some(name) = artist.get("attributes").and_then(|a| str_field(a, "name")) else {
+                continue;
+            };
+            if let Some(photo) = artwork_url(&idx, artist, "profileArt") {
+                out.push((name, photo));
+            }
+        }
+        match next_cursor(&doc) {
+            Some(c) => cursor = Some(c),
+            None => return Ok(out),
+        }
+    }
+}
+
+/// A playlist as listed in the user's collection.
+pub(crate) struct PlaylistSummary {
+    pub id: String,
+    pub title: String,
+    pub image_url: Option<String>,
+}
+
+/// The user's collected playlists (created + followed).
+#[tracing::instrument(name = "tidal.list_playlists", skip_all)]
+pub(crate) async fn list_playlists(
+    creds: &Creds,
+    user_id: &str,
+) -> Result<Vec<PlaylistSummary>, String> {
+    let mut out = Vec::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let mut query: Vec<(&str, &str)> = vec![("include", "playlists.coverArt")];
+        if let Some(c) = &cursor {
+            query.push(("page[cursor]", c));
+        }
+        let doc = api_get(
+            creds,
+            &["userCollections", user_id, "relationships", "playlists"],
+            &query,
+        )
+        .await?;
+        let idx = index_resources(&doc);
+        for key in data_idents(&doc)
+            .into_iter()
+            .filter(|(t, _)| t == "playlists")
+        {
+            let Some(p) = idx.get(&key) else { continue };
+            out.push(PlaylistSummary {
+                id: key.1.clone(),
+                title: p
+                    .get("attributes")
+                    .and_then(|a| str_field(a, "name"))
+                    .unwrap_or_default(),
+                image_url: artwork_url(&idx, p, "coverArt"),
+            });
+        }
+        match next_cursor(&doc) {
+            Some(c) => cursor = Some(c),
+            None => return Ok(out),
+        }
+    }
+}
+
+/// A playlist's full track list, in order (paginated).
+#[tracing::instrument(name = "tidal.playlist_entries", skip(creds))]
+pub(crate) async fn get_playlist_entries(
+    creds: &Creds,
+    playlist_id: &str,
+) -> Result<Vec<Track>, String> {
+    let includes = track_includes("items");
+    let mut out = Vec::new();
+    let mut cursor: Option<String> = None;
+    loop {
+        let mut query: Vec<(&str, &str)> = vec![("include", includes.as_str())];
+        if let Some(c) = &cursor {
+            query.push(("page[cursor]", c));
+        }
+        let doc = api_get(
+            creds,
+            &["playlists", playlist_id, "relationships", "items"],
+            &query,
+        )
+        .await?;
+        out.extend(tracks_from_doc(&doc));
+        match next_cursor(&doc) {
+            Some(c) => cursor = Some(c),
+            None => return Ok(out),
+        }
+    }
+}
+
+/// Search the TIDAL catalog for tracks. The query string is the search
+/// resource's id.
+#[tracing::instrument(name = "tidal.search", skip(creds), fields(query = %query))]
+pub(crate) async fn search_tracks(creds: &Creds, query: &str) -> Result<Vec<Track>, String> {
+    if query.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let includes = track_includes("tracks");
+    let doc = api_get(
+        creds,
+        &["searchResults", query, "relationships", "tracks"],
+        &[("include", includes.as_str())],
+    )
+    .await?;
+    Ok(tracks_from_doc(&doc))
+}
+
+/// Resolve a track to a playable stream URL.
+///
+/// **Not supported on the public API.** `trackManifests` returns
+/// Widevine-encrypted MPEG-DASH for every format, and full-length streams
+/// additionally require a higher developer access tier than THIRD_PARTY. We
+/// fetch the manifest only to surface the specific reason, then error — kopuz's
+/// player can neither decrypt Widevine nor demux DASH.
+#[tracing::instrument(name = "tidal.resolve_stream", skip(creds), fields(track_id = %track_id))]
+pub(crate) async fn resolve_stream(creds: &Creds, track_id: &str) -> Result<String, String> {
+    let doc = api_get(
+        creds,
+        &["trackManifests", track_id],
+        &[
+            ("manifestType", "MPEG_DASH"),
+            ("formats", "FLAC"),
+            ("uriScheme", "DATA"),
+            ("usage", "PLAYBACK"),
+            ("adaptive", "false"),
+        ],
+    )
+    .await?;
+    let attrs = doc.get("data").and_then(|d| d.get("attributes"));
+    if let Some(reason) = attrs.and_then(|a| str_field(a, "previewReason")) {
+        return Err(format!(
+            "TIDAL playback unavailable: only a preview is offered ({reason}). \
+             Full streaming needs a higher developer access tier."
+        ));
+    }
+    let drm = attrs
+        .and_then(|a| a.get("drmData"))
+        .and_then(|d| str_field(d, "drmSystem"));
+    Err(format!(
+        "TIDAL playback isn't supported through the public API: the stream is \
+         {} MPEG-DASH, which kopuz can't decrypt or demux.",
+        drm.as_deref().unwrap_or("DRM-protected")
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn creds_pack_roundtrip() {
+        let creds = Creds {
+            access: "a-token".into(),
+            refresh: "r-token".into(),
+            country: "DE".into(),
+            client_id: "cid".into(),
+            client_secret: "csecret".into(),
+        };
+        assert_eq!(unpack_creds(&pack_creds(&creds)).as_ref(), Some(&creds));
+        assert!(unpack_creds("").is_none());
+    }
+
+    #[test]
+    fn parse_callback_extracts_code() {
+        assert_eq!(
+            parse_callback("/callback?code=ABC123&state=xy", "xy").as_deref(),
+            Ok("ABC123")
+        );
+        assert!(parse_callback("/callback?code=ABC&state=bad", "xy").is_err());
+        assert!(parse_callback("/callback?error=access_denied&state=xy", "xy").is_err());
+    }
+
+    #[test]
+    fn pkce_challenge_is_sha256_of_verifier() {
+        let p = new_pkce();
+        assert_eq!(p.challenge, b64url(&Sha256::digest(p.verifier.as_bytes())));
+        assert!(!p.verifier.contains('=') && !p.verifier.contains('+'));
+    }
+
+    #[test]
+    fn iso_duration_parses() {
+        assert_eq!(parse_iso_duration("PT3M35S"), 215);
+        assert_eq!(parse_iso_duration("PT1H2M3S"), 3723);
+        assert_eq!(parse_iso_duration("PT45S"), 45);
+        assert_eq!(parse_iso_duration("PT0S"), 0);
+    }
+
+    #[test]
+    fn next_cursor_extracts_page_cursor() {
+        let doc = serde_json::json!({
+            "links": { "next": "/v2/userCollections/1/relationships/tracks?page%5Bcursor%5D=abc123&countryCode=US" }
+        });
+        assert_eq!(next_cursor(&doc).as_deref(), Some("abc123"));
+        let none = serde_json::json!({ "links": { "self": "x" } });
+        assert!(next_cursor(&none).is_none());
+    }
+
+    #[test]
+    fn parse_track_resolves_jsonapi_relationships() {
+        let doc = serde_json::json!({
+            "data": [{
+                "type": "tracks", "id": "77646437",
+                "attributes": { "title": "Song", "duration": "PT3M35S" },
+                "relationships": {
+                    "artists": { "data": [{"type":"artists","id":"a1"},{"type":"artists","id":"a2"}] },
+                    "albums": { "data": [{"type":"albums","id":"al1"}] }
+                }
+            }],
+            "included": [
+                {"type":"artists","id":"a1","attributes":{"name":"Main Artist"}},
+                {"type":"artists","id":"a2","attributes":{"name":"Feature"}},
+                {"type":"albums","id":"al1","attributes":{"title":"Album"},
+                 "relationships":{"coverArt":{"data":{"type":"artworks","id":"art1"}}}},
+                {"type":"artworks","id":"art1","attributes":{"files":[
+                    {"href":"https://resources.tidal.com/images/x/80.jpg","meta":{"width":80}},
+                    {"href":"https://resources.tidal.com/images/x/640.jpg","meta":{"width":640}}
+                ]}}
+            ]
+        });
+        let tracks = tracks_from_doc(&doc);
+        assert_eq!(tracks.len(), 1);
+        let t = &tracks[0];
+        assert_eq!(t.id.key(), "77646437");
+        assert_eq!(t.id.service(), Some(config::MusicService::Tidal));
+        assert_eq!(t.title, "Song");
+        assert_eq!(t.artist, "Main Artist");
+        assert_eq!(t.artists, vec!["Main Artist", "Feature"]);
+        assert_eq!(t.album, "Album");
+        assert_eq!(t.duration, 215);
+        assert_eq!(
+            t.cover.as_deref(),
+            Some("https://resources.tidal.com/images/x/640.jpg")
+        );
+        assert!(t.album_id.starts_with("tidal:al1:urlhex_"));
+    }
+
+    #[test]
+    fn parse_track_without_album_has_empty_ref() {
+        let doc = serde_json::json!({
+            "data": [{ "type": "tracks", "id": "1",
+                "attributes": { "title": "Lonely", "duration": "PT10S" } }]
+        });
+        let tracks = tracks_from_doc(&doc);
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].album_id, "");
+        assert_eq!(tracks[0].duration, 10);
+    }
+}

--- a/crates/server/src/tidal.rs
+++ b/crates/server/src/tidal.rs
@@ -3,18 +3,18 @@
 //!
 //! Sign-in uses the **user's own registered app** (developer.tidal.com) — its
 //! client id is entered when adding the server; nothing is baked into the repo.
-//! kopuz opens the TIDAL authorize page in a **clean, isolated Chromium-family
-//! profile** (see [`signin`]), the user logs in, and TIDAL redirects to a
-//! loopback callback ([`REDIRECT_URI`]) that a short-lived local listener
-//! captures the authorization code from. The code + PKCE verifier are exchanged
-//! for tokens. No SPA, no cookie/localStorage scraping.
+//! kopuz opens the TIDAL authorize page in the **user's default browser** (see
+//! [`signin`]), the user logs in, and TIDAL redirects to a loopback callback
+//! ([`REDIRECT_URI`]) that a short-lived local listener captures the
+//! authorization code from. The code + PKCE verifier are exchanged for tokens.
+//! No SPA, no cookie/localStorage scraping.
 //!
-//! The isolated profile is required because `login.tidal.com` is fronted by
-//! DataDome: it rejects Firefox and privacy-hardened/extension-laden browsers as
-//! `UNSUPPORTED_OS` (error 11102). For the authorize page to then load instead
-//! of erroring on the OAuth side, the developer.tidal.com app **must** also have
-//! (1) [`REDIRECT_URI`] registered verbatim and (2) every scope in [`SCOPE`]
-//! enabled — TIDAL errors the authorize request otherwise.
+//! For the authorize page to load instead of erroring (a 400 renders as TIDAL
+//! error 11102, "Something went wrong"), the developer.tidal.com app **must**
+//! have (1) [`REDIRECT_URI`] registered verbatim and (2) every scope in
+//! [`SCOPE`] enabled. `login.tidal.com` is also fronted by DataDome, which can
+//! reject privacy-hardened/extension-laden browsers as `UNSUPPORTED_OS` (same
+//! 11102 error page).
 //!
 //! Access tokens are refreshed with the stored refresh token against the same
 //! client. The token set + the client id/secret are packed into the single
@@ -167,76 +167,29 @@ pub fn delete_profile(server_id: &str) -> std::io::Result<()> {
     crate::cookies::delete_profile(PROFILE_PREFIX, server_id)
 }
 
-/// Run the PKCE sign-in in a **clean, isolated Chromium-family profile** — NOT
-/// the user's default browser.
+/// Run the PKCE sign-in in the **user's default browser**: open the authorize
+/// page, then wait on the loopback listener for TIDAL's redirect carrying the
+/// authorization code.
 ///
-/// TIDAL's `login.tidal.com/authorize` page is fronted by DataDome, whose device
-/// check rejects Firefox, privacy-hardened browsers, and profiles carrying
-/// ad-block/privacy extensions as `UNSUPPORTED_OS` (error 11102) — the authorize
-/// page then shows "Something went wrong". A fresh extension-less Chromium
-/// profile passes it, so we launch one (preferring plain Chrome/Chromium/Edge
-/// over Brave, whose shields also trip DataDome) rather than `webbrowser::open`,
-/// which would hand the URL to the user's default browser.
-///
-/// A background task owns the single loopback accept; the launcher's extract
-/// closure (polled while the browser is open) reads the captured code.
-#[tracing::instrument(name = "tidal.signin", skip(client_id, client_secret, server_id), fields(browser = %browser))]
+/// If the page shows TIDAL error 11102 ("Something went wrong") instead of the
+/// login form, either the developer.tidal.com app is misconfigured (redirect
+/// URI/scopes — see [`REDIRECT_URI`] and [`SCOPE`]) or DataDome rejected the
+/// browser (`UNSUPPORTED_OS`).
+#[tracing::instrument(name = "tidal.signin", skip_all)]
 pub async fn signin(
-    browser: config::Browser,
     client_id: &str,
     client_secret: &str,
-    server_id: &str,
     timeout: std::time::Duration,
 ) -> Result<TokenGrant, String> {
-    let browser = crate::cookies::first_available_browser(browser)
-        .await
-        .ok_or(
-            "TIDAL sign-in needs Google Chrome, Chromium, or Edge installed — TIDAL's login page \
-         blocks Firefox and privacy-hardened browsers (DataDome error 11102 / UNSUPPORTED_OS)."
-                .to_string(),
-        )?;
-
     let pkce = new_pkce();
     let state = b64url(&rand::random::<[u8; 12]>());
     let listener = bind_loopback().await?;
 
-    let slot: std::sync::Arc<tokio::sync::Mutex<Option<Result<String, String>>>> =
-        std::sync::Arc::new(tokio::sync::Mutex::new(None));
-    let cap_slot = slot.clone();
-    let cap_state = state.clone();
-    tokio::spawn(async move {
-        let r = capture_redirect_code(listener, &cap_state, timeout).await;
-        *cap_slot.lock().await = Some(r);
-    });
-
     let url = authorize_url(client_id, &pkce.challenge, &state);
-    let poll_slot = slot.clone();
-    let launch = crate::cookies::launch_signin_and_extract(
-        browser,
-        server_id,
-        PROFILE_PREFIX,
-        &url,
-        timeout,
-        move |_browser, _profile| {
-            let slot = poll_slot.clone();
-            async move {
-                match &*slot.lock().await {
-                    None => Ok(None),
-                    Some(Ok(code)) => Ok(Some(code.clone())),
-                    Some(Err(e)) => Err(e.clone()),
-                }
-            }
-        },
-    )
-    .await;
+    webbrowser::open(&url)
+        .map_err(|e| format!("TIDAL sign-in: couldn't open the default browser: {e}"))?;
 
-    let code = match launch {
-        Ok(code) => code,
-        Err(launch_err) => match slot.lock().await.take() {
-            Some(Err(e)) => return Err(e),
-            _ => return Err(launch_err),
-        },
-    };
+    let code = capture_redirect_code(listener, &state, timeout).await?;
     exchange_code(client_id, client_secret, &code, &pkce.verifier).await
 }
 
@@ -300,20 +253,19 @@ async fn capture_redirect_code(
 }
 
 /// Pull the `code` from a `/callback?…` target, verifying `state` and surfacing
-/// an OAuth `error` param.
+/// an OAuth `error` param. Values are percent-decoded — a still-encoded code
+/// would get encoded a second time in the token exchange form.
 fn parse_callback(target: &str, expect_state: &str) -> Result<String, String> {
-    let query = target.split_once('?').map(|(_, q)| q).unwrap_or("");
+    let url = reqwest::Url::parse(&format!("http://localhost{target}"))
+        .map_err(|e| format!("TIDAL sign-in: unparsable callback ({e})"))?;
     let mut code = None;
     let mut state = None;
     let mut error = None;
-    for pair in query.split('&') {
-        let Some((k, v)) = pair.split_once('=') else {
-            continue;
-        };
-        match k {
-            "code" => code = Some(v.to_string()),
-            "state" => state = Some(v.to_string()),
-            "error" => error = Some(v.to_string()),
+    for (k, v) in url.query_pairs() {
+        match k.as_ref() {
+            "code" => code = Some(v.into_owned()),
+            "state" => state = Some(v.into_owned()),
+            "error" => error = Some(v.into_owned()),
             _ => {}
         }
     }
@@ -1042,6 +994,18 @@ mod tests {
         );
         assert!(parse_callback("/callback?code=ABC&state=bad", "xy").is_err());
         assert!(parse_callback("/callback?error=access_denied&state=xy", "xy").is_err());
+    }
+
+    #[test]
+    fn parse_callback_percent_decodes() {
+        assert_eq!(
+            parse_callback("/callback?code=eyJ%2Fab%3D%3D&state=xy", "xy").as_deref(),
+            Ok("eyJ/ab==")
+        );
+        assert_eq!(
+            parse_callback("/callback?error=access%20denied&state=xy", "xy"),
+            Err("TIDAL denied the sign-in: access denied".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add a TIDAL media source backed by the public Developer API (openapi.tidal.com/v2, JSON:API) with OAuth2 Authorization-Code + PKCE sign-in against the user's own developer.tidal.com client.

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
