### PR TITLE
docs: fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,3 +812,7 @@ longer than needed.
 
 - Logo design by: Lucas Amorim -
   [His Instagram Account](https://www.instagram.com/yattets/)
+
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=Kopuz-org/kopuz&type=date&legend=top-left)](https://star-history.dera.page/#Kopuz-org/kopuz&type=date&legend=top-left)

--- a/docs/README-ML.md
+++ b/docs/README-ML.md
@@ -432,4 +432,4 @@ KOPUZ_LOG="info,dioxus_core=trace" kopuz
 
 ## സ്റ്റാർ ചരിത്രം (Star History)
 
-[![Star History Chart](https://api.star-history.com/chart?repos=Kopuz-org/kopuz&type=date&legend=top-left)](https://www.star-history.com/?repos=Kopuz-org%2Fkopuz&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Kopuz-org/kopuz&type=date&legend=top-left)](https://star-history.dera.page/#Kopuz-org/kopuz&type=date&legend=top-left)

--- a/docs/README-PT-PT.md
+++ b/docs/README-PT-PT.md
@@ -560,4 +560,4 @@ guardar imagens descodificadas na memória mais tempo do que o necessário.
 
 ## Histórico de Estrelas
 
-[![Star History Chart](https://api.star-history.com/chart?repos=Kopuz-org/kopuz&type=date&legend=top-left)](https://www.star-history.com/?repos=Kopuz-org%2Fkopuz&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Kopuz-org/kopuz&type=date&legend=top-left)](https://star-history.dera.page/#Kopuz-org/kopuz&type=date&legend=top-left)

--- a/docs/README-TR.md
+++ b/docs/README-TR.md
@@ -565,4 +565,4 @@ görüntüleri bellekte ihtiyaç duyulandan daha uzun süre tutmuyoruz.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=Kopuz-org/kopuz&type=date&legend=top-left)](https://www.star-history.com/?repos=Kopuz-org%2Fkopuz&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Kopuz-org/kopuz&type=date&legend=top-left)](https://star-history.dera.page/#Kopuz-org/kopuz&type=date&legend=top-left)


### PR DESCRIPTION
The Star History chart on the README is currently broken because the service that used to power it is no longer able to fetch stargazer data reliably. This restores the section that was removed in 72c001b and points both the main README and the localized READMEs at a working chart host, so the project history renders again.