### PR TITLE
fix: remote favorites sync

### DIFF
--- a/crates/components/src/normal/bottombar.rs
+++ b/crates/components/src/normal/bottombar.rs
@@ -4,7 +4,8 @@ use dioxus::prelude::*;
 use hooks::use_player_controller::{LoopMode, PlayerController};
 use player::player::Player;
 
-use crate::shared::{fmt_time, toggle_favorite};
+use crate::shared::fmt_time;
+use hooks::favorites::toggle_favorite;
 
 #[component]
 pub fn BottombarNormal(

--- a/crates/components/src/shared.rs
+++ b/crates/components/src/shared.rs
@@ -1,6 +1,3 @@
-use dioxus::prelude::*;
-use server::source::TrackFavorite;
-
 pub fn fmt_time(secs: u64) -> String {
     if secs == u64::MAX {
         return "--:--".to_string();
@@ -8,42 +5,4 @@ pub fn fmt_time(secs: u64) -> String {
     let m = secs / 60;
     let s = secs % 60;
     format!("{m}:{s:02}")
-}
-
-/// Toggle a favorite, offline-capable: the DB records the change as a pending
-/// row (`dirty`) and the background reconciler pushes it to the server when one
-/// is reachable. No auth required at toggle time — anonymous likes queue up and
-/// flush on sign-in.
-pub fn toggle_favorite(current_track: Option<reader::models::Track>) {
-    let Some(track) = current_track else { return };
-    let ref_ = track.id.key().to_string();
-    if ref_.trim().is_empty() {
-        return;
-    }
-    let Some(source_sig) = try_consume_context::<Signal<::server::source::ActiveSource>>() else {
-        return;
-    };
-    let gens = try_consume_context::<hooks::db_reactivity::Generations>();
-    let source = source_sig.peek().clone();
-    spawn(async move {
-        let new_fav = !track.is_favorite(&source).await;
-        if new_fav {
-            // Cache the track so the favorites view (which resolves refs → the
-            // `tracks` table) can display it immediately, instead of only after
-            // the next sync upserts it. Harmless for a track already cached.
-            let _ = source.upsert_tracks(std::slice::from_ref(&track)).await;
-        }
-        if let Err(e) = track.set_favorite(&source, new_fav).await {
-            tracing::warn!(error = %e, "failed to record favorite toggle");
-        }
-        if let Some(gens) = gens {
-            gens.bump(hooks::db_reactivity::Table::Favorites);
-            gens.bump(hooks::db_reactivity::Table::Tracks);
-        }
-        // A like on a syncing source is a pending DB row until the reconciler
-        // flushes it — nudge it. (Local has no remote to push to.)
-        if source.capabilities().sync {
-            hooks::use_sync_task::nudge();
-        }
-    });
 }

--- a/crates/components/src/track_row.rs
+++ b/crates/components/src/track_row.rs
@@ -8,6 +8,7 @@ use crate::queue_drag::{
 use config::{AppConfig, UiStyle};
 use dioxus::prelude::*;
 use hooks::PlayerController;
+use hooks::toast::toast;
 use reader::models::Track;
 use tracing::Instrument;
 
@@ -33,26 +34,6 @@ pub(crate) fn share_to_musicbrainz(release_id: Option<String>, artist: String, t
         }
         .instrument(tracing::info_span!("musicbrainz.fetch")),
     );
-}
-
-fn toast(msg: &str) {
-    let escaped = serde_json::to_string(msg).unwrap_or_else(|_| "\"\"".to_string());
-    let js = format!(
-        r#"(function(m){{
-            let t = document.getElementById('kopuz-toast');
-            if (!t) {{
-                t = document.createElement('div');
-                t.id = 'kopuz-toast';
-                t.style.cssText = 'position:fixed;left:50%;bottom:88px;transform:translateX(-50%);background:rgba(20,20,20,0.95);color:#fff;padding:10px 18px;border-radius:8px;font:14px system-ui,sans-serif;z-index:99999;box-shadow:0 4px 16px rgba(0,0,0,0.4);pointer-events:none;opacity:0;transition:opacity 150ms;border:1px solid rgba(255,255,255,0.1);';
-                document.body.appendChild(t);
-            }}
-            t.textContent = m;
-            t.style.opacity = '1';
-            clearTimeout(t._h);
-            t._h = setTimeout(() => {{ t.style.opacity = '0'; }}, 1800);
-        }})({escaped});"#
-    );
-    let _ = dioxus::document::eval(&js);
 }
 
 #[component]

--- a/crates/components/src/vaxry/bottombar.rs
+++ b/crates/components/src/vaxry/bottombar.rs
@@ -4,7 +4,8 @@ use dioxus::prelude::*;
 use hooks::use_player_controller::{LoopMode, PlayerController};
 use player::player::Player;
 
-use crate::shared::{fmt_time, toggle_favorite};
+use crate::shared::fmt_time;
+use hooks::favorites::toggle_favorite;
 
 #[component]
 pub fn BottombarVaxry(

--- a/crates/hooks/src/favorites.rs
+++ b/crates/hooks/src/favorites.rs
@@ -33,14 +33,22 @@ pub fn toggle_favorite(track: Option<Track>) {
             tracing::warn!(error = %e, track = %track.id.uid(), "favorite: local write failed");
             return;
         }
-        bump_favorites(gens);
+        // Favorites changed; Tracks too (record_favorite caches the track).
+        gens.bump(Table::Favorites);
+        gens.bump(Table::Tracks);
 
         // Push in the background; revert the local state if the remote rejects it.
         if let Err(e) = source.push_favorite(&key, new_fav).await {
             tracing::warn!(error = %e, track = %track.id.uid(), "favorite push rejected; reverting");
             let _ = source.record_favorite(&track, !new_fav).await;
-            bump_favorites(gens);
-            crate::toast::toast_error(&favorite_error(&track));
+            gens.bump(Table::Favorites);
+            gens.bump(Table::Tracks);
+            // Name the service so a snapped-back heart doesn't read as a broken UI.
+            let msg = match track.id.service() {
+                Some(service) => format!("Couldn't update favorite on {}", service.display_name()),
+                None => "Couldn't update favorite".to_string(),
+            };
+            crate::toast::toast_error(&msg);
         }
     });
 }
@@ -76,7 +84,9 @@ pub fn set_favorite_many(tracks: Vec<Track>, on: bool) {
         if recorded.is_empty() {
             return;
         }
-        bump_favorites(gens);
+        // Favorites changed; Tracks too (record_favorite caches the tracks).
+        gens.bump(Table::Favorites);
+        gens.bump(Table::Tracks);
 
         // Push each; revert the ones the remote rejects.
         let mut reverted = false;
@@ -89,22 +99,9 @@ pub fn set_favorite_many(tracks: Vec<Track>, on: bool) {
             }
         }
         if reverted {
-            bump_favorites(gens);
+            gens.bump(Table::Favorites);
+            gens.bump(Table::Tracks);
             crate::toast::toast_error("Couldn't update some favorites");
         }
     });
-}
-
-/// A short "the server rejected it" notice, so a reverted heart doesn't read as
-/// a broken UI. Names the service when the track has one.
-fn favorite_error(track: &Track) -> String {
-    match track.id.service() {
-        Some(service) => format!("Couldn't update favorite on {}", service.display_name()),
-        None => "Couldn't update favorite".to_string(),
-    }
-}
-
-fn bump_favorites(gens: Generations) {
-    gens.bump(Table::Favorites);
-    gens.bump(Table::Tracks);
 }

--- a/crates/hooks/src/favorites.rs
+++ b/crates/hooks/src/favorites.rs
@@ -1,0 +1,120 @@
+//! Favorite toggling on the active source, optimistically.
+//!
+//! The heart flips immediately: the local state is written
+//! ([`record_favorite`](server::source::MediaSource::record_favorite)) and shown,
+//! then the change is pushed to the remote in the background
+//! ([`push_favorite`](server::source::MediaSource::push_favorite)); if the push
+//! is rejected the local state is reverted and a toast explains why, so a
+//! snapping-back heart doesn't read as a broken UI.
+
+use dioxus::prelude::*;
+use reader::Track;
+use server::source::ActiveSource;
+
+use crate::db_reactivity::{Generations, Table};
+
+/// Toggle `track`'s favorite state on the active source, optimistically (write +
+/// show immediately, push in the background, revert + toast if the remote
+/// rejects it). A no-op for an empty key.
+pub fn toggle_favorite(track: Option<Track>) {
+    let Some(track) = track else { return };
+    if track.id.key().trim().is_empty() {
+        return;
+    }
+    let Some(source) = active_source() else {
+        return;
+    };
+    let gens = try_consume_context::<Generations>();
+
+    spawn(async move {
+        let key = track.id.key().to_string();
+        let new_fav = !source.is_favorite(&key).await;
+
+        // Optimistic: write locally and reflect it on the heart right away.
+        if let Err(e) = source.record_favorite(&track, new_fav).await {
+            tracing::warn!(error = %e, track = %track.id.uid(), "favorite: local write failed");
+            return;
+        }
+        bump_favorites(gens);
+
+        // Push in the background; revert the local state if the remote rejects it.
+        if let Err(e) = source.push_favorite(&key, new_fav).await {
+            tracing::warn!(error = %e, track = %track.id.uid(), "favorite push rejected; reverting");
+            let _ = source.record_favorite(&track, !new_fav).await;
+            bump_favorites(gens);
+            crate::toast::toast_error(&favorite_error(&track));
+        }
+    });
+}
+
+/// Set every track in `tracks` to `on` on the active source (the home-hero heart,
+/// favoriting a whole album). Optimistic: all are recorded and shown, then
+/// pushed; any the remote rejects are reverted.
+pub fn set_favorite_many(tracks: Vec<Track>, on: bool) {
+    if tracks.is_empty() {
+        return;
+    }
+    let Some(source) = active_source() else {
+        return;
+    };
+    let gens = try_consume_context::<Generations>();
+
+    spawn(async move {
+        // Optimistic: record every track locally, then show them all.
+        let mut recorded = Vec::new();
+        for track in tracks {
+            if track.id.key().trim().is_empty() {
+                continue;
+            }
+            if source.record_favorite(&track, on).await.is_ok() {
+                recorded.push(track);
+            }
+        }
+        if recorded.is_empty() {
+            return;
+        }
+        bump_favorites(gens);
+
+        // Push each; revert the ones the remote rejects.
+        let mut reverted = false;
+        for track in recorded {
+            let key = track.id.key().to_string();
+            if let Err(e) = source.push_favorite(&key, on).await {
+                tracing::warn!(error = %e, track = %track.id.uid(), "favorite push rejected; reverting");
+                let _ = source.record_favorite(&track, !on).await;
+                reverted = true;
+            }
+        }
+        if reverted {
+            bump_favorites(gens);
+            crate::toast::toast_error("Couldn't update some favorites");
+        }
+    });
+}
+
+/// The active source handle, or `None` (with a warn) when the context is missing.
+fn active_source() -> Option<ActiveSource> {
+    match try_consume_context::<Signal<ActiveSource>>() {
+        Some(sig) => Some(sig.peek().clone()),
+        None => {
+            tracing::warn!("favorite toggle: no ActiveSource context");
+            None
+        }
+    }
+}
+
+/// A short "the server rejected it" notice, so a reverted heart doesn't read as
+/// a broken UI. Names the service when the track has one.
+fn favorite_error(track: &Track) -> String {
+    match track.id.service() {
+        Some(service) => format!("Couldn't update favorite on {}", service.display_name()),
+        None => "Couldn't update favorite".to_string(),
+    }
+}
+
+fn bump_favorites(gens: Option<Generations>) {
+    if let Some(gens) = gens {
+        gens.bump(Table::Favorites);
+        gens.bump(Table::Tracks);
+    }
+}

--- a/crates/hooks/src/favorites.rs
+++ b/crates/hooks/src/favorites.rs
@@ -21,10 +21,8 @@ pub fn toggle_favorite(track: Option<Track>) {
     if track.id.key().trim().is_empty() {
         return;
     }
-    let Some(source) = active_source() else {
-        return;
-    };
-    let gens = try_consume_context::<Generations>();
+    let source = consume_context::<Signal<ActiveSource>>().peek().clone();
+    let gens = consume_context::<Generations>();
 
     spawn(async move {
         let key = track.id.key().to_string();
@@ -54,16 +52,21 @@ pub fn set_favorite_many(tracks: Vec<Track>, on: bool) {
     if tracks.is_empty() {
         return;
     }
-    let Some(source) = active_source() else {
-        return;
-    };
-    let gens = try_consume_context::<Generations>();
+    let source = consume_context::<Signal<ActiveSource>>().peek().clone();
+    let gens = consume_context::<Generations>();
 
     spawn(async move {
-        // Optimistic: record every track locally, then show them all.
+        // Optimistic: record every track locally, then show them all. Tracks
+        // already in the target state are skipped — pushing them again is at
+        // best wasted requests, at worst a remote rejection (e.g. deleting a
+        // like that doesn't exist) that would revert a state that was correct.
         let mut recorded = Vec::new();
         for track in tracks {
-            if track.id.key().trim().is_empty() {
+            let key = track.id.key().to_string();
+            if key.trim().is_empty() {
+                continue;
+            }
+            if source.is_favorite(&key).await == on {
                 continue;
             }
             if source.record_favorite(&track, on).await.is_ok() {
@@ -92,17 +95,6 @@ pub fn set_favorite_many(tracks: Vec<Track>, on: bool) {
     });
 }
 
-/// The active source handle, or `None` (with a warn) when the context is missing.
-fn active_source() -> Option<ActiveSource> {
-    match try_consume_context::<Signal<ActiveSource>>() {
-        Some(sig) => Some(sig.peek().clone()),
-        None => {
-            tracing::warn!("favorite toggle: no ActiveSource context");
-            None
-        }
-    }
-}
-
 /// A short "the server rejected it" notice, so a reverted heart doesn't read as
 /// a broken UI. Names the service when the track has one.
 fn favorite_error(track: &Track) -> String {
@@ -112,9 +104,7 @@ fn favorite_error(track: &Track) -> String {
     }
 }
 
-fn bump_favorites(gens: Option<Generations>) {
-    if let Some(gens) = gens {
-        gens.bump(Table::Favorites);
-        gens.bump(Table::Tracks);
-    }
+fn bump_favorites(gens: Generations) {
+    gens.bump(Table::Favorites);
+    gens.bump(Table::Tracks);
 }

--- a/crates/hooks/src/lib.rs
+++ b/crates/hooks/src/lib.rs
@@ -3,10 +3,12 @@
 
 pub mod db_reactivity;
 pub mod debug_db;
+pub mod favorites;
 pub mod playback_ref;
 mod player_controller_queue;
 pub mod scrobble_scheduler;
 pub mod source_switch;
+pub mod toast;
 pub mod use_db_queries;
 pub mod use_player_controller;
 pub mod use_player_task;

--- a/crates/hooks/src/toast.rs
+++ b/crates/hooks/src/toast.rs
@@ -1,0 +1,37 @@
+//! A tiny transient toast, rendered by injecting a fixed-position element via
+//! `document.eval` (no component/state plumbing needed for a fire-and-forget
+//! message). Shared so any hook or component can surface a brief notice.
+
+/// Show `msg` as a neutral (info) toast for ~1.8s.
+pub fn toast(msg: &str) {
+    show(msg, "rgba(20,20,20,0.95)", "rgba(255,255,255,0.1)");
+}
+
+/// Show `msg` as an error toast (reddish) — for a failure the user should notice.
+pub fn toast_error(msg: &str) {
+    show(msg, "rgba(45,18,18,0.96)", "rgba(239,68,68,0.55)");
+}
+
+/// Bottom-centered toast reusing a single `#kopuz-toast` element; `bg`/`border`
+/// are re-applied every call so the level (info vs error) always matches `msg`.
+fn show(msg: &str, bg: &str, border: &str) {
+    let escaped = serde_json::to_string(msg).unwrap_or_else(|_| "\"\"".to_string());
+    let js = format!(
+        r#"(function(m){{
+            let t = document.getElementById('kopuz-toast');
+            if (!t) {{
+                t = document.createElement('div');
+                t.id = 'kopuz-toast';
+                t.style.cssText = 'position:fixed;left:50%;bottom:88px;transform:translateX(-50%);color:#fff;padding:10px 18px;border-radius:8px;font:14px system-ui,sans-serif;z-index:99999;box-shadow:0 4px 16px rgba(0,0,0,0.4);pointer-events:none;opacity:0;transition:opacity 150ms;border:1px solid transparent;';
+                document.body.appendChild(t);
+            }}
+            t.style.background = '{bg}';
+            t.style.borderColor = '{border}';
+            t.textContent = m;
+            t.style.opacity = '1';
+            clearTimeout(t._h);
+            t._h = setTimeout(() => {{ t.style.opacity = '0'; }}, 1800);
+        }})({escaped});"#
+    );
+    let _ = dioxus::document::eval(&js);
+}

--- a/crates/hooks/src/toast.rs
+++ b/crates/hooks/src/toast.rs
@@ -22,7 +22,7 @@ fn show(msg: &str, bg: &str, border: &str) {
             if (!t) {{
                 t = document.createElement('div');
                 t.id = 'kopuz-toast';
-                t.style.cssText = 'position:fixed;left:50%;bottom:88px;transform:translateX(-50%);color:#fff;padding:10px 18px;border-radius:8px;font:14px system-ui,sans-serif;z-index:99999;box-shadow:0 4px 16px rgba(0,0,0,0.4);pointer-events:none;opacity:0;transition:opacity 150ms;border:1px solid transparent;';
+                t.style.cssText = 'position:fixed;left:50%;bottom:112px;transform:translateX(-50%);color:#fff;padding:10px 18px;border-radius:8px;font:14px system-ui,sans-serif;z-index:99999;box-shadow:0 4px 16px rgba(0,0,0,0.4);pointer-events:none;opacity:0;transition:opacity 150ms;border:1px solid transparent;';
                 document.body.appendChild(t);
             }}
             t.style.background = '{bg}';

--- a/crates/hooks/src/use_db_queries.rs
+++ b/crates/hooks/src/use_db_queries.rs
@@ -13,7 +13,6 @@
 
 use db::{Page, ReadDb, Source, TrackFilter};
 use dioxus::prelude::*;
-use server::source::TrackFavorite;
 use tracing::Instrument;
 use utils::offload;
 
@@ -397,7 +396,10 @@ pub fn use_track_is_favorite(track: Memo<Option<reader::Track>>) -> Memo<bool> {
         let track = track();
         offload(async move {
             match track {
-                Some(t) => t.is_favorite(&source).await,
+                Some(t) => {
+                    let key = t.id.key();
+                    !key.trim().is_empty() && source.is_favorite(key.as_ref()).await
+                }
                 None => false,
             }
         })

--- a/crates/pages/src/home_body.rs
+++ b/crates/pages/src/home_body.rs
@@ -1,7 +1,5 @@
-use ::server::source::TrackFavorite;
 use config::{AppConfig, ListenNowStyle, UiStyle};
 use dioxus::prelude::*;
-use hooks::db_reactivity::Table;
 use hooks::use_db_queries::{
     use_active_source, use_album_tracks, use_albums, use_artist_sample_tracks, use_favorites,
     use_playlists, use_top_genre, use_tracks_by_keys,
@@ -637,9 +635,7 @@ fn ServerHeroBanner(
     let mut start_y = use_signal(|| 0.0_f64);
     let mut start_h = use_signal(|| 0_u32);
 
-    let gens = hooks::db_reactivity::use_generations();
     let source = use_active_source();
-    let active_source = use_context::<Signal<::server::source::ActiveSource>>();
     // The track's own `album_id` (not the resolved `Album`, which lags behind a
     // separate albums query) — so the play button and the favorite-state heart
     // work the instant the hero track renders, not only once albums load.
@@ -785,16 +781,7 @@ fn ServerHeroBanner(
                                         } else {
                                             hero_tracks_res.read().clone().unwrap_or_default()
                                         };
-                                        let new_fav = !jelly_hero_fav;
-                                        let source = active_source.peek().clone();
-                                        spawn(async move {
-                                            for t in &tracks {
-                                                let _ = t.set_favorite(&source, new_fav).await;
-                                            }
-                                            gens.bump(Table::Favorites);
-                                            // Pending DB rows; the reconciler pushes them.
-                                            hooks::use_sync_task::nudge();
-                                        });
+                                        hooks::favorites::set_favorite_many(tracks, !jelly_hero_fav);
                                     },
                                     i { class: "{hero_heart_icon}" }
                                 }

--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -354,6 +354,29 @@ pub trait MediaSource: Send + Sync {
             .map_err(SourceError::from)
     }
 
+    /// Record `track`'s favorite state LOCALLY as a clean row (no dirty/pending),
+    /// without touching the remote. The optimistic half of a favorite toggle:
+    /// write this first so the UI reflects the change immediately, then
+    /// [`push_favorite`](Self::push_favorite) to the remote — and call this again
+    /// with the opposite `on` to revert if the push is rejected. An empty key is a
+    /// no-op.
+    async fn record_favorite(&self, track: &reader::Track, on: bool) -> Result<(), SourceError> {
+        let key = track.id.key();
+        if key.trim().is_empty() {
+            return Ok(());
+        }
+        // Cache the track so the favorites view can resolve the ref.
+        if on {
+            let _ = self.upsert_tracks(std::slice::from_ref(track)).await;
+        }
+        let sid = self.source().as_str();
+        self.db().set_favorite(sid, key.as_ref(), on).await?;
+        self.db()
+            .clear_favorite_dirty(sid, key.as_ref())
+            .await
+            .map_err(SourceError::from)
+    }
+
     /// Report a track as now-playing to the remote's scrobble endpoint. Default
     /// no-op — only remotes that scrobble (Subsonic) override. Best-effort: the
     /// caller ignores the result.
@@ -776,36 +799,6 @@ fn remote_source(db: Db, source: Source, conn: &ServerConn) -> Box<dyn MediaSour
 /// rotation, so call sites read the cached handle instead of rebuilding — and
 /// for a server, re-standing-up an HTTP client — on every operation.
 pub type ActiveSource = std::sync::Arc<dyn MediaSource>;
-
-/// Ergonomic, track-centric wrappers over the source's DB-backed favorite truth,
-/// so call sites read `track.is_favorite(&source).await` instead of pulling the
-/// key out by hand. Defined here (not on `reader::Track`) because the truth lives
-/// on [`MediaSource`], and `reader` can't depend on `server`.
-#[async_trait]
-pub trait TrackFavorite {
-    /// Whether this track is currently favorited for `source` (an empty key —
-    /// e.g. an unresolved track — is never a favorite).
-    async fn is_favorite(&self, source: &ActiveSource) -> bool;
-
-    /// Set this track's favorite state for `source` (an empty key is a no-op).
-    async fn set_favorite(&self, source: &ActiveSource, on: bool) -> Result<(), SourceError>;
-}
-
-#[async_trait]
-impl TrackFavorite for reader::Track {
-    async fn is_favorite(&self, source: &ActiveSource) -> bool {
-        let key = self.id.key();
-        !key.trim().is_empty() && source.is_favorite(key.as_ref()).await
-    }
-
-    async fn set_favorite(&self, source: &ActiveSource, on: bool) -> Result<(), SourceError> {
-        let key = self.id.key();
-        if key.trim().is_empty() {
-            return Ok(());
-        }
-        source.set_favorite(key.as_ref(), on).await
-    }
-}
 
 /// The configured server's [`MediaSource`], or `None` when no usable creds
 /// exist. Unlike [`active`] this ignores the active source — the reconciler

--- a/crates/server/tests/source.rs
+++ b/crates/server/tests/source.rs
@@ -7,7 +7,29 @@
 use std::path::PathBuf;
 
 use db::Source;
+use reader::{Track, TrackId};
 use server::source;
+
+fn track(id: TrackId) -> Track {
+    Track {
+        id,
+        cover: None,
+        album_id: String::new(),
+        title: String::new(),
+        artist: String::new(),
+        album: String::new(),
+        duration: 0,
+        khz: 0,
+        bitrate: 0,
+        track_number: None,
+        disc_number: None,
+        musicbrainz_release_id: None,
+        musicbrainz_recording_id: None,
+        musicbrainz_track_id: None,
+        playlist_item_id: None,
+        artists: Vec::new(),
+    }
+}
 
 fn unique_db() -> PathBuf {
     // pid + counter, not just clock: macOS's µs clock let parallel tests
@@ -78,4 +100,29 @@ async fn local_favorite_round_trips() {
 
     src.set_favorite("/music/x.flac", false).await.unwrap();
     assert!(!src.is_favorite("/music/x.flac").await);
+}
+
+#[tokio::test]
+async fn record_favorite_writes_a_clean_local_row_and_reverts() {
+    let db = db::init(&unique_db()).await.unwrap();
+    let src = source::local(db.clone());
+    let t = track(TrackId::Local("/music/x.flac".into()));
+
+    // record_favorite writes the local state as a CLEAN row (no dirty/pending) —
+    // the optimistic half of a toggle.
+    src.record_favorite(&t, true).await.unwrap();
+    assert!(
+        db.favorites("local")
+            .await
+            .unwrap()
+            .contains(&"/music/x.flac".to_string())
+    );
+    assert!(db.dirty_favorites("local").await.unwrap().is_empty());
+
+    // Calling it with the opposite `on` reverts cleanly (the revert-on-push-fail
+    // path) — no favorite, no lingering row.
+    src.record_favorite(&t, false).await.unwrap();
+    assert!(!src.is_favorite("/music/x.flac").await);
+    assert!(db.dirty_favorites("local").await.unwrap().is_empty());
+    assert!(db.dirty_unlikes("local").await.unwrap().is_empty());
 }


### PR DESCRIPTION
Favoriting now properly works on remote sources.

<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
