### PR TITLE
fullscreen: remember last tab when unhiding tabs in fullscreen mode

### DIFF
--- a/crates/components/src/fullscreen/desktop.rs
+++ b/crates/components/src/fullscreen/desktop.rs
@@ -29,6 +29,7 @@ pub(crate) fn FullscreenDesktop(
 ) -> Element {
     let use_player_bar = config.read().fullscreen_use_player_bar;
     let tabs_collapsed = config.read().fullscreen_tabs_collapsed;
+    let active_tab = use_signal(|| 0usize);
 
     rsx! {
         div {
@@ -92,6 +93,7 @@ pub(crate) fn FullscreenDesktop(
                         current_queue_index,
                         lyrics,
                         current_song_progress,
+                        active_tab
                     }
                 }
             }

--- a/crates/components/src/fullscreen/tabs.rs
+++ b/crates/components/src/fullscreen/tabs.rs
@@ -12,7 +12,6 @@ pub(crate) fn Tabs(
     current_song_progress: Signal<u64>,
     active_tab: Signal<usize>,
 ) -> Element {
-
     rsx! {
         div {
             class: "flex-1 flex flex-col h-full min-w-0 bg-black/45 border-l border-white/5",

--- a/crates/components/src/fullscreen/tabs.rs
+++ b/crates/components/src/fullscreen/tabs.rs
@@ -10,8 +10,8 @@ pub(crate) fn Tabs(
     current_queue_index: Signal<usize>,
     lyrics: Signal<Option<Option<utils::lyrics::Lyrics>>>,
     current_song_progress: Signal<u64>,
+    active_tab: Signal<usize>,
 ) -> Element {
-    let mut active_tab = use_signal(|| 0usize);
 
     rsx! {
         div {


### PR DESCRIPTION
Moved the active_tab variable from tabs.rs to desktop.rs so that its state is preserved when toggling the tabs panel.

## AI Disclosure
I used Gemini 3.6 Flash (Web) to get a bit of help with git and to check if my English was correct as it is not my native language. I reviewed every change and command that the AI generated.

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
