### PR TITLE
various: surface youtube liked music as a playlist

### DIFF
--- a/crates/db/.sqlx/query-0b847ea7418a1f70580154b6ea5da25c529c554078e09e62fdb2686f76c3b5fd.json
+++ b/crates/db/.sqlx/query-0b847ea7418a1f70580154b6ea5da25c529c554078e09e62fdb2686f76c3b5fd.json
@@ -1,6 +1,6 @@
 {
   "db_name": "SQLite",
-  "query": "SELECT rowid_pk as \"rowid_pk!\", source_pl_id, name, cover_path, image_tag FROM playlists WHERE source = ?1 AND source_pl_id != 'LM' ORDER BY position",
+  "query": "SELECT rowid_pk as \"rowid_pk!\", source_pl_id, name, cover_path, image_tag FROM playlists WHERE source = ?1 ORDER BY position",
   "describe": {
     "columns": [
       {
@@ -40,5 +40,5 @@
       true
     ]
   },
-  "hash": "1abd360c5db591d1ee8abb42648f6013a2dee8b48a30ec2b7dc694650d263522"
+  "hash": "0b847ea7418a1f70580154b6ea5da25c529c554078e09e62fdb2686f76c3b5fd"
 }

--- a/crates/db/src/backend/dump.rs
+++ b/crates/db/src/backend/dump.rs
@@ -44,12 +44,9 @@ pub async fn load_playlists(pool: &SqlitePool, source: &Source) -> Result<Playli
     // and a server playlist that share an id never collide here. The caller
     // passes the IN-MEMORY active source (the persisted blob lags a switch).
     let src = source.as_str();
-    // 'LM' (YT Liked Music) is NOT surfaced as a playlist — likes are the
-    // favorites view's domain — so it never appears in the playlists grid even
-    // if an older sync materialized a row for it.
     let rows = sqlx::query!(
         "SELECT rowid_pk as \"rowid_pk!\", source_pl_id, name, cover_path, image_tag \
-         FROM playlists WHERE source = ?1 AND source_pl_id != 'LM' ORDER BY position",
+         FROM playlists WHERE source = ?1 ORDER BY position",
         src
     )
     .fetch_all(pool)

--- a/crates/db/tests/persistence.rs
+++ b/crates/db/tests/persistence.rs
@@ -500,18 +500,20 @@ async fn streaming_playlist_tracks_upsert_then_sweep() {
 }
 
 #[tokio::test]
-async fn liked_music_playlist_is_hidden_from_the_grid() {
+async fn liked_music_playlist_surfaces_in_the_grid() {
     let db_path = unique_db();
     let db = db::init(&db_path).await.unwrap();
     seed_active_server(&db, "srv-1").await;
     let srv = Source::Server("srv-1".into());
 
-    // A real playlist surfaces; the reserved "LM" (YT Liked Music) one never
-    // does — likes belong to the favorites view, not the playlists grid.
+    // "LM" (YT Liked Music) is a playlist like any other as far as the store is
+    // concerned — the YT source decides where its entries come from. This read
+    // used to filter the id out, which hid the tile no matter what the source
+    // returned.
     db.upsert_playlist_meta(&srv, "PLX", "Mix", None, None)
         .await
         .unwrap();
-    db.upsert_playlist_meta(&srv, "LM", "Liked Songs", None, None)
+    db.upsert_playlist_meta(&srv, "LM", "Liked Music", None, None)
         .await
         .unwrap();
     db.set_playlist_tracks(&srv, "LM", &["VID1".into()])
@@ -520,7 +522,14 @@ async fn liked_music_playlist_is_hidden_from_the_grid() {
 
     let store = db.load_playlists(&srv).await.unwrap();
     let ids: Vec<&str> = store.playlists.iter().map(|p| p.id.as_str()).collect();
-    assert_eq!(ids, vec!["PLX"], "LM must not surface as a playlist");
+    assert!(
+        ids.contains(&"LM"),
+        "LM must surface as a playlist: {ids:?}"
+    );
+    assert!(ids.contains(&"PLX"));
+
+    let lm = store.playlists.iter().find(|p| p.id == "LM").unwrap();
+    assert_eq!(lm.tracks, vec!["VID1".to_string()]);
 
     let _ = std::fs::remove_dir_all(db_path.parent().unwrap());
 }

--- a/crates/server/src/source/youtube_music.rs
+++ b/crates/server/src/source/youtube_music.rs
@@ -10,6 +10,14 @@ use super::{
     mirror_created,
 };
 
+/// YT Music's "Liked Music" auto-playlist. It is not browsed like the user's
+/// other playlists: its contents are the liked songs, which kopuz already keeps
+/// as this source's favorites, so it is served straight out of the favorites
+/// table. That keeps the tile and the heart icons from ever disagreeing, and
+/// costs no extra round-trip. Confined to this file on purpose — no other
+/// source has such a playlist and the UI stays unaware of it.
+const LIKED_MUSIC_ID: &str = "LM";
+
 pub(super) struct YtSource {
     db: Db,
     source: Source,
@@ -23,6 +31,16 @@ impl YtSource {
             source,
             client: YouTubeMusicClient::with_cookies(conn.token.clone()),
         }
+    }
+
+    /// The favorites, as playlist entries, in favorite order — `tracks_by_keys`
+    /// answers in table order, which would shuffle the tile on every sync.
+    async fn liked_music_entries(&self) -> Result<Vec<reader::Track>, SourceError> {
+        let keys = self.db.favorites(self.source.as_str()).await?;
+        let mut tracks = self.db.tracks_by_keys(&self.source, &keys).await?;
+        let position = |t: &reader::Track| keys.iter().position(|k| k == t.id.key().as_ref());
+        tracks.sort_by_key(|t| position(t).unwrap_or(usize::MAX));
+        Ok(tracks)
     }
 }
 
@@ -73,6 +91,8 @@ impl MediaSource for YtSource {
         if playlist_ref.trim().is_empty() {
             return Err(SourceError::InvalidInput("playlist has no id".into()));
         }
+        // Liked Music needs no special case here: YT builds `RDAMPLLM` like any
+        // other playlist mix — that is exactly what its own web client asks for.
         self.client
             .start_playlist_mix(playlist_ref)
             .await
@@ -250,6 +270,26 @@ impl MediaSource for YtSource {
         playlist_id: &str,
         item_refs: &[String],
     ) -> Result<Vec<String>, SourceError> {
+        // Adding to Liked Music IS liking, so it goes through the favorite path
+        // rather than a playlist mutation YT would reject. The local row is
+        // written clean, not dirty — the push already happened here, and a dirty
+        // row would have the reconciler push it a second time.
+        if playlist_id == LIKED_MUSIC_ID {
+            let sid = self.source.as_str();
+            let mut added = Vec::new();
+            for id in item_refs {
+                if self.push_favorite(id, true).await.is_err() {
+                    continue;
+                }
+                if self.db.set_favorite(sid, id, true).await.is_ok() {
+                    let _ = self.db.clear_favorite_dirty(sid, id).await;
+                    added.push(id.clone());
+                }
+            }
+            return mirror_added(&self.db, &self.source, LIKED_MUSIC_ID, &added)
+                .await
+                .map(|()| added);
+        }
         let mut added = Vec::new();
         for id in item_refs {
             if self.client.add_to_playlist(playlist_id, id).await.is_ok() {
@@ -280,6 +320,21 @@ impl MediaSource for YtSource {
         let vid = track.id.key();
         if vid.is_empty() {
             return Err(SourceError::InvalidInput("track has no video id".into()));
+        }
+        // Removing from Liked Music is unliking (see `add_to_playlist`). Local
+        // first so the row disappears immediately, then push, reverting the
+        // local write if YT rejects it — the same order the favorites hook uses.
+        if playlist_id == LIKED_MUSIC_ID {
+            self.record_favorite(track, false).await?;
+            if let Err(e) = self.push_favorite(&vid, false).await {
+                let _ = self.record_favorite(track, true).await;
+                return Err(e);
+            }
+            return self
+                .db
+                .remove_playlist_tracks(&self.source, LIKED_MUSIC_ID, &[vid.into_owned()])
+                .await
+                .map_err(SourceError::from);
         }
         self.client.remove_from_playlist(playlist_id, &vid).await?;
         self.db
@@ -330,7 +385,7 @@ impl MediaSource for YtSource {
     }
 
     async fn fetch_playlists(&self) -> Result<Vec<PlaylistMeta>, SourceError> {
-        Ok(self
+        let mut out: Vec<PlaylistMeta> = self
             .client
             .list_playlists()
             .await?
@@ -343,13 +398,31 @@ impl MediaSource for YtSource {
                     .as_ref()
                     .map(|u| reader::CoverRef::encode_url(u)),
             })
-            .collect())
+            .collect();
+        // YT's own library grid normally carries the Liked Music tile (with its
+        // artwork), so this only fills in when that tile is missing — the grid's
+        // shape is not something to depend on. Anonymous sessions have no likes,
+        // so nothing is added there.
+        if self.client.is_authenticated() && !out.iter().any(|p| p.id == LIKED_MUSIC_ID) {
+            out.insert(
+                0,
+                PlaylistMeta {
+                    id: LIKED_MUSIC_ID.to_string(),
+                    name: "Liked Music".to_string(),
+                    image_tag: None,
+                },
+            );
+        }
+        Ok(out)
     }
 
     async fn fetch_playlist_entries(
         &self,
         playlist_id: &str,
     ) -> Result<Vec<reader::Track>, SourceError> {
+        if playlist_id == LIKED_MUSIC_ID {
+            return self.liked_music_entries().await;
+        }
         // The YT client already returns typed tracks.
         Ok(self.client.get_playlist_entries(playlist_id).await?)
     }
@@ -359,6 +432,13 @@ impl MediaSource for YtSource {
         playlist_id: &str,
         cursor: Option<String>,
     ) -> Result<PlaylistPage, SourceError> {
+        if playlist_id == LIKED_MUSIC_ID {
+            // Favorites are already local, so there's nothing to page through.
+            return Ok(PlaylistPage {
+                tracks: self.liked_music_entries().await?,
+                next: None,
+            });
+        }
         // True per-page InnerTube walk so a long playlist streams into the cache
         // (and the UI) instead of blocking on a full fetch every visit.
         let (tracks, next) = self

--- a/crates/server/src/ytmusic/mod.rs
+++ b/crates/server/src/ytmusic/mod.rs
@@ -285,6 +285,12 @@ impl YouTubeMusicClient {
     // discover/mix `post` and innertube::browse now interpret as "skip
     // SAPISID auth headers" (see browse_maybe_auth / discover::post).
 
+    /// Whether this client has cookies — i.e. the user is signed in rather than
+    /// browsing YT anonymously.
+    pub fn is_authenticated(&self) -> bool {
+        self.cookies.is_some()
+    }
+
     pub async fn start_mix(&self, seed_video_id: &str) -> Result<Vec<Track>, String> {
         mix::fetch(
             mix::MixSeed::Video(seed_video_id),


### PR DESCRIPTION
Added liked music playlist for youtube sources into the playlists section, for allowing playlist operations such as radio on the playlist.

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [ ] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>