### PR TITLE
server: youtube music playlist radio (RDAMPL mix)

### DIFF
--- a/crates/server/src/source.rs
+++ b/crates/server/src/source.rs
@@ -135,6 +135,18 @@ pub trait MediaSource: Send + Sync {
         Err(SourceError::unsupported("radio"))
     }
 
+    /// Start a radio/mix seeded from a whole playlist, returning the generated
+    /// queue. The queue is the source's own mix for that playlist — not the
+    /// playlist's tracks — so callers play it as-is. Shares
+    /// [`Capabilities::radio`] with [`start_radio`](Self::start_radio): a source
+    /// that can seed radio from a track can seed it from a playlist too.
+    async fn start_playlist_radio(
+        &self,
+        _playlist_ref: &str,
+    ) -> Result<Vec<reader::Track>, SourceError> {
+        Err(SourceError::unsupported("playlist radio"))
+    }
+
     /// The track's canonical public web URL, when this source has shareable web
     /// pages (e.g. a YouTube Music watch link or Spotify track link). `None` otherwise — callers fall
     /// back to a metadata lookup (MusicBrainz). Sync: it's a pure id→URL mapping.

--- a/crates/server/src/source/youtube_music.rs
+++ b/crates/server/src/source/youtube_music.rs
@@ -66,6 +66,19 @@ impl MediaSource for YtSource {
             .map_err(SourceError::from)
     }
 
+    async fn start_playlist_radio(
+        &self,
+        playlist_ref: &str,
+    ) -> Result<Vec<reader::Track>, SourceError> {
+        if playlist_ref.trim().is_empty() {
+            return Err(SourceError::InvalidInput("playlist has no id".into()));
+        }
+        self.client
+            .start_playlist_mix(playlist_ref)
+            .await
+            .map_err(SourceError::from)
+    }
+
     fn web_url(&self, track: &reader::Track) -> Option<String> {
         let vid = track.id.key();
         (!vid.trim().is_empty()).then(|| format!("https://music.youtube.com/watch?v={vid}"))

--- a/crates/server/src/ytmusic/mix.rs
+++ b/crates/server/src/ytmusic/mix.rs
@@ -7,15 +7,58 @@ use super::search::synthesize_album_id;
 
 const ORIGIN: &str = "https://music.youtube.com";
 
-#[tracing::instrument(name = "yt.start_mix", skip(cookies), fields(seed = %seed_video_id))]
-pub async fn start_mix(seed_video_id: &str, cookies: &str) -> Result<Vec<Track>, String> {
-    let playlist_id = format!("RDAMVM{seed_video_id}");
+/// What a mix is generated from. The `RD…` id and whether the request pins a
+/// first video are both derived from this one value, so they can't be paired
+/// wrongly — a playlist mix with a `videoId` is not a request YT answers.
+pub(super) enum MixSeed<'a> {
+    /// One track: the mix plays on from it, with the seed itself at index 0.
+    Video(&'a str),
+    /// A whole playlist — YT's own "Start radio" on a playlist. The queue is
+    /// generated, so it bears no relation to the playlist's track list.
+    Playlist(&'a str),
+}
+
+impl MixSeed<'_> {
+    /// The `RD…` playlist id the mix is built under.
+    fn mix_playlist_id(&self) -> String {
+        match self {
+            Self::Video(id) => format!("RDAMVM{id}"),
+            // Playlist ids are stored bare, but the `VL`-prefixed browse form
+            // leaks in from some InnerTube responses (see `playlists.rs`) and
+            // `RDAMPL` wants the bare one. Normalizing here rather than at
+            // construction means no caller can skip it.
+            Self::Playlist(id) => format!("RDAMPL{}", id.strip_prefix("VL").unwrap_or(id)),
+        }
+    }
+
+    /// The video pinned as the queue's first entry, if any. Sending an empty
+    /// `videoId` makes YT hand back an empty queue, so a playlist mix omits the
+    /// field entirely rather than passing a blank one.
+    fn pinned_video_id(&self) -> Option<&str> {
+        match self {
+            Self::Video(id) => Some(id),
+            Self::Playlist(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Display for MixSeed<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Video(id) => write!(f, "video:{id}"),
+            Self::Playlist(id) => write!(f, "playlist:{id}"),
+        }
+    }
+}
+
+/// Ask YT to generate a radio queue from `seed` and return the tracks it lists.
+#[tracing::instrument(name = "yt.mix", skip(cookies), fields(seed = %seed))]
+pub(super) async fn fetch(seed: MixSeed<'_>, cookies: &str) -> Result<Vec<Track>, String> {
     let client = WEB_REMIX;
-    let body = json!({
+    let mut body = json!({
         "enablePersistentPlaylistPanel": true,
         "tunerSettingValue": "AUTOMIX_SETTING_NORMAL",
-        "videoId": seed_video_id,
-        "playlistId": playlist_id,
+        "playlistId": seed.mix_playlist_id(),
         "params": "wAEB",
         "isAudioOnly": true,
         "context": {
@@ -28,6 +71,11 @@ pub async fn start_mix(seed_video_id: &str, cookies: &str) -> Result<Vec<Track>,
             "user": { "lockedSafetyMode": false },
         },
     });
+    if let Some(video_id) = seed.pinned_video_id()
+        && let Some(obj) = body.as_object_mut()
+    {
+        obj.insert("videoId".into(), json!(video_id));
+    }
 
     // Mix endpoint works without auth (anonymous radio for any public
     // video). Skip Cookie + SAPISID when cookies is empty so anon

--- a/crates/server/src/ytmusic/mod.rs
+++ b/crates/server/src/ytmusic/mod.rs
@@ -286,7 +286,19 @@ impl YouTubeMusicClient {
     // SAPISID auth headers" (see browse_maybe_auth / discover::post).
 
     pub async fn start_mix(&self, seed_video_id: &str) -> Result<Vec<Track>, String> {
-        mix::start_mix(seed_video_id, self.cookies.as_deref().unwrap_or("")).await
+        mix::fetch(
+            mix::MixSeed::Video(seed_video_id),
+            self.cookies.as_deref().unwrap_or(""),
+        )
+        .await
+    }
+
+    pub async fn start_playlist_mix(&self, playlist_id: &str) -> Result<Vec<Track>, String> {
+        mix::fetch(
+            mix::MixSeed::Playlist(playlist_id),
+            self.cookies.as_deref().unwrap_or(""),
+        )
+        .await
     }
 
     pub async fn discover_home(&self) -> Result<discover::DiscoverHome, String> {


### PR DESCRIPTION
added MediaSource::start_playlist_radio which allows for getting radio recommendations if the source supports it + implemented it on youtube music

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [ ] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
