### PR TITLE
various: start radio on playlists

### DIFF
--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -29,6 +29,7 @@ pub mod queue_drag;
 pub mod queue_list_view;
 pub mod quick_search;
 pub use quick_search::QuickSearch;
+pub mod radio_actions;
 pub mod reorder_buttons;
 pub mod rightbar;
 pub mod search_bar;

--- a/crates/components/src/normal/showcase.rs
+++ b/crates/components/src/normal/showcase.rs
@@ -203,6 +203,14 @@ pub fn ShowcaseNormal(props: ShowcaseProps) -> Element {
                             onclick: move |_| ctrl.toggle_shuffle(),
                             i { class: "fa-solid fa-shuffle text-xl ml-1" }
                         }
+                        if let Some(start_radio) = props.on_start_radio {
+                            button {
+                                class: "w-14 h-14 rounded-full flex items-center justify-center text-slate-400 hover:text-white hover:bg-white/10 transition-colors active:scale-95",
+                                title: crate::radio_actions::radio_label(),
+                                onclick: move |_| start_radio.call(()),
+                                i { class: "{crate::radio_actions::RADIO_ICON} text-xl" }
+                            }
+                        }
                         button {
                              class: "w-14 h-14 rounded-full bg-indigo-500 hover:bg-indigo-400 text-black flex items-center justify-center transition-transform hover:scale-105",
                              onclick: move |_| {

--- a/crates/components/src/playlist_detail.rs
+++ b/crates/components/src/playlist_detail.rs
@@ -230,6 +230,8 @@ pub fn PlaylistDetail(
         })
         .or_else(|| tracks_val.first().and_then(&cover_for));
 
+    let start_radio = crate::radio_actions::playlist_radio_handler(playlist_id.clone());
+
     let pid_for_remove = playlist_id.clone();
     let pid_for_move_up = playlist_id.clone();
     let pid_for_move_down = playlist_id.clone();
@@ -244,6 +246,7 @@ pub fn PlaylistDetail(
             cover_url: playlist_cover,
             tracks: tracks_val,
             on_close,
+            on_start_radio: start_radio,
             enable_metadata: caps.edit_tags,
             on_cover_click: move |_| {
                 let _ = &pid_for_cover;

--- a/crates/components/src/radio_actions.rs
+++ b/crates/components/src/radio_actions.rs
@@ -1,0 +1,97 @@
+//! "Start radio" as one action, shared by every surface that offers it.
+//!
+//! A track seed and a playlist seed are the same operation from the UI's side:
+//! hand the source an id, get a generated queue back, play it. Keeping the
+//! label, the icon, the capability gate and the failure handling in one place is
+//! what stops the track row and the playlist surfaces from drifting apart.
+
+use dioxus::prelude::*;
+use hooks::PlayerController;
+use reader::models::Track;
+use server::source::ActiveSource;
+use std::future::Future;
+use tracing::Instrument;
+
+pub const RADIO_ICON: &str = "fa-solid fa-tower-broadcast";
+
+pub fn radio_label() -> String {
+    i18n::t("start_radio").to_string()
+}
+
+/// Whether the active source can start radio at all. Both seeds ride the one
+/// [`Capabilities::radio`](server::source::Capabilities) flag.
+fn radio_supported(active_source: &Signal<ActiveSource>) -> bool {
+    active_source.read().capabilities().radio
+}
+
+/// Await a radio queue and hand it to the player. An empty or failed mix leaves
+/// the current queue alone — the user's music keeps playing rather than stopping
+/// on a network hiccup.
+fn spawn_radio<F>(seed: String, fut: F, mut ctrl: PlayerController)
+where
+    F: Future<Output = Result<Vec<Track>, server::source::SourceError>> + 'static,
+{
+    spawn(
+        async move {
+            match fut.await {
+                Ok(tracks) if !tracks.is_empty() => ctrl.play_queue_linear(tracks),
+                Ok(_) => tracing::debug!(seed = %seed, "radio returned empty queue"),
+                Err(e) => tracing::warn!(seed = %seed, error = %e, "radio failed"),
+            }
+        }
+        .instrument(tracing::info_span!("radio.start")),
+    );
+}
+
+/// Start radio seeded from a track and play the generated queue. The radio
+/// operation lives in the source layer ([`MediaSource::start_radio`](server::source::MediaSource::start_radio));
+/// this just resolves the track's id and hands the result to the player.
+pub fn play_track_radio(track: Track, source: ActiveSource, ctrl: PlayerController) {
+    let seed = track.id.key().into_owned();
+    let fetch = seed.clone();
+    spawn_radio(seed, async move { source.start_radio(&fetch).await }, ctrl);
+}
+
+/// Start radio seeded from a playlist. What comes back is the source's mix for
+/// that playlist, not its track list, so it replaces the queue outright.
+pub fn play_playlist_radio(playlist_id: String, source: ActiveSource, ctrl: PlayerController) {
+    let seed = playlist_id.clone();
+    spawn_radio(
+        seed,
+        async move { source.start_playlist_radio(&playlist_id).await },
+        ctrl,
+    );
+}
+
+/// The `on_start_radio` handler for a track row: `Some` iff the active source
+/// supports radio ([`Capabilities::radio`](server::source::Capabilities)), else
+/// `None` (so the row hides the "Start radio" action). Lets every call site wire
+/// radio in one line without repeating the capability gate or context plumbing.
+///
+/// Reads context via `consume_context`, never a `use_*` hook: call sites invoke
+/// this once per visible row, so a hook here would register a per-row-count
+/// number of hooks and panic the parent on rules-of-hooks when the row count
+/// changes (e.g. an empty server library filling in after a sync).
+pub fn track_radio_handler(track: Track) -> Option<EventHandler<()>> {
+    let ctrl = consume_context::<PlayerController>();
+    let active_source = consume_context::<Signal<ActiveSource>>();
+    radio_supported(&active_source).then(|| {
+        EventHandler::new(move |_| {
+            let src = active_source.peek().clone();
+            play_track_radio(track.clone(), src, ctrl)
+        })
+    })
+}
+
+/// The playlist counterpart of [`track_radio_handler`]. Same `consume_context`
+/// rationale — playlist cards are rendered in a loop too.
+pub fn playlist_radio_handler(playlist_id: String) -> Option<EventHandler<()>> {
+    let ctrl = consume_context::<PlayerController>();
+    let active_source = consume_context::<Signal<ActiveSource>>();
+    radio_supported(&active_source).then(|| {
+        EventHandler::new(move |_| {
+            let src = active_source.peek().clone();
+            play_playlist_radio(playlist_id.clone(), src, ctrl)
+        })
+    })
+}

--- a/crates/components/src/showcase.rs
+++ b/crates/components/src/showcase.rs
@@ -136,6 +136,10 @@ pub struct ShowcaseProps {
     pub on_click_menu: Option<EventHandler<usize>>,
     pub on_close_menu: Option<EventHandler<()>>,
     pub actions: Option<Element>,
+    /// "Start radio" for whatever this header represents. A prop rather than an
+    /// `actions` element because the two layouts size their header buttons very
+    /// differently — each renders it in its own idiom, next to shuffle.
+    pub on_start_radio: Option<EventHandler<()>>,
     pub on_download_all: Option<EventHandler<()>>,
     pub on_delete_all: Option<EventHandler<()>>,
     #[props(default = false)]

--- a/crates/components/src/track_list_view.rs
+++ b/crates/components/src/track_list_view.rs
@@ -38,6 +38,8 @@ pub struct TrackListViewProps {
     #[props(default = false)]
     pub enable_metadata: bool,
     pub actions: Option<Element>,
+    #[props(default)]
+    pub on_start_radio: Option<EventHandler<()>>,
 }
 
 #[component]
@@ -99,6 +101,7 @@ pub fn TrackListView(props: TrackListViewProps) -> Element {
                     && props.tracks.iter().all(|t| selected_tracks.read().contains(&t.id)),
                 on_cover_click: props.on_cover_click,
                 actions: props.actions,
+                on_start_radio: props.on_start_radio,
                 on_select_all: move |selected: bool| {
                     if selected {
                         selected_tracks

--- a/crates/components/src/track_row.rs
+++ b/crates/components/src/track_row.rs
@@ -162,8 +162,8 @@ pub fn TrackRow(
     let mix_idx = if on_start_radio.is_some() {
         let idx = actions.len();
         actions.push(MenuAction::new(
-            "Start radio",
-            "fa-solid fa-tower-broadcast",
+            crate::radio_actions::radio_label(),
+            crate::radio_actions::RADIO_ICON,
         ));
         Some(idx)
     } else {
@@ -795,48 +795,12 @@ pub fn TrackRow(
     };
 }
 
-/// The `on_start_radio` handler for a track row: `Some` iff the active source
-/// supports radio ([`Capabilities::radio`]), else `None` (so the row hides the
-/// "Start radio" action). Lets every call site wire radio in one line without
-/// repeating the capability gate or context plumbing.
-///
-/// Reads context via `consume_context`, never a `use_*` hook: call sites invoke
-/// this once per visible row, so a hook here would register a per-row-count
-/// number of hooks and panic the parent on rules-of-hooks when the row count
-/// changes (e.g. an empty server library filling in after a sync).
-pub fn radio_handler(track: Track) -> Option<EventHandler<()>> {
-    let ctrl = consume_context::<PlayerController>();
-    let active_source = consume_context::<Signal<::server::source::ActiveSource>>();
-    let can_radio = active_source.read().capabilities().radio;
-    can_radio.then(|| {
-        EventHandler::new(move |_| {
-            let src = active_source.peek().clone();
-            play_radio(track.clone(), src, ctrl)
-        })
-    })
-}
-
-/// Start radio seeded from a track and play the generated queue. The radio
-/// operation lives in the source layer ([`MediaSource::start_radio`]); this just
-/// resolves the track's source, awaits it, and hands the result to the player.
-/// Call sites wire this into `on_start_radio` only when `capabilities().radio`.
-pub fn play_radio(
-    track: Track,
-    source: ::server::source::ActiveSource,
-    mut ctrl: PlayerController,
-) {
-    let seed = track.id.key().into_owned();
-    spawn(
-        async move {
-            match source.start_radio(&seed).await {
-                Ok(tracks) if !tracks.is_empty() => ctrl.play_queue_linear(tracks),
-                Ok(_) => tracing::debug!(seed = %seed, "radio returned empty queue"),
-                Err(e) => tracing::warn!(seed = %seed, error = %e, "radio failed"),
-            }
-        }
-        .instrument(tracing::info_span!("radio.start")),
-    );
-}
+/// Re-exported from [`crate::radio_actions`], where track and playlist radio
+/// share one implementation. Kept here so the existing row call sites keep
+/// reading `track_row::radio_handler(...)`.
+pub use crate::radio_actions::{
+    play_track_radio as play_radio, track_radio_handler as radio_handler,
+};
 
 /// Copy a shareable link for a track: its source's public web URL when it has
 /// one (YT Music or Spotify), else fall back to a MusicBrainz lookup by metadata. The provider

--- a/crates/components/src/vaxry/showcase.rs
+++ b/crates/components/src/vaxry/showcase.rs
@@ -173,6 +173,15 @@ pub fn ShowcaseVaxry(props: ShowcaseProps) -> Element {
                                 i { class: "fa-solid fa-shuffle text-xs" }
                                 "{i18n::t(\"shuffle\")}"
                             }
+                            if let Some(start_radio) = props.on_start_radio {
+                                button {
+                                    class: "inline-flex items-center justify-center h-9 w-9 rounded-full text-sm font-medium transition-colors border border-white/12 hover:bg-white/10 active:scale-95",
+                                    style: "color: var(--color-white); opacity: 0.6;",
+                                    title: crate::radio_actions::radio_label(),
+                                    onclick: move |_| start_radio.call(()),
+                                    i { class: "{crate::radio_actions::RADIO_ICON} text-xs" }
+                                }
+                            }
                             if props.on_download_all.is_some() || props.on_delete_all.is_some() {
                                 button {
                                     class: "inline-flex items-center justify-center h-9 w-9 rounded-full text-sm font-medium transition-colors border border-white/12 hover:bg-white/10 active:scale-95",

--- a/crates/i18n/locales/ar.ftl
+++ b/crates/i18n/locales/ar.ftl
@@ -93,6 +93,7 @@ add_to_queue = إضافة إلى قائمة الانتظار
 play_next = تشغيل التالي
 add_to_playlist = إضافة إلى قائمة التشغيل
 remove_from_playlist = إزالة من قائمة التشغيل
+start_radio = بدء الراديو
 share_musicbrainz = مشاركة (MusicBrainz)
 share_link_copied = تم نسخ رابط MusicBrainz
 delete = حذف

--- a/crates/i18n/locales/de.ftl
+++ b/crates/i18n/locales/de.ftl
@@ -93,6 +93,7 @@ add_to_queue = Zur Warteschlange hinzufügen
 play_next = Als Nächstes abspielen
 add_to_playlist = Zur Playlist hinzufügen
 remove_from_playlist = Aus Playlist entfernen
+start_radio = Radio starten
 share_musicbrainz = Teilen (MusicBrainz)
 share_link_copied = MusicBrainz-Link kopiert
 delete = Löschen

--- a/crates/i18n/locales/en.ftl
+++ b/crates/i18n/locales/en.ftl
@@ -166,6 +166,7 @@ add_to_queue = Add to Queue
 play_next = Play Next
 add_to_playlist = Add to Playlist
 remove_from_playlist = Remove from Playlist
+start_radio = Start Radio
 share_musicbrainz = Share (MusicBrainz)
 share_link_copied = MusicBrainz link copied
 delete = Delete

--- a/crates/i18n/locales/es.ftl
+++ b/crates/i18n/locales/es.ftl
@@ -93,6 +93,7 @@ add_to_queue = Agregar a la Cola
 play_next = Reproducir a continuación
 add_to_playlist = Agregar a Playlist
 remove_from_playlist = Eliminar de Playlist
+start_radio = Iniciar Radio
 share_musicbrainz = Compartir (MusicBrainz)
 share_link_copied = Enlace de MusicBrainz copiado
 delete = Borrar

--- a/crates/i18n/locales/fil.ftl
+++ b/crates/i18n/locales/fil.ftl
@@ -166,6 +166,7 @@ add_to_queue = Idagdag sa Queue
 play_next = I-play Susunod
 add_to_playlist = Idagdag sa Playlist
 remove_from_playlist = Alisin sa Playlist
+start_radio = Simulan ang Radyo
 share_musicbrainz = Ibahagi (MusicBrainz)
 share_link_copied = Nakopya ang link ng MusicBrainz
 delete = Burahin

--- a/crates/i18n/locales/fr.ftl
+++ b/crates/i18n/locales/fr.ftl
@@ -93,6 +93,7 @@ add_to_queue = Ajouter à la file d'attente
 play_next = Lire ensuite
 add_to_playlist = Ajouter a la playlist
 remove_from_playlist = Supprimer De La Playlist
+start_radio = Lancer La Radio
 share_musicbrainz = Partager (MusicBrainz)
 share_link_copied = Lien MusicBrainz copié
 delete = Supprimer

--- a/crates/i18n/locales/gr.ftl
+++ b/crates/i18n/locales/gr.ftl
@@ -93,6 +93,7 @@ add_to_queue = Προσθήκη στην Ουρά
 play_next = Αναπαραγωγή στη συνέχεια
 add_to_playlist = Προσθήκη στη Λίστα Αναπαραγωγής
 remove_from_playlist = Αφαίρεση από τη Λίστα Αναπαραγωγής
+start_radio = Έναρξη Ραδιοφώνου
 share_musicbrainz = Κοινοποίηση (MusicBrainz)
 share_link_copied = Ο σύνδεσμος MusicBrainz αντιγράφηκε
 delete = Διαγραφή

--- a/crates/i18n/locales/he.ftl
+++ b/crates/i18n/locales/he.ftl
@@ -93,6 +93,7 @@ add_to_queue = הוספה לתור
 play_next = נגן הבא בתור
 add_to_playlist = הוספה לרשימת השמעה
 remove_from_playlist = הסרה מרשימת השמעה
+start_radio = הפעלת רדיו
 share_musicbrainz = שיתוף (MusicBrainz)
 share_link_copied = קישור MusicBrainz הועתק
 delete = מחיקה

--- a/crates/i18n/locales/hu.ftl
+++ b/crates/i18n/locales/hu.ftl
@@ -93,6 +93,7 @@ add_to_queue = Hozzáadás sorhoz
 play_next = Lejátszás következőként
 add_to_playlist = Hozzáadás lejátszási listához
 remove_from_playlist = Eltávolítás a lejátszási listából
+start_radio = Rádió indítása
 share_musicbrainz = Megosztás (MusicBrainz)
 share_link_copied = MusicBrainz-link másolva
 delete = Törlés

--- a/crates/i18n/locales/id.ftl
+++ b/crates/i18n/locales/id.ftl
@@ -166,6 +166,7 @@ add_to_queue = Tambahkan ke Antrian
 play_next = Putar Berikutnya
 add_to_playlist = Tambahkan ke Daftar Putar
 remove_from_playlist = Hapus dari Daftar Putar
+start_radio = Mulai Radio
 share_musicbrainz = Bagikan (MusicBrainz)
 share_link_copied = Tautan MusicBrainz disalin
 delete = Hapus

--- a/crates/i18n/locales/it.ftl
+++ b/crates/i18n/locales/it.ftl
@@ -166,6 +166,7 @@ add_to_queue = Aggiungi alla Coda
 play_next = Riproduci come successivo 
 add_to_playlist = Aggiungi alla Playlist
 remove_from_playlist = Rimuovi dalla Playlist
+start_radio = Avvia Radio
 share_musicbrainz = Condividi (MusicBrainz)
 share_link_copied = link MusicBrainz copiato
 delete = Elimina

--- a/crates/i18n/locales/ja.ftl
+++ b/crates/i18n/locales/ja.ftl
@@ -93,6 +93,7 @@ add_to_queue = キューに追加
 play_next = 次に再生
 add_to_playlist = プレイリストに追加
 remove_from_playlist = プレイリストから削除
+start_radio = ラジオを開始
 share_musicbrainz = 共有 (MusicBrainz)
 share_link_copied = MusicBrainzのリンクをコピーしました
 delete = 削除

--- a/crates/i18n/locales/ko.ftl
+++ b/crates/i18n/locales/ko.ftl
@@ -93,6 +93,7 @@ add_to_queue = 대기열에 추가
 play_next = 다음으로 재생
 add_to_playlist = 재생목록에 추가
 remove_from_playlist = 재생목록에서 제거
+start_radio = 라디오 시작
 share_musicbrainz = 공유 (MusicBrainz)
 share_link_copied = MusicBrainz 링크가 복사됨
 delete = 삭제

--- a/crates/i18n/locales/ml.ftl
+++ b/crates/i18n/locales/ml.ftl
@@ -166,6 +166,7 @@ add_to_queue = ക്യൂവിലേക്ക് ചേർക്കുക
 play_next = അടുത്തത് പ്ലേ ചെയ്യുക
 add_to_playlist = പ്ലേലിസ്റ്റിലേക്ക് ചേർക്കുക
 remove_from_playlist = പ്ലേലിസ്റ്റിൽ നിന്ന് നീക്കം ചെയ്യുക
+start_radio = റേഡിയോ ആരംഭിക്കുക
 share_musicbrainz = പങ്കിടുക (MusicBrainz)
 share_link_copied = MusicBrainz ലിങ്ക് പകർത്തി
 delete = ഇല്ലാതാക്കുക

--- a/crates/i18n/locales/nl.ftl
+++ b/crates/i18n/locales/nl.ftl
@@ -166,6 +166,7 @@ add_to_queue = Aan wachtrij toevoegen
 play_next = Hierna afspelen
 add_to_playlist = Aan afspeellijst toevoegen
 remove_from_playlist = Uit afspeellijst verwijderen
+start_radio = Radio starten
 share_musicbrainz = Delen (MusicBrainz)
 share_link_copied = MusicBrainz-link gekopieerd
 delete = Verwijderen

--- a/crates/i18n/locales/pl.ftl
+++ b/crates/i18n/locales/pl.ftl
@@ -93,6 +93,7 @@ add_to_queue = Dodaj do Kolejki
 play_next = Odtwórz jako następny
 add_to_playlist = Dodaj do Playlisty
 remove_from_playlist = Usuń z Playlisty
+start_radio = Uruchom Radio
 share_musicbrainz = Udostępnij (MusicBrainz)
 share_link_copied = Skopiowano link MusicBrainz
 delete = Usuń

--- a/crates/i18n/locales/pt-BR.ftl
+++ b/crates/i18n/locales/pt-BR.ftl
@@ -146,6 +146,7 @@ add_to_queue = Adicionar à fila
 play_next = Tocar a seguir
 add_to_playlist = Adicionar à playlist
 remove_from_playlist = Remover da playlist
+start_radio = Iniciar rádio
 share_musicbrainz = Compartilhar (MusicBrainz)
 share_link_copied = Link do MusicBrainz copiado
 delete = Excluir

--- a/crates/i18n/locales/pt-PT.ftl
+++ b/crates/i18n/locales/pt-PT.ftl
@@ -146,6 +146,7 @@ add_to_queue = Adicionar à fila
 play_next = Tocar a seguir
 add_to_playlist = Adicionar à playlist
 remove_from_playlist = Remover da playlist
+start_radio = Iniciar rádio
 share_musicbrainz = Partilhar (MusicBrainz)
 share_link_copied = Ligação do MusicBrainz copiada
 delete = Apagar

--- a/crates/i18n/locales/ro.ftl
+++ b/crates/i18n/locales/ro.ftl
@@ -93,6 +93,7 @@ add_to_queue = Adaugă la Coadă
 play_next = Redă în continuare
 add_to_playlist = Adaugă la Lista de Redare
 remove_from_playlist = Elimină din Lista de Redare
+start_radio = Pornește Radioul
 share_musicbrainz = Distribuie (MusicBrainz)
 share_link_copied = Link MusicBrainz copiat
 delete = Șterge

--- a/crates/i18n/locales/ru.ftl
+++ b/crates/i18n/locales/ru.ftl
@@ -93,6 +93,7 @@ add_to_queue = Добавить в очередь
 play_next = Воспроизвести следующим
 add_to_playlist = Добавить в плейлист
 remove_from_playlist = Удалить из плейлиста
+start_radio = Запустить радио
 share_musicbrainz = Поделиться (MusicBrainz)
 share_link_copied = Ссылка MusicBrainz скопирована
 delete = Удалить

--- a/crates/i18n/locales/sv.ftl
+++ b/crates/i18n/locales/sv.ftl
@@ -166,6 +166,7 @@ add_to_queue = Lägg till i kön
 play_next = Spela nästa
 add_to_playlist = Lägg till i spellista
 remove_from_playlist = Ta bort från spellista
+start_radio = Starta radio
 share_musicbrainz = Dela (MusicBrainz)
 share_link_copied = MusicBrainz länk kopierad
 delete = Ta bort

--- a/crates/i18n/locales/ta.ftl
+++ b/crates/i18n/locales/ta.ftl
@@ -166,6 +166,7 @@ add_to_queue = வரிசையில் சேர்
 play_next = அடுத்ததை இயக்கு
 add_to_playlist = பிளேலிஸ்ட்டில் சேர்
 remove_from_playlist = பிளேலிஸ்ட்டிலிருந்து அகற்று
+start_radio = வானொலியைத் தொடங்கு
 share_musicbrainz = பகிர் (MusicBrainz)
 share_link_copied = MusicBrainz இணைப்பு நகலெடுக்கப்பட்டது
 delete = நீக்கு

--- a/crates/i18n/locales/tok-SP.ftl
+++ b/crates/i18n/locales/tok-SP.ftl
@@ -93,6 +93,7 @@ add_to_queue = 󱥄󱥌󱥩󱤾󱤕
 play_next = 󱥄󱤕󱤬󱥒
 add_to_playlist = 󱥄󱥌󱥩󱤟󱤕
 remove_from_playlist = 󱥄󱥶󱥧󱤟󱤕
+start_radio = 󱥄󱥇󱤉󱤾󱤕󱥝
 share_musicbrainz = 󱥄 (MusicBrainz)
 share_link_copied = linja MusicBrainz li kama jo
 delete = 󱥄󱥶

--- a/crates/i18n/locales/tok.ftl
+++ b/crates/i18n/locales/tok.ftl
@@ -93,6 +93,7 @@ add_to_queue = o pana tawa nasin kalama
 play_next = o kalama lon poka
 add_to_playlist = o pana tawa kulupu kalama
 remove_from_playlist = o weka tan kulupu kalama
+start_radio = o open e nasin kalama sin
 share_musicbrainz = o pana (MusicBrainz)
 share_link_copied = linja MusicBrainz li kama jo
 delete = o weka

--- a/crates/i18n/locales/tr.ftl
+++ b/crates/i18n/locales/tr.ftl
@@ -93,6 +93,7 @@ add_to_queue = Sıraya Ekle
 play_next = Sonraki çal
 add_to_playlist = Çalma Listesine Ekle
 remove_from_playlist = Çalma Listesinden Kaldır
+start_radio = Radyo Başlat
 share_musicbrainz = Paylaş (MusicBrainz)
 share_link_copied = MusicBrainz bağlantısı kopyalandı
 delete = Sil

--- a/crates/i18n/locales/uk.ftl
+++ b/crates/i18n/locales/uk.ftl
@@ -93,6 +93,7 @@ add_to_queue = Додати до черги
 play_next = Відтворити наступною
 add_to_playlist = Додати до плейлиста
 remove_from_playlist = Видалити з плейлиста
+start_radio = Запустити радіо
 share_musicbrainz = Поділитися (MusicBrainz)
 share_link_copied = Посилання MusicBrainz скопійовано
 delete = Видалити

--- a/crates/i18n/locales/vi-VN.ftl
+++ b/crates/i18n/locales/vi-VN.ftl
@@ -166,6 +166,7 @@ add_to_queue = Thêm vào hàng đợi
 play_next = Phát tiếp theo
 add_to_playlist = Thêm vào danh sách phát
 remove_from_playlist = Xóa khỏi danh sách phát
+start_radio = Bắt đầu radio
 share_musicbrainz = Chia sẻ (MusicBrainz)
 share_link_copied = Đã sao chép liên kết MusicBrainz
 delete = Xóa

--- a/crates/i18n/locales/zh-CN.ftl
+++ b/crates/i18n/locales/zh-CN.ftl
@@ -93,6 +93,7 @@ add_to_queue = 添加到播放队列
 play_next = 下一首播放
 add_to_playlist = 添加到播放列表
 remove_from_playlist = 从播放列表中移除
+start_radio = 开始电台
 share_musicbrainz = 分享 (MusicBrainz)
 share_link_copied = MusicBrainz 链接已复制
 delete = 删除

--- a/crates/pages/src/playlists.rs
+++ b/crates/pages/src/playlists.rs
@@ -309,6 +309,19 @@ pub fn PlaylistsPage(
     }
 }
 
+/// What a playlist card's overflow entry does. The menu is built conditionally —
+/// the folder entries only appear inside a folder, radio only when the source
+/// supports it — so entries carry their meaning instead of being matched by
+/// position, where adding one silently rewires every entry after it.
+#[derive(Clone, Copy, PartialEq)]
+enum PlaylistCardAction {
+    MoveToFolder,
+    RemoveFromFolder,
+    Rename,
+    StartRadio,
+    Delete,
+}
+
 /// The playlists grid: folders + local management when the source organises into
 /// folders, else a flat remote list with downloads + remote sync. One component,
 /// gated on [`Capabilities`].
@@ -605,6 +618,15 @@ fn PlaylistsGrid(
     };
     drop(conf);
     let is_yt = caps().albums == ::server::source::AlbumType::YtMusic;
+    // The flat remote card has no overflow menu of its own, so radio is its one
+    // entry — no kind-tagged action list needed here (unlike the folder card).
+    let can_radio = caps().radio;
+    let radio_text = components::radio_actions::radio_label();
+    let radio_actions = vec![MenuAction::new(
+        radio_text.as_str(),
+        components::radio_actions::RADIO_ICON,
+    )];
+    let mut active_menu = active_menu;
     let yt_anon = config
         .read()
         .server
@@ -684,8 +706,37 @@ fn PlaylistsGrid(
                                         }
                                     }
                                 }
-                                h3 { class: "text-xl font-bold text-white mb-1 truncate", "{playlist.name}" }
-                                p { class: "text-sm text-slate-400", "Server • {playlist.tracks.len()} tracks" }
+                                div { class: "flex items-start justify-between gap-2",
+                                    div { class: "min-w-0 flex-1",
+                                        h3 { class: "text-xl font-bold text-white mb-1 truncate", "{playlist.name}" }
+                                        p { class: "text-sm text-slate-400", "Server • {playlist.tracks.len()} tracks" }
+                                    }
+                                    if can_radio {
+                                        {
+                                            let pid_menu = playlist.id.clone();
+                                            let is_menu_open = active_menu.read().as_deref() == Some(playlist.id.as_str());
+                                            let start_radio = components::radio_actions::playlist_radio_handler(playlist.id.clone());
+                                            rsx! {
+                                                div { onclick: move |evt: Event<MouseData>| evt.stop_propagation(),
+                                                    DotsMenu {
+                                                        actions: radio_actions.clone(),
+                                                        is_open: is_menu_open,
+                                                        on_open: move |_| active_menu.set(Some(pid_menu.clone())),
+                                                        on_close: move |_| active_menu.set(None),
+                                                        button_class: "opacity-0 group-hover:opacity-100 focus:opacity-100".to_string(),
+                                                        anchor: "right".to_string(),
+                                                        on_action: move |_: usize| {
+                                                            active_menu.set(None);
+                                                            if let Some(handler) = start_radio {
+                                                                handler.call(());
+                                                            }
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                                 if caps().downloads {
                                     button {
                                         class: "absolute top-4 right-4 w-8 h-8 rounded-full bg-black/40 border border-white/10 flex items-center justify-center text-white/60 hover:text-white hover:border-white/30 transition-colors opacity-0 group-hover:opacity-100",
@@ -788,17 +839,40 @@ fn folders_layout(ctx: FoldersCtx<'_>) -> Element {
     let remove_folder_text = i18n::t("remove_from_folder").to_string();
     let delete_folder_text = i18n::t("delete_folder").to_string();
 
-    let playlist_actions = vec![
-        MenuAction::new(move_text.as_str(), "fa-solid fa-folder-open"),
-        MenuAction::new(rename_playlist_text.as_str(), "fa-solid fa-pen"),
-        MenuAction::new(delete_playlist_text.as_str(), "fa-solid fa-trash").destructive(),
-    ];
-    let folder_playlist_actions = vec![
-        MenuAction::new(move_text.as_str(), "fa-solid fa-folder-open"),
-        MenuAction::new(remove_folder_text.as_str(), "fa-solid fa-folder-minus"),
-        MenuAction::new(rename_playlist_text.as_str(), "fa-solid fa-pen"),
-        MenuAction::new(delete_playlist_text.as_str(), "fa-solid fa-trash").destructive(),
-    ];
+    let radio_text = components::radio_actions::radio_label();
+    let can_radio = consume_context::<Signal<::server::source::ActiveSource>>()
+        .read()
+        .capabilities()
+        .radio;
+
+    let build_playlist_actions = |in_folder: bool| -> (Vec<MenuAction>, Vec<PlaylistCardAction>) {
+        let mut entries = vec![(
+            MenuAction::new(move_text.as_str(), "fa-solid fa-folder-open"),
+            PlaylistCardAction::MoveToFolder,
+        )];
+        if in_folder {
+            entries.push((
+                MenuAction::new(remove_folder_text.as_str(), "fa-solid fa-folder-minus"),
+                PlaylistCardAction::RemoveFromFolder,
+            ));
+        }
+        entries.push((
+            MenuAction::new(rename_playlist_text.as_str(), "fa-solid fa-pen"),
+            PlaylistCardAction::Rename,
+        ));
+        if can_radio {
+            entries.push((
+                MenuAction::new(radio_text.as_str(), components::radio_actions::RADIO_ICON),
+                PlaylistCardAction::StartRadio,
+            ));
+        }
+        entries.push((
+            MenuAction::new(delete_playlist_text.as_str(), "fa-solid fa-trash").destructive(),
+            PlaylistCardAction::Delete,
+        ));
+        entries.into_iter().unzip()
+    };
+
     let folder_actions = vec![
         MenuAction::new(rename_folder_text.as_str(), "fa-solid fa-pen"),
         MenuAction::new(delete_folder_text.as_str(), "fa-solid fa-trash").destructive(),
@@ -814,11 +888,10 @@ fn folders_layout(ctx: FoldersCtx<'_>) -> Element {
         let name = playlist.name.clone();
         let count = playlist.tracks.len();
         let is_menu_open = active_menu.read().as_deref() == Some(playlist.id.as_str());
-        let actions = if in_folder {
-            folder_playlist_actions.clone()
-        } else {
-            playlist_actions.clone()
-        };
+        let (actions, action_kinds) = build_playlist_actions(in_folder);
+        // Resolved during render, like the track rows' radio: the handler reads
+        // context, which an event closure can't do.
+        let start_radio = components::radio_actions::playlist_radio_handler(playlist.id.clone());
         rsx! {
             div {
                 key: "{pid}",
@@ -858,55 +931,52 @@ fn folders_layout(ctx: FoldersCtx<'_>) -> Element {
                             anchor: "right".to_string(),
                             on_action: move |idx: usize| {
                                 active_menu.set(None);
-                                if in_folder {
-                                    match idx {
-                                        0 => move_target_id.set(Some(pid_action.clone())),
-                                        1 => {
-                                            let pid = pid_action.clone();
-                                            let local = consume_context::<Signal<::server::source::ActiveSource>>().peek().clone();
-                                            spawn(async move {
-                                                if local
-                                                    .set_playlist_folder(&pid, None)
-                                                    .await
-                                                    .is_ok()
-                                                {
-                                                    gens.bump(Table::Folders);
-                                                }
-                                            });
-                                        }
-                                        2 => {
-                                            rename_playlist_id.set(Some(pid_action.clone()));
-                                            rename_playlist_name.set(name_for_rename.clone());
-                                        }
-                                        _ => {
-                                            let pid = pid_action.clone();
-                                            let source = consume_context::<Signal<::server::source::ActiveSource>>().peek().clone();
-                                            spawn(async move {
-                                                if source.delete_playlist(&pid).await.is_ok()
-                                                    && source.set_playlist_folder(&pid, None).await.is_ok()
-                                                {
-                                                    gens.bump(Table::Playlists);
-                                                    gens.bump(Table::Folders);
-                                                }
-                                            });
+                                let Some(kind) = action_kinds.get(idx).copied() else {
+                                    return;
+                                };
+                                match kind {
+                                    PlaylistCardAction::MoveToFolder => {
+                                        move_target_id.set(Some(pid_action.clone()))
+                                    }
+                                    PlaylistCardAction::RemoveFromFolder => {
+                                        let pid = pid_action.clone();
+                                        let local = consume_context::<Signal<::server::source::ActiveSource>>().peek().clone();
+                                        spawn(async move {
+                                            if local
+                                                .set_playlist_folder(&pid, None)
+                                                .await
+                                                .is_ok()
+                                            {
+                                                gens.bump(Table::Folders);
+                                            }
+                                        });
+                                    }
+                                    PlaylistCardAction::Rename => {
+                                        rename_playlist_id.set(Some(pid_action.clone()));
+                                        rename_playlist_name.set(name_for_rename.clone());
+                                    }
+                                    PlaylistCardAction::StartRadio => {
+                                        if let Some(handler) = start_radio {
+                                            handler.call(());
                                         }
                                     }
-                                } else {
-                                    match idx {
-                                        0 => move_target_id.set(Some(pid_action.clone())),
-                                        1 => {
-                                            rename_playlist_id.set(Some(pid_action.clone()));
-                                            rename_playlist_name.set(name_for_rename.clone());
-                                        }
-                                        _ => {
-                                            let pid = pid_action.clone();
-                                            let s = consume_context::<Signal<::server::source::ActiveSource>>().peek().clone();
-                                            spawn(async move {
-                                                if s.delete_playlist(&pid).await.is_ok() {
-                                                    gens.bump(Table::Playlists);
-                                                }
-                                            });
-                                        }
+                                    // Deleting from inside a folder also drops the
+                                    // membership row, so the folder doesn't keep a
+                                    // dangling id.
+                                    PlaylistCardAction::Delete => {
+                                        let pid = pid_action.clone();
+                                        let source = consume_context::<Signal<::server::source::ActiveSource>>().peek().clone();
+                                        spawn(async move {
+                                            if source.delete_playlist(&pid).await.is_err() {
+                                                return;
+                                            }
+                                            gens.bump(Table::Playlists);
+                                            if in_folder
+                                                && source.set_playlist_folder(&pid, None).await.is_ok()
+                                            {
+                                                gens.bump(Table::Folders);
+                                            }
+                                        });
                                     }
                                 }
                             },


### PR DESCRIPTION
Added triple dots on playlist grid that has start radio button, for the sources that support it.

Added radio start button on the playlist detail screen for the sources that support it.

## Sanity Checking


[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>