### PR TITLE
feat: Added Navidrome server side "song radio" queue support

### DIFF
--- a/crates/server/src/source/subsonic.rs
+++ b/crates/server/src/source/subsonic.rs
@@ -435,4 +435,24 @@ mod tests {
 
         assert!(meta.image_tag.is_none());
     }
+
+    /// The UI's "Start Radio" action reads this flag alone (see
+    /// `radio_actions::radio_supported`) — a regression here silently hides
+    /// the menu item for every Subsonic/Navidrome user.
+    #[tokio::test]
+    async fn subsonic_capabilities_enable_radio() {
+        let dir = std::env::temp_dir().join(format!("kopuz-subsonic-caps-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = db::init(&dir.join("kopuz.db")).await.unwrap();
+        let conn = ServerConn {
+            service: MusicService::Subsonic,
+            url: "https://music.example.test".to_string(),
+            token: "password".to_string(),
+            user_id: "user".to_string(),
+            device_id: "test".to_string(),
+        };
+        let src = SubsonicSource::new(db, Source::Server("test".to_string()), &conn);
+
+        assert!(src.capabilities().radio);
+    }
 }

--- a/crates/server/src/source/subsonic.rs
+++ b/crates/server/src/source/subsonic.rs
@@ -29,6 +29,48 @@ impl SubsonicSource {
     }
 }
 
+/// Convert a Subsonic song into a `Track`, resolving its own cover and album
+/// instead of a preloaded one. Shared by playlist entries and radio results,
+/// where each song can belong to a different album.
+fn song_to_track(
+    client: &SubsonicClient,
+    service: MusicService,
+    item: crate::subsonic::SubsonicSong,
+) -> reader::Track {
+    let cover_tag = item
+        .cover_art
+        .as_ref()
+        .and_then(|id| client.cover_art_url(id, Some(512)).ok())
+        .map(|url| reader::CoverRef::encode_url(&url));
+    let album_id = reader::CoverRef::stored_item_ref(
+        service,
+        item.album_id.as_deref().unwrap_or(&item.id),
+        Some(cover_tag.as_deref().unwrap_or(reader::CoverRef::NO_COVER)),
+    );
+    let artist = item.artist.clone().unwrap_or_default();
+    reader::models::Track {
+        id: reader::models::TrackId::Server {
+            service,
+            item_id: item.id.clone(),
+        },
+        cover: Some(cover_tag.unwrap_or_else(|| reader::CoverRef::NO_COVER.to_string())),
+        album_id,
+        title: item.title,
+        artist: artist.clone(),
+        album: item.album.unwrap_or_default(),
+        duration: item.duration.unwrap_or(0),
+        khz: item.sampling_rate.unwrap_or(0),
+        bitrate: item.bit_rate.unwrap_or(0).min(u16::MAX as u32) as u16,
+        track_number: item.track,
+        disc_number: item.disc_number,
+        musicbrainz_release_id: None,
+        musicbrainz_recording_id: None,
+        musicbrainz_track_id: None,
+        playlist_item_id: None,
+        artists: vec![artist],
+    }
+}
+
 fn playlist_meta(
     client: &SubsonicClient,
     playlist: crate::subsonic::SubsonicPlaylist,
@@ -185,7 +227,7 @@ impl MediaSource for SubsonicSource {
             sync: true,
             downloads: true,
             discover: false,
-            radio: false,
+            radio: true,
             playlists: PlaylistOps::Reorder,
             artist_view: ArtistView::Library,
             albums: AlbumType::Standard,
@@ -309,45 +351,19 @@ impl MediaSource for SubsonicSource {
         let items = self.client.get_playlist_entries(playlist_id).await?;
         Ok(items
             .into_iter()
-            .map(|item| {
-                // Encode the cover URL as the `urlhex_` tag the cover resolver
-                // understands; album_id carries it (or `:none`) like fetch_library
-                // — same encoder, so these ids match the synced album rows.
-                let cover_tag = item
-                    .cover_art
-                    .as_ref()
-                    .and_then(|id| self.client.cover_art_url(id, Some(512)).ok())
-                    .map(|url| reader::CoverRef::encode_url(&url));
-                let album_id = reader::CoverRef::stored_item_ref(
-                    self.service,
-                    item.album_id.as_deref().unwrap_or(&item.id),
-                    Some(cover_tag.as_deref().unwrap_or(reader::CoverRef::NO_COVER)),
-                );
-                let artist = item.artist.clone().unwrap_or_default();
-                reader::models::Track {
-                    id: reader::models::TrackId::Server {
-                        service: self.service,
-                        item_id: item.id.clone(),
-                    },
-                    cover: Some(
-                        cover_tag.unwrap_or_else(|| reader::CoverRef::NO_COVER.to_string()),
-                    ),
-                    album_id,
-                    title: item.title,
-                    artist: artist.clone(),
-                    album: item.album.unwrap_or_default(),
-                    duration: item.duration.unwrap_or(0),
-                    khz: item.sampling_rate.unwrap_or(0),
-                    bitrate: item.bit_rate.unwrap_or(0).min(u16::MAX as u32) as u16,
-                    track_number: item.track,
-                    disc_number: item.disc_number,
-                    musicbrainz_release_id: None,
-                    musicbrainz_recording_id: None,
-                    musicbrainz_track_id: None,
-                    playlist_item_id: None,
-                    artists: vec![artist],
-                }
-            })
+            .map(|item| song_to_track(&self.client, self.service, item))
+            .collect())
+    }
+
+    async fn start_radio(&self, seed_ref: &str) -> Result<Vec<reader::Track>, SourceError> {
+        const SIMILAR_SONGS_COUNT: usize = 50;
+        let songs = self
+            .client
+            .get_similar_songs(seed_ref, SIMILAR_SONGS_COUNT)
+            .await?;
+        Ok(songs
+            .into_iter()
+            .map(|song| song_to_track(&self.client, self.service, song))
             .collect())
     }
 

--- a/crates/server/src/subsonic.rs
+++ b/crates/server/src/subsonic.rs
@@ -180,6 +180,20 @@ struct PlaylistCreationData {
     playlist: Option<SubsonicPlaylist>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SimilarSongsContainer {
+    #[serde(default)]
+    song: Vec<SubsonicSong>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetSimilarSongs2Data {
+    #[serde(default, rename = "similarSongs2")]
+    similar_songs2: Option<SimilarSongsContainer>,
+}
+
 /// Build a Subsonic `getCoverArt` URL without the caller holding a client — the
 /// player's synchronous cover path needs it but must not construct a client.
 pub fn cover_art_url(
@@ -252,6 +266,25 @@ impl SubsonicClient {
             )
             .await?;
         Ok(data.album.map(|a| a.song).unwrap_or_default())
+    }
+
+    /// OpenSubsonic `getSimilarSongs2`, needs a server-side plugin such as
+    /// Navidrome's AudioMuse to actually return results.
+    pub async fn get_similar_songs(
+        &self,
+        song_id: &str,
+        count: usize,
+    ) -> Result<Vec<SubsonicSong>, String> {
+        let data = self
+            .call::<GetSimilarSongs2Data>(
+                "getSimilarSongs2.view",
+                vec![
+                    ("id".to_string(), song_id.to_string()),
+                    ("count".to_string(), count.to_string()),
+                ],
+            )
+            .await?;
+        Ok(data.similar_songs2.map(|s| s.song).unwrap_or_default())
     }
 
     pub async fn get_playlists(&self) -> Result<Vec<SubsonicPlaylist>, String> {


### PR DESCRIPTION
Added song radio support for navidrome servers that support it. For example, Audiomuse classifies songs with a ML and adds queue support, other clients support this and Kopuz did not.
AI has been used for some parts, it has been tested by hand
<!--
Please include a clear and concise description of the aim of your pull request
above this line.

If this pull request fixes an open issue, link it with `Fixes #<issue number>`.
For playback, scanning, source, packaging, or crash fixes, include the relevant
logs or reproduction steps.
-->

## Sanity Checking

<!--
Please check all that apply. These boxes help maintainers quickly understand
what you already verified and what still needs review.
-->

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [X] I have read and followed the [contribution guidelines].
- [X] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [X] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [X] I have tested and self-reviewed my changes.

### Style and Consistency

- [X] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [X] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [X] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [X] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [X] I ran the smallest relevant verifier for this change.
- [X] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [X] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [X] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
