### PR TITLE
fix: enable librefm scrobbling for local files

### DIFF
--- a/crates/hooks/src/scrobble_scheduler.rs
+++ b/crates/hooks/src/scrobble_scheduler.rs
@@ -27,7 +27,7 @@ impl ScrobbleOptions {
     };
 
     pub const LOCAL: Self = Self {
-        include_librefm: false,
+        include_librefm: true,
         include_musicbrainz_ids: true,
     };
 }


### PR DESCRIPTION
Local files were not being scrobbled to Libre.fm because `ScrobbleOptions::LOCAL` had `include_librefm: false`.  so the fix was to turn it on for local.

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.
- [x] My changes are consistent with the existing crate boundaries and Dioxus style.
- [x] I ran `cargo fmt --all --check`.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings` (debug + release).
- [x] I kept generated assets, translations, and packaging files in sync when this change depends on them.
- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):
- [x] `x86_64-linux`