### PR TITLE
various: add Helium browser for browser sign-in

### DIFF
--- a/crates/config/src/source.rs
+++ b/crates/config/src/source.rs
@@ -129,6 +129,7 @@ pub enum Browser {
     Brave,
     Edge,
     Vivaldi,
+    Helium,
 }
 
 impl Browser {
@@ -138,6 +139,7 @@ impl Browser {
         Browser::Brave,
         Browser::Edge,
         Browser::Vivaldi,
+        Browser::Helium,
     ];
 
     /// The stable id used in URL routes, settings UI option values,
@@ -149,6 +151,7 @@ impl Browser {
             Browser::Brave => "brave",
             Browser::Edge => "edge",
             Browser::Vivaldi => "vivaldi",
+            Browser::Helium => "helium",
         }
     }
 
@@ -159,6 +162,7 @@ impl Browser {
             Browser::Brave => "Brave",
             Browser::Edge => "Edge",
             Browser::Vivaldi => "Vivaldi",
+            Browser::Helium => "Helium",
         }
     }
 

--- a/crates/db/src/backend/cfg_store.rs
+++ b/crates/db/src/backend/cfg_store.rs
@@ -308,6 +308,7 @@ fn parse_browser(s: Option<&str>) -> Option<Browser> {
         Some("brave") => Some(Browser::Brave),
         Some("edge") => Some(Browser::Edge),
         Some("vivaldi") => Some(Browser::Vivaldi),
+        Some("helium") => Some(Browser::Helium),
         _ => None,
     }
 }

--- a/crates/server/src/cookies/browser.rs
+++ b/crates/server/src/cookies/browser.rs
@@ -34,6 +34,7 @@ pub(crate) fn browser_candidates(browser: Browser) -> &'static [&'static str] {
             "microsoft-edge-dev",
         ],
         Browser::Vivaldi => &["vivaldi", "vivaldi-stable"],
+        Browser::Helium => &["helium-browser", "helium"],
     }
 }
 
@@ -44,6 +45,8 @@ pub(crate) fn browser_flatpak_ids(browser: Browser) -> &'static [&'static str] {
         Browser::Chromium => &["org.chromium.Chromium"],
         Browser::Edge => &["com.microsoft.Edge"],
         Browser::Vivaldi => &["com.vivaldi.Vivaldi"],
+        // Helium ships .deb/AppImage/tarball upstream, no flatpak.
+        Browser::Helium => &[],
     }
 }
 
@@ -55,6 +58,7 @@ fn macos_app_paths(browser: Browser) -> &'static [&'static str] {
         Browser::Chromium => &["/Applications/Chromium.app/Contents/MacOS/Chromium"],
         Browser::Edge => &["/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"],
         Browser::Vivaldi => &["/Applications/Vivaldi.app/Contents/MacOS/Vivaldi"],
+        Browser::Helium => &["/Applications/Helium.app/Contents/MacOS/Helium"],
     }
 }
 
@@ -95,6 +99,11 @@ fn windows_install_paths(browser: Browser) -> Vec<PathBuf> {
             add(&pf, r"Vivaldi\Application\vivaldi.exe");
             add(&pf86, r"Vivaldi\Application\vivaldi.exe");
             add(&local, r"Vivaldi\Application\vivaldi.exe");
+        }
+        Browser::Helium => {
+            add(&pf, r"imput\Helium\Application\chrome.exe");
+            add(&pf86, r"imput\Helium\Application\chrome.exe");
+            add(&local, r"imput\Helium\Application\chrome.exe");
         }
     }
     out

--- a/crates/server/src/cookies/store.rs
+++ b/crates/server/src/cookies/store.rs
@@ -33,16 +33,19 @@ pub(crate) async fn read_cookies(
     let cookies = tokio::task::spawn_blocking(move || -> Result<Vec<Cookie>, String> {
         // rookie's built-in table has no `helium` entry and `get_browser_config`
         // unwraps on a miss, so build Helium's config by hand. As an
-        // ungoogled-chromium fork its `Safe Storage` secret is keyed by the
-        // "Helium" product name (login Keychain on macOS, "Helium Safe Storage"
-        // libsecret label on Linux) — not Chromium's.
+        // ungoogled-chromium fork Helium only rebrands its `Safe Storage` secret
+        // on macOS ("Helium Safe Storage" in the login Keychain). Its Linux
+        // build keeps the upstream os_crypt product name, so cookies are keyed
+        // by the "Chromium Safe Storage" libsecret label (application attribute
+        // "chromium") — using "helium" there finds no key, so the v11 cookies
+        // never decrypt and sign-in polls forever.
         let helium_config;
         let config = match browser {
             Browser::Helium => {
                 helium_config = rookie::config::Browser {
                     paths: Vec::new(),
                     channels: None,
-                    unix_crypt_name: Some("helium".to_string()),
+                    unix_crypt_name: Some("chromium".to_string()),
                     osx_key_service: Some("Helium Safe Storage".to_string()),
                     osx_key_user: Some("Helium".to_string()),
                 };

--- a/crates/server/src/cookies/store.rs
+++ b/crates/server/src/cookies/store.rs
@@ -31,7 +31,25 @@ pub(crate) async fn read_cookies(
     let domains = vec![domain.to_string()];
 
     let cookies = tokio::task::spawn_blocking(move || -> Result<Vec<Cookie>, String> {
-        let config = rookie::config::get_browser_config(browser_name);
+        // rookie's built-in table has no `helium` entry and `get_browser_config`
+        // unwraps on a miss, so build Helium's config by hand. As an
+        // ungoogled-chromium fork its `Safe Storage` secret is keyed by the
+        // "Helium" product name (login Keychain on macOS, "Helium Safe Storage"
+        // libsecret label on Linux) — not Chromium's.
+        let helium_config;
+        let config = match browser {
+            Browser::Helium => {
+                helium_config = rookie::config::Browser {
+                    paths: Vec::new(),
+                    channels: None,
+                    unix_crypt_name: Some("helium".to_string()),
+                    osx_key_service: Some("Helium Safe Storage".to_string()),
+                    osx_key_user: Some("Helium".to_string()),
+                };
+                &helium_config
+            }
+            _ => rookie::config::get_browser_config(browser_name),
+        };
         let raw =
             rookie::chromium_based(config, db_path, Some(domains)).map_err(|e| e.to_string())?;
         Ok(raw

--- a/crates/server/src/cookies/windows_native.rs
+++ b/crates/server/src/cookies/windows_native.rs
@@ -63,7 +63,7 @@ const ABE_KEY_FILE: &str = ".kopuz-abe";
 /// (elevation CLSID, candidate IElevator IIDs newest-first). Chrome 149 rotated
 /// to IElevator2Chrome (== the elevation typelib GUID); the older IElevatorChrome
 /// IID is kept as a fallback for pre-149. Brands without an elevation service
-/// (Chromium/Vivaldi) return None — the plant is skipped, v10 still works.
+/// (Chromium/Vivaldi/Helium) return None — the plant is skipped, v10 still works.
 fn brand_elevation(browser: Browser) -> Option<(u128, &'static [u128])> {
     match browser {
         Browser::Chrome => Some((
@@ -81,7 +81,7 @@ fn brand_elevation(browser: Browser) -> Option<(u128, &'static [u128])> {
             0x576B31AF_6369_4B6B_8560_E4B203A97A8B,
             &[0xF396861E_0C8E_4C71_8256_2FAE6D759CE9],
         )),
-        Browser::Chromium | Browser::Vivaldi => None,
+        Browser::Chromium | Browser::Vivaldi | Browser::Helium => None,
     }
 }
 


### PR DESCRIPTION
Adds Helium as a browser sign-in option for YouTube Music and SoundCloud

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [ ] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [x] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
