### PR TITLE
fix: settings scroll lag when CD selected

### DIFF
--- a/crates/kopuz/assets/tailwind.css
+++ b/crates/kopuz/assets/tailwind.css
@@ -91,6 +91,7 @@
     --leading-tight: 1.25;
     --leading-snug: 1.375;
     --leading-relaxed: 1.625;
+    --radius-sm: 0.25rem;
     --radius-md: 0.375rem;
     --radius-lg: 0.5rem;
     --radius-xl: 0.75rem;

--- a/crates/kopuz/assets/themes.css
+++ b/crates/kopuz/assets/themes.css
@@ -497,18 +497,75 @@ select:disabled {
     width: min(14rem, calc(100vw - 2rem));
 }
 
-.settings-workspace {
-    --settings-fan-radius: clamp(5rem, calc(50vh - 3.75rem), 15.5rem);
-    --settings-fan-radius: clamp(5rem, calc(50dvh - 3.75rem), 15.5rem);
-    display: grid;
-    grid-template-columns: calc(var(--settings-fan-radius) + 2rem) minmax(0, 1fr);
-    min-height: calc(100vh - 6rem);
-    min-height: calc(100dvh - 6rem);
-    align-items: start;
-    gap: 0.75rem;
+.settings-category-content {
+    min-width: 0;
+    scroll-margin-top: 1rem;
+    contain: layout;
+    animation: settings-category-enter 220ms ease-out;
+}
+
+@keyframes settings-category-enter {
+    from {
+        opacity: 0;
+        transform: translateY(7px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.settings-section {
+    border: 1px solid color-mix(in srgb, var(--color-white, #ffffff) 11%, transparent);
+    background: color-mix(in srgb, var(--color-black, #000000) 78%, transparent);
+    box-shadow: 0 10px 32px rgba(0, 0, 0, 0.24);
+}
+
+.settings-section-header {
+    background: color-mix(in srgb, var(--color-black, #000000) 58%, transparent);
+    transition: background-color 140ms ease;
+}
+
+.settings-section-header:hover {
+    background: color-mix(in srgb, var(--color-white, #ffffff) 7%, transparent);
+}
+
+.settings-section-body > .settings-row:nth-child(even) {
+    background: color-mix(in srgb, var(--color-white, #ffffff) 2.5%, transparent);
+}
+
+.settings-row {
+    min-height: 3.25rem;
+    transition: background-color 120ms ease;
+}
+
+.settings-row:hover {
+    background: color-mix(in srgb, var(--color-white, #ffffff) 5%, transparent) !important;
+}
+
+.settings-subsection-label {
+    padding: 0.65rem 1.25rem 0.45rem;
+    background: color-mix(in srgb, var(--color-black, #000000) 32%, transparent);
+    color: color-mix(in srgb, var(--color-white, #ffffff) 48%, transparent);
+    font-size: 0.625rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
 }
 
 @media (min-width: 901px) and (min-height: 541px) {
+    .settings-layout-cd .settings-workspace {
+        --settings-fan-radius: clamp(5rem, calc(50vh - 3.75rem), 15.5rem);
+        --settings-fan-radius: clamp(5rem, calc(50dvh - 3.75rem), 15.5rem);
+        display: grid;
+        grid-template-columns: calc(var(--settings-fan-radius) + 2rem) minmax(0, 1fr);
+        min-height: calc(100vh - 6rem);
+        min-height: calc(100dvh - 6rem);
+        align-items: start;
+        gap: 0.75rem;
+        contain: layout;
+    }
+
     .settings-page.settings-layout-cd {
         max-width: none !important;
         margin-right: 0 !important;
@@ -519,170 +576,183 @@ select:disabled {
     .settings-page.settings-layout-cd > h1 {
         margin-left: 1.5rem;
     }
-}
 
-.settings-fan {
-    position: sticky;
-    top: max(0.5rem, calc(50vh - var(--settings-fan-radius)));
-    height: calc(var(--settings-fan-radius) + var(--settings-fan-radius));
-    overflow: hidden;
-    isolation: isolate;
-}
+    .settings-layout-cd .settings-fan {
+        position: sticky;
+        top: max(0.5rem, calc(50vh - var(--settings-fan-radius)));
+        height: calc(var(--settings-fan-radius) * 2);
+        overflow: hidden;
+        isolation: isolate;
+        contain: strict;
+        contain-intrinsic-size: calc(var(--settings-fan-radius) + 2rem) calc(var(--settings-fan-radius) * 2);
+        will-change: transform;
+        transform: translate3d(0, 0, 0);
+        backface-visibility: hidden;
+        pointer-events: auto;
+    }
 
-.settings-fan-disc {
-    position: relative;
-    width: var(--settings-fan-radius);
-    height: calc(var(--settings-fan-radius) + var(--settings-fan-radius));
-}
+    .settings-layout-cd .settings-fan-disc {
+        position: relative;
+        width: var(--settings-fan-radius);
+        height: 100%;
+        contain: strict;
+        transform: translate3d(0, 0, 0);
+        backface-visibility: hidden;
+    }
 
-.settings-fan-disc::before {
-    position: absolute;
-    z-index: 0;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    border: 1px solid color-mix(in srgb, var(--color-white, #ffffff) 13%, transparent);
-    border-left: 0;
-    border-radius: 0 999px 999px 0;
-    background:
-        repeating-radial-gradient(
+    .settings-layout-cd .settings-fan-disc::before {
+        position: absolute;
+        z-index: 0;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        border: 1px solid color-mix(in srgb, var(--color-white, #ffffff) 14%, transparent);
+        border-left: 0;
+        border-radius: 0 999px 999px 0;
+        background: radial-gradient(
             circle at left center,
-            transparent 0 8px,
-            color-mix(in srgb, var(--color-white, #ffffff) 3.5%, transparent) 9px,
-            transparent 10px
-        ),
-        radial-gradient(
-            circle at left center,
-            color-mix(in srgb, var(--color-white, #ffffff) 8%, var(--color-black, #000000)) 0 21%,
-            color-mix(in srgb, var(--color-black, #000000) 72%, transparent) 21.5% 100%
+            color-mix(in srgb, var(--color-white, #ffffff) 12%, var(--color-black, #000000)) 0 16%,
+            color-mix(in srgb, var(--color-black, #000000) 88%, transparent) 17% 28%,
+            color-mix(in srgb, var(--color-white, #ffffff) 7%, var(--color-black, #000000)) 29% 34%,
+            color-mix(in srgb, var(--color-black, #000000) 84%, transparent) 35% 52%,
+            color-mix(in srgb, var(--color-white, #ffffff) 6%, var(--color-black, #000000)) 53% 58%,
+            color-mix(in srgb, var(--color-black, #000000) 80%, transparent) 59% 78%,
+            color-mix(in srgb, var(--color-white, #ffffff) 5%, var(--color-black, #000000)) 79% 84%,
+            color-mix(in srgb, var(--color-black, #000000) 82%, transparent) 85% 100%
         );
-    box-shadow: 0 20px 55px rgba(0, 0, 0, 0.38), inset 0 0 28px rgba(255, 255, 255, 0.04);
-    content: "";
-}
+        box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+        content: "";
+        transform: translateZ(0);
+        backface-visibility: hidden;
+    }
 
-.settings-fan-disc::after {
-    position: absolute;
-    z-index: 10;
-    top: 50%;
-    left: -12.9%;
-    width: 25.8%;
-    aspect-ratio: 1;
-    border: 1px solid color-mix(in srgb, var(--color-white, #ffffff) 22%, transparent);
-    border-radius: 999px;
-    background: radial-gradient(
-        circle,
-        color-mix(in srgb, var(--color-black, #000000) 94%, transparent) 0 42%,
-        color-mix(in srgb, var(--color-white, #ffffff) 11%, var(--color-black, #000000)) 45% 68%,
-        color-mix(in srgb, var(--color-black, #000000) 75%, transparent) 71%
-    );
-    box-shadow: 0 0 18px rgba(0, 0, 0, 0.42);
-    content: "";
-    transform: translateY(-50%);
-    pointer-events: none;
-}
+    .settings-layout-cd .settings-fan-disc::after {
+        position: absolute;
+        z-index: 10;
+        top: 50%;
+        left: -12.9%;
+        width: 25.8%;
+        aspect-ratio: 1;
+        border: 1px solid color-mix(in srgb, var(--color-white, #ffffff) 22%, transparent);
+        border-radius: 999px;
+        background: radial-gradient(
+            circle,
+            color-mix(in srgb, var(--color-black, #000000) 94%, transparent) 0 42%,
+            color-mix(in srgb, var(--color-white, #ffffff) 11%, var(--color-black, #000000)) 45% 68%,
+            color-mix(in srgb, var(--color-black, #000000) 75%, transparent) 71%
+        );
+        box-shadow: 0 0 14px rgba(0, 0, 0, 0.4);
+        content: "";
+        transform: translateY(-50%) translateZ(0);
+        backface-visibility: hidden;
+        pointer-events: none;
+    }
 
-.settings-fan-item {
-    --fan-angle: 0deg;
-    position: absolute;
-    z-index: 1;
-    top: 0;
-    left: -100%;
-    width: 200%;
-    height: 100%;
-    padding: 0;
-    border: 1px solid color-mix(in srgb, var(--color-white, #ffffff) 14%, transparent);
-    border-radius: 999px;
-    background: radial-gradient(
-        circle,
-        color-mix(in srgb, var(--color-white, #ffffff) 5%, transparent) 0 24%,
-        color-mix(in srgb, var(--color-white, #ffffff) 9%, var(--color-black, #000000)) 25% 76%,
-        color-mix(in srgb, var(--color-white, #ffffff) 14%, var(--color-black, #000000)) 100%
-    );
-    box-shadow: 0 8px 22px rgba(0, 0, 0, 0.18);
-    clip-path: polygon(50% 50%, 99.04% 40.25%, 100% 50%, 99.04% 59.75%);
-    color: white;
-    cursor: pointer;
-    opacity: 0.48;
-    filter: saturate(0.7) blur(0.18px);
-    transform: rotate(var(--fan-angle));
-    transform-origin: center;
-    transition: transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1), opacity 180ms ease,
-        filter 180ms ease, box-shadow 180ms ease;
-}
+    .settings-layout-cd .settings-fan-item {
+        --fan-angle: 0deg;
+        position: absolute;
+        z-index: 1;
+        top: 0;
+        left: -100%;
+        width: 200%;
+        height: 100%;
+        padding: 0;
+        border: 1px solid color-mix(in srgb, var(--color-white, #ffffff) 14%, transparent);
+        border-radius: 999px;
+        background: radial-gradient(
+            circle,
+            color-mix(in srgb, var(--color-white, #ffffff) 5%, transparent) 0 24%,
+            color-mix(in srgb, var(--color-white, #ffffff) 9%, var(--color-black, #000000)) 25% 76%,
+            color-mix(in srgb, var(--color-white, #ffffff) 14%, var(--color-black, #000000)) 100%
+        );
+        clip-path: polygon(50% 50%, 99.04% 40.25%, 100% 50%, 99.04% 59.75%);
+        color: white;
+        cursor: pointer;
+        opacity: 0.52;
+        transform: rotate(var(--fan-angle)) translateZ(0);
+        transform-origin: center;
+        backface-visibility: hidden;
+        transition: opacity 140ms ease, background 140ms ease;
+    }
 
-.settings-fan-item:hover {
-    opacity: 0.78;
-    filter: brightness(1.12);
-}
+    .settings-layout-cd .settings-fan-item:hover {
+        opacity: 0.85;
+        background: radial-gradient(
+            circle,
+            color-mix(in srgb, var(--color-white, #ffffff) 10%, transparent) 0 24%,
+            color-mix(in srgb, var(--color-white, #ffffff) 16%, var(--color-black, #000000)) 25% 76%,
+            color-mix(in srgb, var(--color-white, #ffffff) 22%, var(--color-black, #000000)) 100%
+        );
+    }
 
-.settings-fan-item:hover + .settings-fan-label {
-    color: white;
-    opacity: 1;
-}
+    .settings-layout-cd .settings-fan-item:hover + .settings-fan-label {
+        color: white;
+        opacity: 1;
+    }
 
-.settings-fan-item:focus-visible {
-    outline: 2px solid color-mix(in srgb, var(--color-white, #ffffff) 86%, transparent);
-    outline-offset: 3px;
-}
+    .settings-layout-cd .settings-fan-item:focus-visible {
+        outline: 2px solid color-mix(in srgb, var(--color-white, #ffffff) 86%, transparent);
+        outline-offset: 3px;
+    }
 
-.settings-fan-item.is-selected {
-    z-index: 5;
-    opacity: 1;
-    filter: brightness(1.32);
-    box-shadow: 0 10px 28px rgba(255, 255, 255, 0.08);
-    transform: rotate(var(--fan-angle));
-}
+    .settings-layout-cd .settings-fan-item.is-selected {
+        z-index: 5;
+        opacity: 1;
+        background: radial-gradient(
+            circle,
+            color-mix(in srgb, var(--color-white, #ffffff) 14%, transparent) 0 24%,
+            color-mix(in srgb, var(--color-white, #ffffff) 22%, var(--color-black, #000000)) 25% 76%,
+            color-mix(in srgb, var(--color-white, #ffffff) 28%, var(--color-black, #000000)) 100%
+        );
+        transform: rotate(var(--fan-angle)) translateZ(0);
+    }
 
-.settings-fan-label {
-    position: absolute;
-    z-index: 8;
-    top: calc(50% + var(--label-y));
-    left: var(--label-x);
-    display: block;
-    width: min(8.5rem, 100%);
-    height: min(3rem, 16%);
-    font-size: clamp(0.55rem, 2.6vh, 0.8rem);
-    font-weight: 650;
-    letter-spacing: 0.015em;
-    line-height: 1.05;
-    color: color-mix(in srgb, var(--color-white, #ffffff) 78%, transparent);
-    opacity: 0.82;
-    pointer-events: none;
-    text-align: center;
-    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.55);
-    transform: translate(-50%, -50%) rotate(var(--label-tilt));
-    transition: opacity 180ms ease, transform 180ms ease, font-size 180ms ease;
-}
+    .settings-layout-cd .settings-fan-label {
+        position: absolute;
+        z-index: 8;
+        top: calc(50% + var(--label-y));
+        left: var(--label-x);
+        display: block;
+        width: min(8.5rem, 100%);
+        height: min(3rem, 16%);
+        font-size: clamp(0.55rem, 2.6vh, 0.8rem);
+        font-weight: 650;
+        letter-spacing: 0.015em;
+        line-height: 1.05;
+        color: color-mix(in srgb, var(--color-white, #ffffff) 78%, transparent);
+        opacity: 0.82;
+        pointer-events: none;
+        text-align: center;
+        text-rendering: optimizeSpeed;
+        transform: translate(-50%, -50%) rotate(var(--label-tilt)) translateZ(0);
+        backface-visibility: hidden;
+        transition: opacity 140ms ease, font-size 140ms ease;
+    }
 
-.settings-fan-label i {
-    display: none;
-}
+    .settings-layout-cd .settings-fan-label i {
+        display: none;
+    }
 
-.settings-fan-label > span {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    width: 6.5rem;
-    text-align: center;
-    transform: translate(-50%, -50%);
-}
+    .settings-layout-cd .settings-fan-label > span {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 6.5rem;
+        text-align: center;
+        transform: translate(-50%, -50%);
+    }
 
-.settings-fan-label.is-selected {
-    font-size: clamp(0.6rem, 2.8vh, 0.86rem);
-    color: white;
-    opacity: 1;
-    transform: translate(-50%, -50%) rotate(var(--label-tilt));
-}
+    .settings-layout-cd .settings-fan-label.is-selected {
+        font-size: clamp(0.6rem, 2.8vh, 0.86rem);
+        color: white;
+        opacity: 1;
+        transform: translate(-50%, -50%) rotate(var(--label-tilt)) translateZ(0);
+    }
 
-.settings-fan-mobile-label {
-    display: none;
-}
-
-.settings-category-content {
-    min-width: 0;
-    scroll-margin-top: 1rem;
-    animation: settings-category-enter 220ms ease-out;
+    .settings-layout-cd .settings-fan-mobile-label {
+        display: none;
+    }
 }
 
 @keyframes settings-category-enter {

--- a/crates/pages/src/settings/mod.rs
+++ b/crates/pages/src/settings/mod.rs
@@ -742,91 +742,89 @@ pub fn Settings(config: Signal<AppConfig>) -> Element {
                         {hooks::debug_db_section()}
                     }
                 }
+            }
+            }
 
-
-
-                if show_add_server() {
-                    AddServerPopup {
-                        server_name,
-                        server_url,
-                        server_service,
-                        yt_browser,
-                        yt_anonymous,
-                        host_access,
-                        error,
-                        on_close: move |_| show_add_server.set(false),
-                        on_save: handle_add_server
-                    }
+            if show_add_server() {
+                AddServerPopup {
+                    server_name,
+                    server_url,
+                    server_service,
+                    yt_browser,
+                    yt_anonymous,
+                    host_access,
+                    error,
+                    on_close: move |_| show_add_server.set(false),
+                    on_save: handle_add_server
                 }
+            }
 
-                if show_add_local_source() {
-                    AddLocalSourcePopup {
-                        name: local_source_name,
-                        directories: local_source_directories,
-                        error: local_source_error,
-                        on_close: move |_| {
-                            show_add_local_source.set(false);
-                            local_source_name.set(String::new());
-                            local_source_directories.set(Vec::new());
-                            local_source_error.set(None);
-                        },
-                        on_save: move |_| {
-                            let name = local_source_name().trim().to_string();
-                            if name.is_empty() {
-                                local_source_error.set(Some(i18n::t("local_library_name_required").to_string()));
-                                return;
-                            }
-                            let directories = local_source_directories();
-                            if directories.is_empty() {
-                                local_source_error.set(Some(i18n::t("local_library_folder_required").to_string()));
-                                return;
-                            }
-                            let source = config::SavedLocalSource::new(name, directories);
-                            let active = config::Source::LocalLibrary(source.id.clone());
-                            {
-                                let mut cfg = config.write();
-                                cfg.add_local_source(source);
-                                cfg.set_active_local_source(active);
-                            }
-                            show_add_local_source.set(false);
-                            local_source_name.set(String::new());
-                            local_source_directories.set(Vec::new());
-                            local_source_error.set(None);
-                        },
-                    }
+            if show_add_local_source() {
+                AddLocalSourcePopup {
+                    name: local_source_name,
+                    directories: local_source_directories,
+                    error: local_source_error,
+                    on_close: move |_| {
+                        show_add_local_source.set(false);
+                        local_source_name.set(String::new());
+                        local_source_directories.set(Vec::new());
+                        local_source_error.set(None);
+                    },
+                    on_save: move |_| {
+                        let name = local_source_name().trim().to_string();
+                        if name.is_empty() {
+                            local_source_error.set(Some(i18n::t("local_library_name_required").to_string()));
+                            return;
+                        }
+                        let directories = local_source_directories();
+                        if directories.is_empty() {
+                            local_source_error.set(Some(i18n::t("local_library_folder_required").to_string()));
+                            return;
+                        }
+                        let source = config::SavedLocalSource::new(name, directories);
+                        let active = config::Source::LocalLibrary(source.id.clone());
+                        {
+                            let mut cfg = config.write();
+                            cfg.add_local_source(source);
+                            cfg.set_active_local_source(active);
+                        }
+                        show_add_local_source.set(false);
+                        local_source_name.set(String::new());
+                        local_source_directories.set(Vec::new());
+                        local_source_error.set(None);
+                    },
                 }
+            }
 
-                if show_add_registry() {
-                    AddRegistryPopup {
-                        registry_url,
-                        error: registry_error,
-                        loading: registry_loading,
-                        on_close: move |_| show_add_registry.set(false),
-                        on_save: handle_add_registry
-                    }
+            if show_add_registry() {
+                AddRegistryPopup {
+                    registry_url,
+                    error: registry_error,
+                    loading: registry_loading,
+                    on_close: move |_| show_add_registry.set(false),
+                    on_save: handle_add_registry
                 }
+            }
 
-                if show_login() {
-                    LoginPopup {
-                        username,
-                        password,
-                        service_name: config
-                            .read()
-                            .server
-                            .as_ref()
-                            .map(|server| server.service.display_name().to_string())
-                            .unwrap_or_else(|| i18n::t("server").to_string()),
-                        error: login_error,
-                        loading: is_loading,
-                        on_close: move |_| {
-                            show_login.set(false);
-                            username.set(String::new());
-                            password.set(String::new());
-                            login_error.set(None);
-                        },
-                        on_save: handle_login
-                    }
-                }
+            if show_login() {
+                LoginPopup {
+                    username,
+                    password,
+                    service_name: config
+                        .read()
+                        .server
+                        .as_ref()
+                        .map(|server| server.service.display_name().to_string())
+                        .unwrap_or_else(|| i18n::t("server").to_string()),
+                    error: login_error,
+                    loading: is_loading,
+                    on_close: move |_| {
+                        show_login.set(false);
+                        username.set(String::new());
+                        password.set(String::new());
+                        login_error.set(None);
+                    },
+                    on_save: handle_login
                 }
             }
         }


### PR DESCRIPTION
Moved all settings sections into `main#settings-category-content` (noticed many werent)

Did CSS optimizations for the CD fan:
-  replaced `repeating-radial-gradient` loops with a much better 1 pass multi stop.
- got rid of a few heavy blur and shadow effects 
- enabled gpu cache so it doesnt redraw the cd fan again (and again)

## Sanity Checking

[contribution guidelines]: https://github.com/Kopuz-org/kopuz/blob/master/CONTRIBUTING.md

- [x] I have read and followed the [contribution guidelines].
- [x] My commits follow Kopuz's scoped commit convention and history hygiene
      rules.
- [x] I have disclosed any AI assistance as required by the AI policy in the
      [contribution guidelines], or this pull request did not use AI assistance.
- [x] I have tested and self-reviewed my changes.

### Style and Consistency

- [x] My changes are consistent with the existing crate boundaries and Dioxus
      style.
- [x] I ran `cargo fmt --all --check` or `cargo fmt --all` as appropriate.
- [x] I ran `cargo clippy --workspace --all-targets -- -D warnings`, or
      explained why it could not be run.
- [x] I kept generated assets, translations, and packaging files in sync when
      this change depends on them.

### Testing

- [x] I ran the smallest relevant verifier for this change.
- [x] I documented any platform or verifier that I could not run.

Tested on platform(s):

- [x] `x86_64-linux`
- [ ] `aarch64-linux`
- [ ] `x86_64-darwin`
- [ ] `aarch64-darwin`
- [ ] Windows
- [ ] Android
- [ ] iOS
