### PR TITLE
fix: prevent long album titles from hiding song list

### DIFF
--- a/crates/components/src/normal/showcase.rs
+++ b/crates/components/src/normal/showcase.rs
@@ -149,7 +149,7 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                          }
                      }
                  }
-                 div { class: "flex-1",
+                 div { class: "flex-1 min-w-0",
                      if !props.description.is_empty() {
                          if let Some(on_description_click) = props.on_description_click {
                              button {
@@ -161,7 +161,7 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                              h5 { class: "text-sm font-bold text-white/60 mb-2", "{props.description}" }
                          }
                      }
-                     h1 { class: if cfg!(target_os = "android") { "text-3xl font-semibold tracking-tight text-white mb-3" } else { "text-5xl md:text-7xl font-semibold tracking-tight text-white mb-6" }, "{props.name}" }
+                     h1 { class: if cfg!(target_os = "android") { "text-3xl font-semibold tracking-tight text-white mb-3 break-words line-clamp-3" } else { "text-5xl md:text-7xl font-semibold tracking-tight text-white mb-6 break-words line-clamp-3" }, "{props.name}" }
                      div { class: if cfg!(target_os = "android") { "flex items-center justify-center gap-4 text-slate-400" } else { "flex items-center gap-6 text-slate-400" },
                          {
                             let count = props.tracks.len();


### PR DESCRIPTION
long album names caused the header to grow unbounded with `shrink-0`, hiding the entire song list

Added `break-words line-clamp-3` to the `<h1>` so album name never goes past 3 lines

Fixes #575

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS