### PR TITLE
spotify: add Helium support

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,9 +536,27 @@ You need three things:
   Browsing your library still works without Premium, playback does not.
 - **Your own Spotify client.** Kopuz does not ship a Client ID, you create one
   in about two minutes and paste it in.
-- **A supported browser installed.** Chrome, Edge, Brave, Chromium, Vivaldi, or
-  Safari on macOS. Firefox is not usable here: the SDK has a long-standing bug
-  in Firefox where playback dies a few seconds in, so Kopuz will not pick it.
+- **A supported browser installed.** Chrome, Edge, Brave, Chromium, Vivaldi,
+  Helium or Safari on macOS. Firefox is not usable here: the SDK has a
+  long-standing bug in Firefox where playback dies a few seconds in, so Kopuz
+  will not pick it.
+
+  > [!NOTE]
+  > To use the Spotify backend with Helium, you need to place the Widevine files
+  > in the correct location. See
+  > [here](https://github.com/imputnet/helium/issues/116#issuecomment-3668370766)
+  > for more information. On NixOS using
+  > [hjem](https://github.com/feel-co/hjem), this can be done by adding
+  >
+  > ```nix
+  > hjem.users.your-username = {
+  >   xdg.config.files."net.imput.helium/WidevineCdm/latest-component-updated-widevine-cdm".text = ''
+  >     {"Path":"${pkgs.widevine-cdm}/share/google/chrome/WidevineCdm"}
+  >   '';
+  > };
+  > ```
+  >
+  > to your configuration.
 
 ### 1. Create your Spotify app
 
@@ -640,7 +658,7 @@ Kopuz:
 
 ### Troubleshooting
 
-- **"Spotify playback needs Chrome, Edge, Brave, Chromium, Vivaldi, or Safari"**
+- **"Spotify playback needs Chrome, Edge, Brave, Chromium, Vivaldi, Helium, or Safari"**
   means none of those were found. Install one, then pick it under **Settings →
   Media servers**.
 - **Sign-in never completes.** Check the redirect URI on your Spotify app

--- a/crates/server/src/spotify/host.rs
+++ b/crates/server/src/spotify/host.rs
@@ -240,6 +240,14 @@ const BROWSERS: &[(PlayerBrowser, &str, &str)] = &[
         "com.apple.Safari",
         "Safari.app",
     ),
+    (
+        PlayerBrowser {
+            id: "helium",
+            label: "Helium",
+        },
+        "com.imputnet.helium",
+        "Helium.app",
+    ),
 ];
 
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -278,6 +286,13 @@ const BROWSERS: &[(PlayerBrowser, &[&str])] = &[
             label: "Vivaldi",
         },
         &["vivaldi"],
+    ),
+    (
+        PlayerBrowser {
+            id: "helium",
+            label: "Helium",
+        },
+        &["helium"],
     ),
 ];
 


### PR DESCRIPTION
Adds support for Helium. 

Winedevine works on Helium when adding it via

```nix
  # Add widevine support, see:
  # https://github.com/imputnet/helium/issues/116#issuecomment-3668370766
  hjem.users.${username} = {
    xdg.config.files."net.imput.helium/WidevineCdm/latest-component-updated-widevine-cdm".text = ''
      {"Path":"${pkgs.widevine-cdm}/share/google/chrome/WidevineCdm"}
    '';
  };
```


<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [ ] I have read and followed the [contribution guidelines].
- [ ] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [ ] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [ ] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [ ] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [ ] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
