### PR TITLE
fix: improve selection bar contrast on light accents

### DIFF
--- a/crates/components/src/selection_bar.rs
+++ b/crates/components/src/selection_bar.rs
@@ -1,6 +1,6 @@
 use dioxus::prelude::*;
 
-const DEFAULT_SELECTION_BAR_CLASS: &str = "fixed bottom-24 left-1/2 -translate-x-1/2 bg-indigo-500 text-white px-6 py-2.5 rounded-full shadow-2xl flex items-center gap-4 z-50 animate-in fade-in zoom-in duration-200 font-mono";
+const DEFAULT_SELECTION_BAR_CLASS: &str = "fixed bottom-24 left-1/2 -translate-x-1/2 bg-indigo-500 text-black px-6 py-2.5 rounded-full shadow-2xl flex items-center gap-4 z-50 animate-in fade-in zoom-in duration-200 font-mono";
 
 #[component]
 pub fn SelectionBar(
@@ -27,7 +27,7 @@ pub fn SelectionBar(
 
             span { class: "font-bold text-lg whitespace-nowrap pl-2", "{count} selected" }
 
-            div { class: "w-px h-5 bg-white/20" }
+            div { class: "w-px h-5 bg-black/20" }
 
             div { class: "flex items-center gap-4",
                 button {
@@ -53,7 +53,7 @@ pub fn SelectionBar(
                 }
             }
 
-            div { class: "w-px h-5 bg-white/20" }
+            div { class: "w-px h-5 bg-black/20" }
 
             button {
                 class: "hover:opacity-80 transition-opacity flex items-center justify-center pr-2",

--- a/crates/pages/src/artist.rs
+++ b/crates/pages/src/artist.rs
@@ -556,7 +556,7 @@ pub fn Artist(
                             SelectionBar {
                                 count: selected_tracks.read().len(),
                                 show_delete: caps().delete_from_disk,
-                                class: Some("absolute bottom-24 left-1/2 -translate-x-1/2 bg-indigo-500 text-white px-6 py-2.5 rounded-full shadow-2xl flex items-center gap-4 z-50 animate-in fade-in zoom-in duration-200 font-mono".to_string()),
+                                class: Some("absolute bottom-24 left-1/2 -translate-x-1/2 bg-indigo-500 text-black px-6 py-2.5 rounded-full shadow-2xl flex items-center gap-4 z-50 animate-in fade-in zoom-in duration-200 font-mono".to_string()),
                                 on_add_to_queue: move |_| {
                                     let selected = selected_tracks.read().clone();
                                     let tracks: Vec<_> = artist_tracks()


### PR DESCRIPTION
Use theme surface ink (text-black) instead of body text (text-white) on the indigo accent pill so Ayu Dark/Mirage cyan stays readable. Fixes   #598 

Prev it used to be hard to read in Ayu Dark/Mirage
<img width="1619" height="932" alt="image" src="https://github.com/user-attachments/assets/f1ea53af-65cb-41df-9f96-27e35fcd37bd" />

After fix:
<img width="1195" height="891" alt="image" src="https://github.com/user-attachments/assets/e90e59e3-32c1-473b-bb95-c3901fae816e" />


## Sanity Checking
[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

-  [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
